### PR TITLE
prevent redeem during flash mint

### DIFF
--- a/contracts/interfaces/IYDai.sol
+++ b/contracts/interfaces/IYDai.sol
@@ -15,6 +15,7 @@ interface IYDai is IERC20 {
     function mint(address, uint) external;
     function burn(address, uint) external;
     function flashMint(address, uint, bytes calldata) external;
+    function redeem(address, address, uint256) external;
     // function transfer(address, uint) external returns (bool);
     // function transferFrom(address, address, uint) external returns (bool);
     // function approve(address, uint) external returns (bool);

--- a/contracts/mocks/FlashMintRedeemerMock.sol
+++ b/contracts/mocks/FlashMintRedeemerMock.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.6.10;
+
+import "../interfaces/IFlashMinter.sol";
+import "../interfaces/IYDai.sol";
+
+
+contract FlashMintRedeemerMock is IFlashMinter {
+
+    event Parameters(address user, uint256 amount, bytes data);
+
+    uint256 public flashBalance;
+
+    function executeOnFlashMint(address to, uint256 yDaiAmount, bytes calldata data) external override {
+        flashBalance = IYDai(msg.sender).balanceOf(address(this));
+        IYDai(msg.sender).redeem(address(this), address(this), flashBalance);
+        emit Parameters(to, yDaiAmount, data);
+    }
+
+    function flashMint(address yDai, uint256 amount, bytes calldata data) public {
+        IYDai(yDai).flashMint(address(this), amount, data);
+    }
+}

--- a/test/121_ydai.ts
+++ b/test/121_ydai.ts
@@ -1,5 +1,6 @@
 import { YieldEnvironmentLite, Contract } from "./shared/fixtures";
 const FlashMinterMock = artifacts.require('FlashMinterMock');
+const FlashMintRedeemerMock = artifacts.require('FlashMintRedeemerMock');
 
 import { WETH, chi1, rate1, daiTokens1, wethTokens1, toRay, mulRay, divRay, subBN } from './shared/utils';
 
@@ -29,6 +30,7 @@ contract('yDai', async (accounts) =>  {
     let dai: Contract;
     let yDai1: Contract;
     let flashMinter: Contract;
+    let flashMintRedeemer: Contract;
 
     beforeEach(async() => {
         snapshot = await helper.takeSnapshot();
@@ -49,6 +51,10 @@ contract('yDai', async (accounts) =>  {
         // Test setup
         // Setup Flash Minter
         flashMinter = await FlashMinterMock.new(
+            { from: owner },
+        );
+
+        flashMintRedeemer = await FlashMintRedeemerMock.new(
             { from: owner },
         );
         
@@ -116,7 +122,7 @@ contract('yDai', async (accounts) =>  {
         );
     });
 
-    it("yDai flash mints", async() => {
+    it("yDai1 flash mints", async() => {
         const yDaiSupply = await yDai1.totalSupply();
         expectEvent(
             await flashMinter.flashMint(yDai1.address, daiTokens1, web3.utils.fromAscii("DATA"), { from: user1 }),
@@ -173,6 +179,38 @@ contract('yDai', async (accounts) =>  {
             );
         });
 
+        it("yDai1 still flash mints", async() => {
+            const yDaiSupply = await yDai1.totalSupply();
+            expectEvent(
+                await flashMinter.flashMint(yDai1.address, daiTokens1, web3.utils.fromAscii("DATA"), { from: user1 }),
+                "Parameters",
+                {
+                    user: flashMinter.address,
+                    amount: daiTokens1.toString(),
+                    data: web3.utils.fromAscii("DATA"),
+                },
+            );
+    
+            assert.equal(
+                await flashMinter.flashBalance(),
+                daiTokens1.toString(),
+                "FlashMinter should have seen the tokens",
+            );
+            assert.equal(
+                await yDai1.totalSupply(),
+                yDaiSupply.toString(),
+                "There should be no change in yDai supply",
+            );
+        });
+
+        it("yDai1 cannot redeem during flash mint", async() => {
+            const yDaiSupply = await yDai1.totalSupply();
+            await expectRevert(
+                flashMintRedeemer.flashMint(yDai1.address, daiTokens1, web3.utils.fromAscii("DATA"), { from: user1 }),
+                "YDai: Locked"
+            );
+        });
+    
         it("yDai1 rate gets fixed at maturity time", async() => {
             await vat.fold(WETH, vat.address, subBN(rate2, rate1), { from: owner });
             


### PR DESCRIPTION
This change prevents someone from redeeming yDai for Dai during a flash mint of yDai. This prevents possible attacks, including the possibility that someone could flash-mint yDai, redeem it to force a large borrow of Dai, and atomically take some action to cause the Yield Protocol's Maker Vault to become undercollateralized.

It also prevents users from abusing the system to use it as a free way to flash-borrow Dai.