### PR TITLE
Reintroduced `to` in `EthProxy`

### DIFF
--- a/contracts/peripheral/EthProxy.sol
+++ b/contracts/peripheral/EthProxy.sol
@@ -29,22 +29,22 @@ contract EthProxy {
 
     /// @dev Users use `post` in EthProxy to post ETH to the Controller, which will be converted to Weth here.
     /// Users must have called `controller.addDelegate(ethProxy.address)` to authorize EthProxy to act in their behalf.
-    /// Use of EthProxy cannot be delegated further.
+    /// @param to Yield Vault to deposit collateral in.
     /// @param amount Amount of collateral to move.
-    function post(uint256 amount)
+    function post(address to, uint256 amount)
         public payable {
         _weth.deposit{ value: amount }();
-        _controller.post(WETH, address(this), msg.sender, amount);
+        _controller.post(WETH, address(this), to, amount);
     }
 
     /// @dev Users wishing to withdraw their Weth as ETH from the Controller should use this function.
     /// Users must have called `controller.addDelegate(ethProxy.address)` to authorize EthProxy to act in their behalf.
-    /// Use of EthProxy cannot be delegated further.
+    /// @param to Wallet to send Eth to.
     /// @param amount Amount of weth to move.
-    function withdraw(uint256 amount)
+    function withdraw(address payable to, uint256 amount)
         public {
         _controller.withdraw(WETH, msg.sender, address(this), amount);
         _weth.withdraw(amount);
-        msg.sender.transfer(amount);
+        to.transfer(amount);
     }
 }


### PR DESCRIPTION
Now `EthProxy` can be used for payments for no extra gas cost.

@brucedonovan, sorry, you have to put the destination address when using `EthProxy` again.