### PR TITLE
Fix ethProxy bugs

### DIFF
--- a/contracts/EthProxy.sol
+++ b/contracts/EthProxy.sol
@@ -35,7 +35,7 @@ contract EthProxy is UserProxy(), Constants {
     }
 
     function withdraw(address from, address payable to, uint256 amount)
-        public onlyHolderOrProxy(to, "EthProxy: Only Holder Or Proxy") {
+        public onlyHolderOrProxy(from, "EthProxy: Only Holder Or Proxy") {
         _dealer.withdraw(WETH, from, address(this), amount);
         _weth.withdraw(amount);
         to.transfer(amount);

--- a/test/028_dealer_ethProxy.js
+++ b/test/028_dealer_ethProxy.js
@@ -328,6 +328,23 @@ contract('Dealer - Weth', async (accounts) =>  {
             );
         });
 
+        it("allows user to withdraw weth to another account", async() => {
+            const previousBalance = await balance.current(user);
+            await ethProxy.withdraw(owner, user, wethTokens, { from: owner });
+
+            expect(await balance.current(user)).to.be.bignumber.gt(previousBalance);
+            assert.equal(
+                (await vat.urns(ilk, treasury.address)).ink,
+                0,
+                "Treasury should not not have weth in MakerDAO",
+            );
+            assert.equal(
+                await dealer.powerOf.call(WETH, owner),
+                0,
+                "Owner should not have borrowing power",
+            );
+        });
+
         it("gas tokens are passed on to user", async() => {
             await ethProxy.withdraw(owner, owner, wethTokens, { from: owner });
 


### PR DESCRIPTION
`post` credited eth to the sender account, instead of the receiving one.

`withdraw` checked that the receiving account was the holder of the funds.