### PR TITLE
Implemented and tested trade previews - Fixes #152

### DIFF
--- a/contracts/market/Market.sol
+++ b/contracts/market/Market.sol
@@ -116,6 +116,19 @@ contract Market is IMarket, ERC20, Delegable {
         _updateState(uint256(chaiReserves).add(chaiIn), uint256(yDaiReserves).sub(yDaiOut));
     }
 
+    /// @dev Returns how much yDai would be obtained by selling `chaiIn` chai
+    function sellChaiPreview(uint128 chaiIn) external view returns(uint256) {
+        return YieldMath.yDaiOutForChaiIn(
+            toUint128(chai.balanceOf(address(this))),
+            toUint128(yDai.balanceOf(address(this))),
+            chaiIn,
+            toUint128(maturity - now),
+            k,
+            int128((_pot.chi() << 64) / 10**27),
+            g
+        );
+    }
+
     /// @dev Buy Chai for yDai
     /// @param from Wallet providing the yDai being sold. Must have approved the operator with `market.addDelegate(operator)`.
     /// @param to Wallet receiving the chai being bought
@@ -137,6 +150,19 @@ contract Market is IMarket, ERC20, Delegable {
         chai.transfer(to, chaiOut);
 
         _updateState(uint256(chaiReserves).sub(chaiOut), uint256(yDaiReserves).add(yDaiIn));
+    }
+
+    /// @dev Returns how much yDai would be required to buy `chaiOut` chai
+    function buyChaiPreview(uint128 chaiOut) external view returns(uint256) {
+        return YieldMath.yDaiInForChaiOut(
+            toUint128(chai.balanceOf(address(this))),
+            toUint128(yDai.balanceOf(address(this))),
+            chaiOut,
+            toUint128(maturity - now),
+            k,
+            int128((_pot.chi() << 64) / 10**27),
+            g
+        );
     }
 
     /// @dev Sell yDai for Chai
@@ -162,6 +188,19 @@ contract Market is IMarket, ERC20, Delegable {
         _updateState(uint256(chaiReserves).sub(chaiOut), uint256(yDaiReserves).add(yDaiIn));
     }
 
+    /// @dev Returns how much chai would be obtained by selling `yDaiIn` yDai
+    function sellYDaiPreview(uint128 yDaiIn) external view returns(uint256) {
+        return YieldMath.chaiOutForYDaiIn(
+            toUint128(chai.balanceOf(address(this))),
+            toUint128(yDai.balanceOf(address(this))),
+            yDaiIn,
+            toUint128(maturity - now),
+            k,
+            int128((_pot.chi() << 64) / 10**27),
+            g
+        );
+    }
+
     /// @dev Buy yDai for chai
     /// @param from Wallet providing the chai being sold. Must have approved the operator with `market.addDelegate(operator)`.
     /// @param to Wallet receiving the yDai being bought
@@ -183,6 +222,20 @@ contract Market is IMarket, ERC20, Delegable {
         yDai.transfer(to, yDaiOut);
 
         _updateState(uint256(chaiReserves).add(chaiIn), uint256(yDaiReserves).sub(yDaiOut));
+    }
+
+
+    /// @dev Returns how much chai would be required to buy `yDaiOut` yDai
+    function buyYDaiPreview(uint128 yDaiOut) external view returns(uint256) {
+        return YieldMath.chaiInForYDaiOut(
+            toUint128(chai.balanceOf(address(this))),
+            toUint128(yDai.balanceOf(address(this))),
+            yDaiOut,
+            toUint128(maturity - now),
+            k,
+            int128((_pot.chi() << 64) / 10**27),
+            g
+        );
     }
 
     /// @dev Maintain the price oracle

--- a/test/market/202_market.js
+++ b/test/market/202_market.js
@@ -306,6 +306,9 @@ contract('Market', async (accounts) =>  {
                 "'To' wallet should have no yDai, instead has " + await yDai1.balanceOf(operator),
             );
 
+            // Test preview since we are here
+            const yDaiOutPreview = await market.sellChaiPreview(oneToken, { from: operator });
+
             await market.addDelegate(operator, { from: from });
             await chai.approve(market.address, oneToken, { from: from });
             await market.sellChai(from, to, oneToken, { from: operator });
@@ -320,6 +323,8 @@ contract('Market', async (accounts) =>  {
             const yDaiOut = new BN(await yDai1.balanceOf(to));
             expect(yDaiOut).to.be.bignumber.gt(expectedYDaiOut.mul(new BN('99')).div(new BN('100')));
             expect(yDaiOut).to.be.bignumber.lt(expectedYDaiOut.mul(new BN('101')).div(new BN('100')));
+            expect(yDaiOut).to.be.bignumber.gt(yDaiOutPreview.mul(new BN('99')).div(new BN('100')));
+            expect(yDaiOut).to.be.bignumber.lt(yDaiOutPreview.mul(new BN('101')).div(new BN('100')));
         });
 
         it("buys chai", async() => {
@@ -346,6 +351,9 @@ contract('Market', async (accounts) =>  {
                 "'From' wallet should have " + yDaiTokens1 + " yDai, instead has " + await yDai1.balanceOf(from),
             );
 
+            // Test preview since we are here
+            const yDaiInPreview = await market.buyChaiPreview(oneToken, { from: operator });
+
             await market.addDelegate(operator, { from: from });
             await yDai1.approve(market.address, yDaiTokens1, { from: from });
             await market.buyChai(from, to, oneToken, { from: operator });
@@ -360,6 +368,8 @@ contract('Market', async (accounts) =>  {
             const yDaiIn = (new BN(yDaiTokens1.toString())).sub(new BN(await yDai1.balanceOf(from)));
             expect(yDaiIn).to.be.bignumber.gt(expectedYDaiIn.mul(new BN('99')).div(new BN('100')));
             expect(yDaiIn).to.be.bignumber.lt(expectedYDaiIn.mul(new BN('101')).div(new BN('100')));
+            expect(yDaiIn).to.be.bignumber.gt(yDaiInPreview.mul(new BN('99')).div(new BN('100')));
+            expect(yDaiIn).to.be.bignumber.lt(yDaiInPreview.mul(new BN('101')).div(new BN('100')));
         });
 
         it("sells yDai", async() => {
@@ -386,6 +396,9 @@ contract('Market', async (accounts) =>  {
                 "'To' wallet should have no chai, instead has " + await chai.balanceOf(to),
             );
 
+            // Test preview since we are here
+            const chaiOutPreview = await market.sellYDaiPreview(oneToken, { from: operator });
+
             await market.addDelegate(operator, { from: from });
             await yDai1.approve(market.address, oneToken, { from: from });
             await market.sellYDai(from, to, oneToken, { from: operator });
@@ -400,6 +413,8 @@ contract('Market', async (accounts) =>  {
             const chaiOut = new BN(await chai.balanceOf(to));
             expect(chaiOut).to.be.bignumber.gt(expectedChaiOut.mul(new BN('99')).div(new BN('100')));
             expect(chaiOut).to.be.bignumber.lt(expectedChaiOut.mul(new BN('101')).div(new BN('100')));
+            expect(chaiOut).to.be.bignumber.gt(chaiOutPreview.mul(new BN('99')).div(new BN('100')));
+            expect(chaiOut).to.be.bignumber.lt(chaiOutPreview.mul(new BN('101')).div(new BN('100')));
         });
 
         it("buys yDai", async() => {
@@ -426,6 +441,9 @@ contract('Market', async (accounts) =>  {
                 "'To' wallet should have no yDai, instead has " + await yDai1.balanceOf(to),
             );
 
+            // Test preview since we are here
+            const chaiInPreview = await market.buyYDaiPreview(oneToken, { from: operator });
+
             await market.addDelegate(operator, { from: from });
             await chai.approve(market.address, chaiTokens1, { from: from });
             await market.buyYDai(from, to, oneToken, { from: operator });
@@ -440,6 +458,8 @@ contract('Market', async (accounts) =>  {
             const chaiIn = (new BN(chaiTokens1.toString())).sub(new BN(await chai.balanceOf(from)));
             expect(chaiIn).to.be.bignumber.gt(expectedChaiIn.mul(new BN('99')).div(new BN('100')));
             expect(chaiIn).to.be.bignumber.lt(expectedChaiIn.mul(new BN('101')).div(new BN('100')));
+            expect(chaiIn).to.be.bignumber.gt(chaiInPreview.mul(new BN('99')).div(new BN('100')));
+            expect(chaiIn).to.be.bignumber.lt(chaiInPreview.mul(new BN('101')).div(new BN('100')));
         });
 
         // --- DELEGATION TESTS ---


### PR DESCRIPTION
All trading functions now have a `*Preview(uint256 amount)` that returns what the trade would be.

These can be used both to preview a trade, or to get a price (by entering 1 token).