### PR TITLE
Fixed parameter order.

### DIFF
--- a/contracts/Unwind.sol
+++ b/contracts/Unwind.sol
@@ -262,7 +262,7 @@ contract Unwind is Ownable(), DecimalMath {
     }
 
     /// @dev Redeems YDai for weth
-    function redeem(uint256 maturity, uint256 yDaiAmount, address user) public {
+    function redeem(uint256 maturity, address user, uint256 yDaiAmount) public {
         require(settled && cashedOut, "Unwind: Not ready");
         IYDai yDai = _controller.series(maturity);
         yDai.burn(user, yDaiAmount);

--- a/test/152_unwind_controller.js
+++ b/test/152_unwind_controller.js
@@ -109,7 +109,7 @@ contract('Unwind - Controller', async (accounts) =>  {
 
         it("does not allow to redeem YDai if treasury not settled and cashed", async() => {
             await expectRevert(
-                unwind.redeem(maturity1, yDaiTokens, user2, { from: user2 }),
+                unwind.redeem(maturity1, user2, yDaiTokens, { from: user2 }),
                 "Unwind: Not ready",
             );
         });
@@ -167,7 +167,7 @@ contract('Unwind - Controller', async (accounts) =>  {
             });
 
             it("user can redeem YDai", async() => {
-                await unwind.redeem(maturity1, yDaiTokens, user2, { from: user2 });
+                await unwind.redeem(maturity1, user2, yDaiTokens, { from: user2 });
 
                 assert.equal(
                     await weth.balanceOf(user2),


### PR DESCRIPTION
The parameters in `unwind.redeem` were in the wrong order.