### PR TITLE
Dai payments are always approved for the treasury.

### DIFF
--- a/contracts/ERC20Dealer.sol
+++ b/contracts/ERC20Dealer.sol
@@ -150,14 +150,9 @@ contract ERC20Dealer is Ownable, Constants {
     // user --- dai ---> us
     // debt--
     function repay(address from, uint256 dai) public {
-        require(
-            _dai.transferFrom(from, address(this), dai),       // Take dai from user
-            "ERC20Dealer: Dai transfer fail"
-        );
-
         (uint256 toRepay, uint256 debtDecrease) = amounts(from, inYDai(dai));
-        _dai.approve(address(_treasury), toRepay);              // Treasury will take the dai
-        _treasury.push(address(this), toRepay);                 // Give the dai to Treasury
+        // Treasury must have been approved to take the dai
+        _treasury.push(from, toRepay);                 // Have the Treasury take the dai
         debtYDai[from] = debtYDai[from].sub(debtDecrease);
     }
 

--- a/contracts/Mint.sol
+++ b/contracts/Mint.sol
@@ -36,12 +36,9 @@ contract Mint is Constants {
             !_yDai.isMature(),
             "Mint: yDai is mature"
         );
-        require(
-            _dai.transferFrom(user, address(this), dai),           // Take dai from user
-            "Mint: Dai transfer fail"
-        );
-        _dai.approve(address(_treasury), dai);      // Treasury will take the dai
-        _treasury.push(address(this), dai);                  // Give the dai to Treasury
+
+        // Treasury must have been approved to take the dai
+        _treasury.push(user, dai);                  // Have Treasury take the dai from user
         _yDai.mint(user, dai);                      // Mint yDai to user
     }
 

--- a/test/022_mint.js
+++ b/test/022_mint.js
@@ -148,7 +148,7 @@ contract('Mint', async (accounts) =>  {
         );
     });
 
-    it("mint takes dai and pushes it to Treasury, mints yDai for the user", async() => {
+    it("mint takes dai, mints yDai for the user", async() => {
         // Borrow dai
         await weth.approve(wethJoin.address, wethTokens, { from: owner });
         await wethJoin.join(owner, wethTokens, { from: owner });
@@ -170,7 +170,7 @@ contract('Mint', async (accounts) =>  {
             0,
             "Treasury has savings",
         );
-        await dai.approve(mint.address, daiTokens, { from: owner });
+        await dai.approve(treasury.address, daiTokens, { from: owner });
         await mint.mint(owner, daiTokens, { from: owner });
 
         assert.equal(
@@ -242,7 +242,7 @@ contract('Mint', async (accounts) =>  {
         await daiJoin.exit(owner, moreDai, { from: owner });
         
         // Mint yDai
-        await dai.approve(mint.address, moreDai, { from: owner });
+        await dai.approve(treasury.address, moreDai, { from: owner });
         await mint.mint(owner, moreDai, { from: owner });
 
         // yDai matures

--- a/test/023_erc20Dealer.js
+++ b/test/023_erc20Dealer.js
@@ -376,7 +376,7 @@ contract('ERC20Dealer', async (accounts) =>  {
                     "Owner does not have debt",
                 );
 
-                await dai.approve(dealer.address, daiTokens, { from: owner });
+                await dai.approve(treasury.address, daiTokens, { from: owner });
                 await dealer.repay(owner, daiTokens, { from: owner });
     
                 assert.equal(


### PR DESCRIPTION
Dai payments are always approved for the treasury.

To post collateral from users directly to the Treasury I need to merge ERC20Dealer, WethDealer and ChaiDealer into one, I'll give it a go.