### PR TITLE
Protected against overflow, for better style.

### DIFF
--- a/contracts/Controller.sol
+++ b/contracts/Controller.sol
@@ -108,6 +108,15 @@ contract Controller is IController, Orchestrated(), Delegable(), DecimalMath {
         skimStart = Math.max(skimStart, maturity.add(THREE_MONTHS));
     }
 
+    /// @dev Safe casting from uint256 to int256
+    function toInt256(uint256 x) internal pure returns(int256) {
+        require(
+            x <= 57896044618658097711785492504343953926634992332820282019728792003956564819967,
+            "Controller: Cast overflow"
+        );
+        return int256(x);
+    }
+
     /// @dev Disables post, withdraw, borrow and repay. To be called only when Treasury shuts down.
     function shutdown() public override {
         require(
@@ -215,7 +224,7 @@ contract Controller is IController, Orchestrated(), Delegable(), DecimalMath {
             _treasury.pushChai(from, amount);
         }
         
-        emit Posted(collateral, to, int256(amount)); // TODO: Watch for overflow
+        emit Posted(collateral, to, toInt256(amount));
     }
 
     /// @dev Returns collateral to `to` address, taking it from `from` collateral account.
@@ -244,7 +253,7 @@ contract Controller is IController, Orchestrated(), Delegable(), DecimalMath {
             _treasury.pullChai(to, amount);
         }
 
-        emit Posted(collateral, from, -int256(amount)); // TODO: Watch for overflow
+        emit Posted(collateral, from, -toInt256(amount));
     }
 
     /// @dev Mint yDai for a given series for address `to` by locking its market value in collateral, user debt is increased in the given collateral.
@@ -274,7 +283,7 @@ contract Controller is IController, Orchestrated(), Delegable(), DecimalMath {
         );
 
         series[maturity].mint(to, yDaiAmount);
-        emit Borrowed(collateral, maturity, from, int256(yDaiAmount)); // TODO: Watch for overflow
+        emit Borrowed(collateral, maturity, from, toInt256(yDaiAmount));
     }
 
     /// @dev Burns yDai of a given series from `from` address, user debt is decreased for the given collateral and yDai series.
@@ -325,7 +334,7 @@ contract Controller is IController, Orchestrated(), Delegable(), DecimalMath {
         debtYDai[collateral][maturity][user] = debtYDai[collateral][maturity][user].sub(yDaiAmount);
         totalDebtYDai[collateral][maturity] = totalDebtYDai[collateral][maturity].sub(yDaiAmount);
 
-        emit Borrowed(collateral, maturity, user, -int256(yDaiAmount)); // TODO: Watch for overflow
+        emit Borrowed(collateral, maturity, user, -toInt256(yDaiAmount));
     }
 
     /// @dev Removes all collateral and debt for an user, for a given collateral type.


### PR DESCRIPTION
This wouldn't be needed, really, but it is a tiny extra gas cost and leaving conversions to overflow is bad practice.