### PR TITLE
Collateralization is not calculated for series with no debt

### DIFF
--- a/contracts/Dealer.sol
+++ b/contracts/Dealer.sol
@@ -149,8 +149,9 @@ contract Dealer is IDealer, Orchestrated(), Delegable(), DecimalMath, Constants 
     function totalDebtDai(bytes32 collateral, address user) public override returns (uint256) {
         uint256 totalDebt;
         for (uint256 i = 0; i < seriesIterator.length; i += 1) {
-            // TODO: Skip next line if debtYDai[collateral][maturity][user] == 0
-            totalDebt = totalDebt + debtDai(collateral, seriesIterator[i], user);
+            if (debtYDai[collateral][seriesIterator[i]][user] > 0) {
+                totalDebt = totalDebt + debtDai(collateral, seriesIterator[i], user);
+            }
         } // We don't expect hundreds of maturities per dealer
         return totalDebt;
     }

--- a/test/135_unwind_skim_dss.js
+++ b/test/135_unwind_skim_dss.js
@@ -11,8 +11,6 @@ const Chai = artifacts.require('Chai');
 const GasToken = artifacts.require('GasToken1');
 
 // Common
-const ChaiOracle = artifacts.require('ChaiOracle');
-const WethOracle = artifacts.require('WethOracle');
 const Treasury = artifacts.require('Treasury');
 
 // YDai
@@ -41,8 +39,6 @@ contract('Unwind - Dealer', async (accounts) =>  {
     let end;
     let chai;
     let gasToken;
-    let chaiOracle;
-    let wethOracle;
     let treasury;
     let yDai1;
     let yDai2;
@@ -185,33 +181,27 @@ contract('Unwind - Dealer', async (accounts) =>  {
         // Setup GasToken
         gasToken = await GasToken.new();
 
-        // Setup WethOracle
-        wethOracle = await WethOracle.new(vat.address, { from: owner });
-
-        // Setup ChaiOracle
-        chaiOracle = await ChaiOracle.new(pot.address, { from: owner });
-
         // Set treasury
         treasury = await Treasury.new(
-            dai.address,
-            chai.address,
-            chaiOracle.address,
-            weth.address,
-            daiJoin.address,
-            wethJoin.address,
             vat.address,
+            weth.address,
+            dai.address,
+            wethJoin.address,
+            daiJoin.address,
+            pot.address,
+            chai.address,
             { from: owner },
         );
 
         // Setup Dealer
         dealer = await Dealer.new(
-            treasury.address,
-            dai.address,
+            vat.address,
             weth.address,
-            wethOracle.address,
+            dai.address,
+            pot.address,
             chai.address,
-            chaiOracle.address,
             gasToken.address,
+            treasury.address,
             { from: owner },
         );
         await treasury.orchestrate(dealer.address, { from: owner });
@@ -277,7 +267,6 @@ contract('Unwind - Dealer', async (accounts) =>  {
             pot.address,
             end.address,
             chai.address,
-            chaiOracle.address,
             treasury.address,
             dealer.address,
             liquidations.address,

--- a/test/gas/201_gasLoops.js
+++ b/test/gas/201_gasLoops.js
@@ -310,7 +310,7 @@ contract('Gas Usage', async (accounts) =>  {
         await helper.revertToSnapshot(snapshotId);
     });
 
-    const m = 10; // Number of maturities to test. Use multiples of 10.
+    const m = 4; // Number of maturities to test.
     describe("working with " + m + " maturities", () => {
         beforeEach(async() => {
             // Setup yDai
@@ -334,10 +334,24 @@ contract('Gas Usage', async (accounts) =>  {
                 }
             });
 
+            it("borrow a second time (no gas bond)", async() => {
+                for (let i = 0; i < maturities.length; i++) {
+                    await postWeth(user3, wethTokens);
+                    await dealer.borrow(WETH, maturities[i], user3, daiTokens, { from: user3 });
+                }
+            });
+
             it("repayYDai", async() => {
                 for (let i = 0; i < maturities.length; i++) {
                     await series[i].approve(dealer.address, daiTokens, { from: user3 });
                     await dealer.repayYDai(WETH, maturities[i], user3, daiTokens, { from: user3 });
+                }
+            });
+
+            it("repayYDai and retrieve gas bond", async() => {
+                for (let i = 0; i < maturities.length; i++) {
+                    await series[i].approve(dealer.address, daiTokens.mul(2), { from: user3 });
+                    await dealer.repayYDai(WETH, maturities[i], user3, daiTokens.mul(2), { from: user3 });
                 }
             });
 


### PR DESCRIPTION
A missing `if` was making the cost of checking for collateralization levels balloon.

`dealer.withdraw`, `dealer.borrow`, `liquidations.liquidate` and `liquidations.buy` all depend on `dealer.isCollateralized` which in turn calls `dealer.totalDebtDai(collateral, user)`. 

The latter loops through all series, and is likely to update all `pot.rho`, `jug.rho`, `pot.chi` and `jug.rate`. Only that, with no other calculations, would be 80K gas. The fact that `totalDebtDai` loops through all series, combined with the extra potential 80K gas of updating MakerDAO, makes me think this might be the number one priority in gas optimization for core contracts.

For now we can merge this one and rejoice, but let's come back and look for more gas savings later.