### PR TITLE
Commented out the deployed bytecode tests to silence warnings.

### DIFF
--- a/test/014_treasury_lending.js
+++ b/test/014_treasury_lending.js
@@ -94,7 +94,7 @@ contract('Treasury', async (accounts) =>  {
         await treasury.grantAccess(user, { from: owner });
     });
 
-    it("get the size of the contract", async() => {
+    /* it("get the size of the contract", async() => {
         console.log();
         console.log("·--------------------|------------------|------------------|------------------·");
         console.log("|  Contract          ·  Bytecode        ·  Deployed        ·  Constructor     |");
@@ -112,7 +112,7 @@ contract('Treasury', async (accounts) =>  {
             "|" + ("" + sizeOfC).padStart(16, ' ') + "  |");
         console.log("·--------------------|------------------|------------------|------------------·");
         console.log();
-    });
+    }); */
     
     it("should fail for failed weth transfers", async() => {
         // Let's check how WETH is implemented, maybe we can remove this one.

--- a/test/015_treasury_saving.js
+++ b/test/015_treasury_saving.js
@@ -99,7 +99,7 @@ contract('Treasury', async (accounts) =>  {
         await treasury.grantAccess(owner, { from: owner });
     });
 
-    it("get the size of the contract", async() => {
+    /* it("get the size of the contract", async() => {
         console.log();
         console.log("·--------------------|------------------|------------------|------------------·");
         console.log("|  Contract          ·  Bytecode        ·  Deployed        ·  Constructor     |");
@@ -117,7 +117,7 @@ contract('Treasury', async (accounts) =>  {
             "|" + ("" + sizeOfC).padStart(16, ' ') + "  |");
         console.log("·--------------------|------------------|------------------|------------------·");
         console.log();
-    });
+    }); */
 
     it("allows to save dai", async() => {
         assert.equal(

--- a/test/023_dealer_weth.js
+++ b/test/023_dealer_weth.js
@@ -140,7 +140,7 @@ contract('Dealer', async (accounts) =>  {
         await helper.revertToSnapshot(snapshotId);
     });
     
-    it("get the size of the contract", async() => {
+    /* it("get the size of the contract", async() => {
         console.log();
         console.log("·--------------------|------------------|------------------|------------------·");
         console.log("|  Contract          ·  Bytecode        ·  Deployed        ·  Constructor     |");
@@ -158,7 +158,7 @@ contract('Dealer', async (accounts) =>  {
             "|" + ("" + sizeOfC).padStart(16, ' ') + "  |");
         console.log("·--------------------|------------------|------------------|------------------·");
         console.log();
-    });
+    }); */
 
     it("allows user to post weth", async() => {
         assert.equal(

--- a/test/024_dealer_chai.js
+++ b/test/024_dealer_chai.js
@@ -154,7 +154,7 @@ contract('Dealer', async (accounts) =>  {
         await helper.revertToSnapshot(snapshotId);
     });
 
-    it("get the size of the contract", async() => {
+    /* it("get the size of the contract", async() => {
         console.log();
         console.log("·--------------------|------------------|------------------|------------------·");
         console.log("|  Contract          ·  Bytecode        ·  Deployed        ·  Constructor     |");
@@ -172,7 +172,7 @@ contract('Dealer', async (accounts) =>  {
             "|" + ("" + sizeOfC).padStart(16, ' ') + "  |");
         console.log("·--------------------|------------------|------------------|------------------·");
         console.log();
-    });
+    }); */
 
     it("allows user to post chai", async() => {
         assert.equal(
@@ -479,9 +479,6 @@ contract('Dealer', async (accounts) =>  {
                 const rateDifferential = divRay(addBN(rate, rateIncrease), rate);
                 const increasedDebt = mulRay(daiTokens, rateDifferential);
                 const debtIncrease = subBN(increasedDebt, daiTokens);
-                console.log(daiTokens.toString());
-                console.log(increasedDebt.toString());
-                console.log(debtIncrease.toString());
                 await vat.fold(ilk, vat.address, rateIncrease, { from: owner });
 
                 assert.equal(


### PR DESCRIPTION
We don't need these tests in each run, they only need to run once after each major refactor.