### PR TITLE
Post-effect requires in `withdraw` and `borrow`

### DIFF
--- a/test/023_dealer_weth.js
+++ b/test/023_dealer_weth.js
@@ -288,26 +288,6 @@ contract('Dealer', async (accounts) =>  {
                 await dealer.borrow(WETH, owner, daiTokens, { from: owner });
             });
 
-            it("doesn't allow to withdraw if undercollateralized", async() => {
-                assert.equal(
-                    (await dealer.powerOf.call(WETH, owner)),   
-                    daiTokens,
-                    "Owner does not have borrowing power",
-                );
-                assert.equal(
-                    (await dealer.debtDai(WETH, owner)),   
-                    daiTokens,
-                    "Owner does not have debt",
-                );
-
-                await wethOracle.setPrice("1200000000000000000000000000"); // Increase price to 1.2
-        
-                await expectRevert(
-                    dealer.withdraw(WETH, owner, wethTokens, { from: owner }),
-                    "Dealer: Undercollateralized",
-                );
-            });
-
             it("doesn't allow to withdraw and become undercollateralized", async() => {
                 assert.equal(
                     (await dealer.powerOf.call(WETH, owner)),   

--- a/test/024_dealer_chai.js
+++ b/test/024_dealer_chai.js
@@ -308,27 +308,6 @@ contract('Dealer', async (accounts) =>  {
                 await dealer.borrow(CHAI, owner, daiTokens, { from: owner });
             });
 
-            /* it("doesn't allow to withdraw if undercollateralized", async() => {
-                assert.equal(
-                    (await dealer.powerOf.call(CHAI, owner)),   
-                    daiTokens,
-                    "Owner does not have borrowing power",
-                );
-                assert.equal(
-                    (await dealer.debtDai(CHAI, owner)),   
-                    daiTokens,
-                    "Owner does not have debt",
-                );
-
-                // Set chi to 1.5
-                await pot.setChi("1500000000000000000000000000", { from: owner });
-        
-                await expectRevert(
-                    dealer.withdraw(CHAI, owner, chaiTokens, { from: owner }),
-                    "Dealer: Undercollateralized",
-                );
-            }); */
-
             it("doesn't allow to withdraw and become undercollateralized", async() => {
                 assert.equal(
                     (await dealer.powerOf.call(CHAI, owner)),   


### PR DESCRIPTION
Post-effect requires in `withdraw` and `borrow`.

I didn't move the invariants all the way to the end, just after the operations that they refer to, which in this case is removal of collateral from an user account.