### PR TITLE
Removing `from` for good.

### DIFF
--- a/contracts/peripheral/LimitPool.sol
+++ b/contracts/peripheral/LimitPool.sol
@@ -23,16 +23,14 @@ contract LimitPool {
     }
 
     /// @dev Sell Dai for yDai
-    /// @param from Wallet providing the dai being sold.
-    /// Must have approved the operator with `pool.addDelegate(limitPool.address, { from: from })`.
     /// @param to Wallet receiving the yDai being bought
     /// @param daiIn Amount of dai being sold
     /// @param minYDaiOut Minimum amount of yDai being bought
-    function sellDai(address from, address to, uint128 daiIn, uint128 minYDaiOut)
+    function sellDai(address to, uint128 daiIn, uint128 minYDaiOut)
         external
         returns(uint256)
     {
-        uint256 yDaiOut = pool.sellDai(from, to, daiIn);
+        uint256 yDaiOut = pool.sellDai(msg.sender, to, daiIn);
         require(
             yDaiOut >= minYDaiOut,
             "LimitPool: Limit not reached"
@@ -41,16 +39,14 @@ contract LimitPool {
     }
 
     /// @dev Buy Dai for yDai
-    /// @param from Wallet providing the yDai being sold.
-    /// Must have approved the operator with `pool.addDelegate(limitPool.address, { from: from })`.
     /// @param to Wallet receiving the dai being bought
     /// @param daiOut Amount of dai being bought
     /// @param maxYDaiIn Maximum amount of yDai being sold
-    function buyDai(address from, address to, uint128 daiOut, uint128 maxYDaiIn)
+    function buyDai(address to, uint128 daiOut, uint128 maxYDaiIn)
         external
         returns(uint256)
     {
-        uint256 yDaiIn = pool.buyDai(from, to, daiOut);
+        uint256 yDaiIn = pool.buyDai(msg.sender, to, daiOut);
         require(
             maxYDaiIn >= yDaiIn,
             "LimitPool: Limit exceeded"
@@ -59,16 +55,14 @@ contract LimitPool {
     }
 
     /// @dev Sell yDai for Dai
-    /// @param from Wallet providing the yDai being sold.
-    /// Must have approved the operator with `pool.addDelegate(limitPool.address, { from: from })`.
     /// @param to Wallet receiving the dai being bought
     /// @param yDaiIn Amount of yDai being sold
     /// @param minDaiOut Minimum amount of dai being bought
-    function sellYDai(address from, address to, uint128 yDaiIn, uint128 minDaiOut)
+    function sellYDai(address to, uint128 yDaiIn, uint128 minDaiOut)
         external
         returns(uint256)
     {
-        uint256 daiOut = pool.sellYDai(from, to, yDaiIn);
+        uint256 daiOut = pool.sellYDai(msg.sender, to, yDaiIn);
         require(
             daiOut >= minDaiOut,
             "LimitPool: Limit not reached"
@@ -77,16 +71,14 @@ contract LimitPool {
     }
 
     /// @dev Buy yDai for dai
-    /// @param from Wallet providing the dai being sold.
-    /// Must have approved the operator with `pool.addDelegate(limitPool.address, { from: from })`.
     /// @param to Wallet receiving the yDai being bought
     /// @param yDaiOut Amount of yDai being bought
     /// @param maxDaiIn Maximum amount of dai being sold
-    function buyYDai(address from, address to, uint128 yDaiOut, uint128 maxDaiIn)
+    function buyYDai(address to, uint128 yDaiOut, uint128 maxDaiIn)
         external
         returns(uint256)
     {
-        uint256 daiIn = pool.buyYDai(from, to, yDaiOut);
+        uint256 daiIn = pool.buyYDai(msg.sender, to, yDaiOut);
         require(
             maxDaiIn >= daiIn,
             "LimitPool: Limit exceeded"

--- a/test/peripheral/521_limitPool.ts
+++ b/test/peripheral/521_limitPool.ts
@@ -72,7 +72,7 @@ contract('LimitPool', async (accounts) =>  {
 
             await pool.addDelegate(limitPool.address, { from: from });
             await yDai1.approve(pool.address, yDaiTokens1, { from: from });
-            await limitPool.buyDai(from, to, oneToken, oneToken.mul(2), { from: from });
+            await limitPool.buyDai(to, oneToken, oneToken.mul(2), { from: from });
 
             const expectedYDaiIn = (new BN(oneToken.toString())).mul(new BN('10019')).div(new BN('10000')); // I just hate javascript
             const yDaiIn = (new BN(yDaiTokens1.toString())).sub(new BN(await yDai1.balanceOf(from)));
@@ -88,7 +88,7 @@ contract('LimitPool', async (accounts) =>  {
             await yDai1.approve(pool.address, yDaiTokens1, { from: from });
 
             await expectRevert(
-                limitPool.buyDai(from, to, oneToken, oneToken.div(2), { from: from }),
+                limitPool.buyDai(to, oneToken, oneToken.div(2), { from: from }),
                 "LimitPool: Limit exceeded",
             );
         });
@@ -99,7 +99,7 @@ contract('LimitPool', async (accounts) =>  {
 
             await pool.addDelegate(limitPool.address, { from: from });
             await yDai1.approve(pool.address, oneToken, { from: from });
-            await limitPool.sellYDai(from, to, oneToken, oneToken.div(2), { from: from });
+            await limitPool.sellYDai(to, oneToken, oneToken.div(2), { from: from });
 
             assert.equal(
                 await yDai1.balanceOf(from),
@@ -121,7 +121,7 @@ contract('LimitPool', async (accounts) =>  {
             await yDai1.approve(pool.address, oneToken, { from: from });
 
             await expectRevert(
-                limitPool.sellYDai(from, to, oneToken, oneToken.mul(2), { from: from }),
+                limitPool.sellYDai(to, oneToken, oneToken.mul(2), { from: from }),
                 "LimitPool: Limit not reached",
             );
         });
@@ -140,7 +140,7 @@ contract('LimitPool', async (accounts) =>  {
 
                 await pool.addDelegate(limitPool.address, { from: from });
                 await dai.approve(pool.address, oneToken, { from: from });
-                await limitPool.sellDai(from, to, oneToken, oneToken.div(2), { from: from });
+                await limitPool.sellDai(to, oneToken, oneToken.div(2), { from: from });
 
                 assert.equal(
                     await dai.balanceOf(from),
@@ -163,7 +163,7 @@ contract('LimitPool', async (accounts) =>  {
                 await dai.approve(pool.address, oneToken, { from: from });
 
                 await expectRevert(
-                    limitPool.sellDai(from, to, oneToken, oneToken.mul(2), { from: from }),
+                    limitPool.sellDai(to, oneToken, oneToken.mul(2), { from: from }),
                     "LimitPool: Limit not reached",
                 );
             });
@@ -174,7 +174,7 @@ contract('LimitPool', async (accounts) =>  {
 
                 await pool.addDelegate(limitPool.address, { from: from });
                 await dai.approve(pool.address, daiTokens1, { from: from });
-                await limitPool.buyYDai(from, to, oneToken, oneToken.mul(2), { from: from });
+                await limitPool.buyYDai(to, oneToken, oneToken.mul(2), { from: from });
 
                 assert.equal(
                     await yDai1.balanceOf(to),
@@ -196,7 +196,7 @@ contract('LimitPool', async (accounts) =>  {
                 await dai.approve(pool.address, daiTokens1, { from: from });
 
                 await expectRevert(
-                    limitPool.buyYDai(from, to, oneToken, oneToken.div(2), { from: from }),
+                    limitPool.buyYDai(to, oneToken, oneToken.div(2), { from: from }),
                     "LimitPool: Limit exceeded",
                 );
             });


### PR DESCRIPTION
I had removed the `onlyHolderOrDelegate` modifier, but I was still accepting `from` addresses.

@brucedonovan, when using `LimitPool`, same as with all proxies, you need to supply only a `to` address.