### PR TITLE
yDai can be redeemed from `from` to `to`

### DIFF
--- a/test/121_ydai.js
+++ b/test/121_ydai.js
@@ -30,7 +30,7 @@ const { toWad, toRay, toRad, addBN, subBN, mulRay, divRay } = require('./shared/
 const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
 
 contract('yDai', async (accounts) =>  {
-    let [ owner, user1, user2 ] = accounts;
+    let [ owner, user1, other ] = accounts;
     let vat;
     let weth;
     let wethJoin;
@@ -196,7 +196,7 @@ contract('yDai', async (accounts) =>  {
 
     it("yDai1 can't be redeemed before maturity time", async() => {
         await expectRevert(
-            yDai1.redeem(owner, daiTokens1, { from: owner }),
+            yDai1.redeem(user1, user1, daiTokens1, { from: user1 }),
             "YDai: yDai is not mature",
         );
     });
@@ -233,7 +233,7 @@ contract('yDai', async (accounts) =>  {
         await helper.advanceBlock();
         await yDai1.mature();
 
-        await yDai1.redeem(user1, daiTokens1, { from: user1 });
+        await yDai1.redeem(user1, user1, daiTokens1, { from: user1 });
 
         assert.equal(
             await flashMinter.flashBalance(),
@@ -304,12 +304,39 @@ contract('yDai', async (accounts) =>  {
             );
     
             await yDai1.approve(yDai1.address, daiTokens1, { from: user1 });
-            await yDai1.redeem(user1, daiTokens1, { from: user1 });
+            await yDai1.redeem(user1, user1, daiTokens1, { from: user1 });
     
             assert.equal(
                 await dai.balanceOf(user1),
                 daiTokens1.toString(),
                 "User1 should have dai",
+            );
+            assert.equal(
+                await yDai1.balanceOf(user1),
+                0,
+                "User1 should not have yDai1",
+            );
+        });
+
+        it("yDai can be redeemed in favour of others", async() => {
+            assert.equal(
+                await yDai1.balanceOf(user1),
+                daiTokens1.toString(),
+                "User1 does not have yDai1",
+            );
+            assert.equal(
+                await dai.balanceOf(other),
+                0,
+                "Other has dai",
+            );
+    
+            await yDai1.approve(yDai1.address, daiTokens1, { from: user1 });
+            await yDai1.redeem(user1, other, daiTokens1, { from: user1 });
+    
+            assert.equal(
+                await dai.balanceOf(other),
+                daiTokens1.toString(),
+                "Other should have dai",
             );
             assert.equal(
                 await yDai1.balanceOf(user1),
@@ -343,7 +370,7 @@ contract('yDai', async (accounts) =>  {
                 );
         
                 await yDai1.approve(yDai1.address, daiTokens1, { from: user1 });
-                await yDai1.redeem(user1, daiTokens1, { from: user1 });
+                await yDai1.redeem(user1, user1, daiTokens1, { from: user1 });
         
                 assert.equal(
                     await dai.balanceOf(user1),

--- a/test/127_yDai_delegable.js
+++ b/test/127_yDai_delegable.js
@@ -214,7 +214,7 @@ contract('yDai - Delegable', async (accounts) =>  {
 
     it("redeem is allowed for account holder", async() => {
         await yDai1.approve(yDai1.address, daiTokens1, { from: holder });
-        await yDai1.redeem(holder, daiTokens1, { from: holder });
+        await yDai1.redeem(holder, holder, daiTokens1, { from: holder });
 
         assert.equal(
             await treasury.debt(),
@@ -231,7 +231,7 @@ contract('yDai - Delegable', async (accounts) =>  {
     it("redeem is not allowed for non designated accounts", async() => {
         await yDai1.approve(yDai1.address, daiTokens1, { from: holder });
         await expectRevert(
-            yDai1.redeem(holder, daiTokens1, { from: other }),
+            yDai1.redeem(holder, holder, daiTokens1, { from: other }),
             "YDai: Only Holder Or Delegate",
         );
     });
@@ -247,7 +247,7 @@ contract('yDai - Delegable', async (accounts) =>  {
                 enabled: true,
             },
         );
-        await yDai1.redeem(holder, daiTokens1, { from: other });
+        await yDai1.redeem(holder, holder, daiTokens1, { from: other });
 
         assert.equal(
             await treasury.debt(),
@@ -278,7 +278,7 @@ contract('yDai - Delegable', async (accounts) =>  {
             );
 
             await expectRevert(
-                yDai1.redeem(holder, daiTokens1, { from: other }),
+                yDai1.redeem(holder, holder, daiTokens1, { from: other }),
                 "YDai: Only Holder Or Delegate",
             );
         });

--- a/test/network/321_ydai.js
+++ b/test/network/321_ydai.js
@@ -91,7 +91,7 @@ contract('yDai', async (accounts) =>  {
 
     it("yDai can't be redeemed if not mature", async() => {
         await expectRevert(
-            yDai4.redeem(owner, daiTokens1, { from: owner }),
+            yDai4.redeem(owner, owner, daiTokens1, { from: owner }),
             "YDai: yDai is not mature",
         );
     });
@@ -151,7 +151,7 @@ contract('yDai', async (accounts) =>  {
         );
 
         await yDai.approve(yDai4.address, daiTokens1, { from: user1 });
-        await yDai.redeem(user1, daiTokens1, { from: user1 });
+        await yDai.redeem(user1, user1, daiTokens1, { from: user1 });
 
         assert.equal(
             await dai.balanceOf(user1),
@@ -203,7 +203,7 @@ contract('yDai', async (accounts) =>  {
             );
     
             await yDai4.approve(yDai4.address, daiTokens1, { from: user1 });
-            await yDai4.redeem(user1, daiTokens1, { from: user1 });
+            await yDai4.redeem(user1, user1, daiTokens1, { from: user1 });
     
             assert.equal(
                 await dai.balanceOf(user1),


### PR DESCRIPTION
To allow further composability, yDai can be redeemed from `from` to `to` by a third account.

Fixes #144 