### PR TITLE
Floored `rateGrowth`

### DIFF
--- a/contracts/Unwind.sol
+++ b/contracts/Unwind.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.6.10;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/math/Math.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./interfaces/IVat.sol";
@@ -175,9 +176,22 @@ contract Unwind is Ownable(), DecimalMath {
                 rate0 = rate;
             }
 
-            profit = profit.add(divd(muld(_controller.totalDebtYDai(WETH, maturity), divd(rate, rate0)), chi0));
-            profit = profit.add(divd(_controller.totalDebtYDai(CHAI, maturity), chi0));
-            profit = profit.sub(divd(yDai.totalSupply(), chi0));
+            profit = profit.add(
+                divd(
+                    muld(
+                        _controller.totalDebtYDai(WETH, maturity),
+                        Math.max(UNIT, divd(rate, rate0)) // rate growth since maturity, floored at 1.0
+                    ),                                    // muld(yDaiDebt, rateGrowth) - Convert Weth collateralized YDai debt to Dai debt
+                    chi                                   // divd(daiDebt, chi) - Convert Dai debt to Chai debt
+                )
+            );
+            profit = profit.add(
+                divd(
+                    _controller.totalDebtYDai(CHAI, maturity),
+                    chi0                                  // divd(yDaiDebt, chi0) - Convert Chai collateralized YDai debt to Chai debt
+                )
+            );
+            profit = profit.sub(divd(yDai.totalSupply(), chi0)); // divd(yDai, chi0) - Convert YDai to Chai
         }
 
         return profit;

--- a/contracts/YDai.sol
+++ b/contracts/YDai.sol
@@ -73,10 +73,11 @@ contract YDai is Orchestrated(), Delegable(), DecimalMath, ERC20Permit, IYDai  {
     }
 
     /// @dev Rate differential between maturity and now in RAY. Returns 1.0 if not mature.
+    /// rateGrowth is floored to 1.0.
     //
-    //           rate_now
+    //                 rate_now
     // rateGrowth() = ----------
-    //           rate_mat
+    //                 rate_mat
     //
     function rateGrowth() public override returns(uint256){
         if (isMature != true) return rate0;
@@ -88,7 +89,7 @@ contract YDai is Orchestrated(), Delegable(), DecimalMath, ERC20Permit, IYDai  {
         } else {
             (, rateNow,,,) = _vat.ilks(WETH);
         }
-        return divd(rateNow, rate0);
+        return Math.max(UNIT, divd(rateNow, rate0));
     }
 
     /// @dev Mature yDai and capture maturity data


### PR DESCRIPTION
Fixes #187.

I floored rateGrowth at 1.0, meaning that the Weth-collateralized yDai debt users have towards us cannot decrease below what it was at maturity.