### PR TITLE
MakerDAO upgradability draft

### DIFF
--- a/contracts/external/maker/dai.sol
+++ b/contracts/external/maker/dai.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2017, 2018, 2019 dbrock, rain, mrchico
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.6.0;
+
+import "./lib.sol";
+
+contract Dai is LibNote {
+    // --- Auth ---
+    mapping (address => uint) public wards;
+    function rely(address guy) external note auth { wards[guy] = 1; }
+    function deny(address guy) external note auth { wards[guy] = 0; }
+    modifier auth {
+        require(wards[msg.sender] == 1, "Dai/not-authorized");
+        _;
+    }
+
+    // --- ERC20 Data ---
+    string  public constant name     = "Dai Stablecoin";
+    string  public constant symbol   = "DAI";
+    string  public constant version  = "1";
+    uint8   public constant decimals = 18;
+    uint256 public totalSupply;
+
+    mapping (address => uint)                      public balanceOf;
+    mapping (address => mapping (address => uint)) public allowance;
+    mapping (address => uint)                      public nonces;
+
+    event Approval(address indexed src, address indexed guy, uint wad);
+    event Transfer(address indexed src, address indexed dst, uint wad);
+
+    // --- Math ---
+    function add(uint x, uint y) internal pure returns (uint z) {
+        require((z = x + y) >= x);
+    }
+    function sub(uint x, uint y) internal pure returns (uint z) {
+        require((z = x - y) <= x);
+    }
+
+    // --- EIP712 niceties ---
+    bytes32 public DOMAIN_SEPARATOR;
+    // bytes32 public constant PERMIT_TYPEHASH = keccak256("Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)");
+    bytes32 public constant PERMIT_TYPEHASH = 0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb;
+
+    constructor(uint256 chainId_) public {
+        wards[msg.sender] = 1;
+        DOMAIN_SEPARATOR = keccak256(abi.encode(
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+            keccak256(bytes(name)),
+            keccak256(bytes(version)),
+            chainId_,
+            address(this)
+        ));
+    }
+
+    // --- Token ---
+    function transfer(address dst, uint wad) external returns (bool) {
+        return transferFrom(msg.sender, dst, wad);
+    }
+    function transferFrom(address src, address dst, uint wad)
+        public returns (bool)
+    {
+        require(balanceOf[src] >= wad, "Dai/insufficient-balance");
+        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+            require(allowance[src][msg.sender] >= wad, "Dai/insufficient-allowance");
+            allowance[src][msg.sender] = sub(allowance[src][msg.sender], wad);
+        }
+        balanceOf[src] = sub(balanceOf[src], wad);
+        balanceOf[dst] = add(balanceOf[dst], wad);
+        emit Transfer(src, dst, wad);
+        return true;
+    }
+    function mint(address usr, uint wad) external auth {
+        balanceOf[usr] = add(balanceOf[usr], wad);
+        totalSupply    = add(totalSupply, wad);
+        emit Transfer(address(0), usr, wad);
+    }
+    function burn(address usr, uint wad) external {
+        require(balanceOf[usr] >= wad, "Dai/insufficient-balance");
+        if (usr != msg.sender && allowance[usr][msg.sender] != uint(-1)) {
+            require(allowance[usr][msg.sender] >= wad, "Dai/insufficient-allowance");
+            allowance[usr][msg.sender] = sub(allowance[usr][msg.sender], wad);
+        }
+        balanceOf[usr] = sub(balanceOf[usr], wad);
+        totalSupply    = sub(totalSupply, wad);
+        emit Transfer(usr, address(0), wad);
+    }
+    function approve(address usr, uint wad) external returns (bool) {
+        allowance[msg.sender][usr] = wad;
+        emit Approval(msg.sender, usr, wad);
+        return true;
+    }
+
+    // --- Alias ---
+    function push(address usr, uint wad) external {
+        transferFrom(msg.sender, usr, wad);
+    }
+    function pull(address usr, uint wad) external {
+        transferFrom(usr, msg.sender, wad);
+    }
+    function move(address src, address dst, uint wad) external {
+        transferFrom(src, dst, wad);
+    }
+
+    // --- Approve by signature ---
+    function permit(address holder, address spender, uint256 nonce, uint256 expiry,
+                    bool allowed, uint8 v, bytes32 r, bytes32 s) external
+    {
+        bytes32 digest =
+            keccak256(abi.encodePacked(
+                "\x19\x01",
+                DOMAIN_SEPARATOR,
+                keccak256(abi.encode(PERMIT_TYPEHASH,
+                                     holder,
+                                     spender,
+                                     nonce,
+                                     expiry,
+                                     allowed))
+        ));
+
+        require(holder != address(0), "Dai/invalid-address-0");
+        require(holder == ecrecover(digest, v, r, s), "Dai/invalid-permit");
+        require(expiry == 0 || now <= expiry, "Dai/permit-expired");
+        require(nonce == nonces[holder]++, "Dai/invalid-nonce");
+        uint wad = allowed ? uint(-1) : 0;
+        allowance[holder][spender] = wad;
+        emit Approval(holder, spender, wad);
+    }
+}

--- a/contracts/external/maker/dssdeploy.sol
+++ b/contracts/external/maker/dssdeploy.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// DssDeploy.sol
+
+// Copyright (C) 2018-2020 Maker Ecosystem Growth Holdings, INC.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.6.0;
+
+import {Vat} from "./vat.sol";
+import {Jug} from "./jug.sol";
+import {DaiJoin} from "./join.sol";
+import {Dai} from "./dai.sol";
+import {End} from "./end.sol";
+import {Pot} from "./pot.sol";
+import {IDssDeploy} from "../../interfaces/IDssDeploy.sol";
+
+contract VatFab {
+    function newVat() public returns (Vat vat) {
+        vat = new Vat();
+        vat.rely(msg.sender);
+        vat.deny(address(this));
+    }
+}
+
+contract JugFab {
+    function newJug(address vat) public returns (Jug jug) {
+        jug = new Jug(vat);
+        jug.rely(msg.sender);
+        jug.deny(address(this));
+    }
+}
+
+contract DaiFab {
+    function newDai(uint chainId) public returns (Dai dai) {
+        dai = new Dai(chainId);
+        dai.rely(msg.sender);
+        dai.deny(address(this));
+    }
+}
+
+contract DaiJoinFab {
+    function newDaiJoin(address vat, address dai) public returns (DaiJoin daiJoin) {
+        daiJoin = new DaiJoin(vat, dai);
+    }
+}
+
+contract PotFab {
+    function newPot(address vat) public returns (Pot pot) {
+        pot = new Pot(vat);
+        pot.rely(msg.sender);
+        pot.deny(address(this));
+    }
+}
+
+contract EndFab {
+    function newEnd() public returns (End end) {
+        end = new End();
+        end.rely(msg.sender);
+        end.deny(address(this));
+    }
+}
+
+contract DssDeploy is IDssDeploy {
+    VatFab     public vatFab;
+    JugFab     public jugFab;
+    DaiFab     public daiFab;
+    DaiJoinFab public daiJoinFab;
+    PotFab     public potFab;
+    EndFab     public endFab;
+
+    Vat     public override vat;
+    Jug     public override jug;
+    Dai     public override dai;
+    DaiJoin public override daiJoin;
+    Pot     public override pot;
+    End     public override end;
+
+    constructor(
+        VatFab vatFab_,
+        JugFab jugFab_,
+        DaiFab daiFab_,
+        DaiJoinFab daiJoinFab_,
+        PotFab potFab_,
+        EndFab endFab_
+    ) public {
+        vatFab = vatFab_;
+        jugFab = jugFab_;
+        daiFab = daiFab_;
+        daiJoinFab = daiJoinFab_;
+        potFab = potFab_;
+        endFab = endFab_;
+    }
+
+    function deployVat() public {
+        vat = vatFab.newVat();
+        vat.init("ETH-A");
+    }
+
+    function deployDai(uint256 chainId) public {
+        require(address(vat) != address(0), "Missing previous step");
+
+        // Deploy
+        dai = daiFab.newDai(chainId);
+        daiJoin = daiJoinFab.newDaiJoin(address(vat), address(dai));
+        dai.rely(address(daiJoin));
+    }
+
+    function deployTaxation() public {
+        require(address(vat) != address(0), "Missing previous step");
+
+        // Deploy
+        jug = jugFab.newJug(address(vat));
+        pot = potFab.newPot(address(vat));
+
+        // Internal
+        vat.rely(address(jug));
+        vat.rely(address(pot));
+    }
+
+    function deployShutdown() public {
+        // Deploy
+        end = endFab.newEnd();
+
+        // Internal references set up
+        end.file("vat", address(vat));
+        end.file("pot", address(pot));
+
+        // Internal
+        vat.rely(address(end));
+        pot.rely(address(end));
+    }
+}

--- a/contracts/interfaces/IDssDeploy.sol
+++ b/contracts/interfaces/IDssDeploy.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.6.10;
+
+import {Vat} from "../external/maker/vat.sol";
+import {Jug} from "../external/maker/jug.sol";
+import {DaiJoin} from "../external/maker/join.sol";
+import {Dai} from "../external/maker/dai.sol";
+import {End} from "../external/maker/end.sol";
+import {Pot} from "../external/maker/pot.sol";
+
+interface IDssDeploy {
+    function vat() external view returns (Vat);
+    // function weth
+    // function wethJoin
+    function dai() external view returns (Dai);
+    function daiJoin() external view returns (DaiJoin);
+    function pot() external view returns (Pot);
+    function jug() external view returns (Jug);
+    function end() external view returns (End);
+    // function chai
+}


### PR DESCRIPTION
I've hacked `DssDeploy` down to size so that we can use it for testing, I might make it even smaller.

This is `DssDeploy`: https://raw.githubusercontent.com/makerdao/dss-deploy/master/src/DssDeploy.sol
Deployed here: https://etherscan.io/address/0xbaa65281c2fa2baacb2cb550ba051525a480d3f4#readContract

You can compare the addresses for MakerDAO [1.0.0](https://changelog.makerdao.com/releases/mainnet/1.0.0/contracts.json) and [1.0.8](https://changelog.makerdao.com/releases/mainnet/1.0.8/contracts.json), at one point they upgraded MCD_FLOP, which is part of the original `DssDeploy` contract.

I've created an `IDssDeploy` interface that we can take on constructor from any contract with MakerDAO dependencies.

From there, anyone can call functions like `treasury.upgradeVat()` to point to the new version if there is an upgrade.

**Important note: ** This doesn't work yet, for some reason the [MCD_Deployer contract in mainnet](https://etherscan.io/address/0xbaa65281c2fa2baacb2cb550ba051525a480d3f4#readContract) still points to the 1.0.0 version of flop. Did their upgrade don't work as expected?