### PR TITLE
Simplified EthProxy

### DIFF
--- a/contracts/peripheral/EthProxy.sol
+++ b/contracts/peripheral/EthProxy.sol
@@ -3,11 +3,10 @@ pragma solidity ^0.6.10;
 
 import "../interfaces/IController.sol";
 import "../interfaces/IWeth.sol";
-import "../helpers/Delegable.sol";
 
 
 /// @dev EthProxy allows users to post and withdraw Eth to the Controller, which will be converted to and from Weth in the process.
-contract EthProxy is Delegable() {
+contract EthProxy {
 
     bytes32 public constant WETH = "ETH-A";
 
@@ -30,18 +29,18 @@ contract EthProxy is Delegable() {
 
     /// @dev Users use `post` in EthProxy to post ETH to the Controller, which will be converted to Weth here.
     /// Users must have called `controller.addDelegate(ethProxy.address)` to authorize EthProxy to act in their behalf.
-    function post(address from, address to, uint256 amount)
-        public payable onlyHolderOrDelegate(from, "EthProxy: Only Holder Or Delegate") {
+    function post(uint256 amount)
+        public payable {
         _weth.deposit{ value: amount }();
-        _controller.post(WETH, address(this), to, amount);
+        _controller.post(WETH, address(this), msg.sender, amount);
     }
 
     /// @dev Users wishing to withdraw their Weth as ETH from the Controller should use this function.
     /// Users must have called `controller.addDelegate(ethProxy.address)` to authorize EthProxy to act in their behalf.
-    function withdraw(address from, address payable to, uint256 amount)
-        public onlyHolderOrDelegate(from, "EthProxy: Only Holder Or Delegate") {
-        _controller.withdraw(WETH, from, address(this), amount);
+    function withdraw(uint256 amount)
+        public  {
+        _controller.withdraw(WETH, msg.sender, address(this), amount);
         _weth.withdraw(amount);
-        to.transfer(amount);
+        msg.sender.transfer(amount);
     }
 }

--- a/test/134_controller_ethProxy.js
+++ b/test/134_controller_ethProxy.js
@@ -73,7 +73,7 @@ contract('Controller - EthProxy', async (accounts) =>  {
         );
         
         const previousBalance = await balance.current(owner);
-        await ethProxy.post(owner, owner, wethTokens1, { from: owner, value: wethTokens1 });
+        await ethProxy.post(wethTokens1, { from: owner, value: wethTokens1 });
 
         expect(await balance.current(owner)).to.be.bignumber.lt(previousBalance);
         assert.equal(
@@ -88,37 +88,9 @@ contract('Controller - EthProxy', async (accounts) =>  {
         );
     });
 
-    it("allows user to post eth to a different account", async() => {
-        assert.equal(
-            (await vat.urns(WETH, treasury.address)).ink,
-            0,
-            "Treasury has weth in MakerDAO",
-        );
-        assert.equal(
-            await controller.powerOf.call(WETH, user),
-            0,
-            "User has borrowing power",
-        );
-        
-        const previousBalance = await balance.current(owner);
-        await ethProxy.post(owner, user, wethTokens1, { from: owner, value: wethTokens1 });
-
-        expect(await balance.current(owner)).to.be.bignumber.lt(previousBalance);
-        assert.equal(
-            (await vat.urns(WETH, treasury.address)).ink,
-            wethTokens1.toString(),
-            "Treasury should have weth in MakerDAO",
-        );
-        assert.equal(
-            await controller.powerOf.call(WETH, user),
-            daiTokens1.toString(),
-            "User should have " + daiTokens1 + " borrowing power, instead has " + await controller.powerOf.call(WETH, user),
-        );
-    });
-
     describe("with posted eth", () => {
         beforeEach(async() => {
-            await ethProxy.post(owner, owner, wethTokens1, { from: owner, value: wethTokens1 });
+            await ethProxy.post(wethTokens1, { from: owner, value: wethTokens1 });
 
             assert.equal(
                 (await vat.urns(WETH, treasury.address)).ink,
@@ -149,26 +121,9 @@ contract('Controller - EthProxy', async (accounts) =>  {
 
         it("allows user to withdraw weth", async() => {
             const previousBalance = await balance.current(owner);
-            await ethProxy.withdraw(owner, owner, wethTokens1, { from: owner });
+            await ethProxy.withdraw(wethTokens1, { from: owner });
 
             expect(await balance.current(owner)).to.be.bignumber.gt(previousBalance);
-            assert.equal(
-                (await vat.urns(WETH, treasury.address)).ink,
-                0,
-                "Treasury should not not have weth in MakerDAO",
-            );
-            assert.equal(
-                await controller.powerOf.call(WETH, owner),
-                0,
-                "Owner should not have borrowing power",
-            );
-        });
-
-        it("allows user to withdraw weth to another account", async() => {
-            const previousBalance = await balance.current(user);
-            await ethProxy.withdraw(owner, user, wethTokens1, { from: owner });
-
-            expect(await balance.current(user)).to.be.bignumber.gt(previousBalance);
             assert.equal(
                 (await vat.urns(WETH, treasury.address)).ink,
                 0,


### PR DESCRIPTION
It makes no sense to make EthProxy delegable, since if doesn't use `transferFrom`. I decided to remove composability as well and instead of partial support for `from` and `to` addresses I've changed it to just `msg.sender`.

@brucedonovan, please change the frontend accordingly, EthProxy doesn't take any address parameters anymore.