### PR TITLE
remove unneeded _dai variable from Liquidations

### DIFF
--- a/contracts/Liquidations.sol
+++ b/contracts/Liquidations.sol
@@ -27,7 +27,6 @@ contract Liquidations is ILiquidations, Orchestrated(), Delegable(), DecimalMath
     uint256 public constant AUCTION_TIME = 3600;
     uint256 public constant DUST = 25000000000000000; // 0.025 ETH
 
-    IERC20 internal _dai;
     ITreasury internal _treasury;
     IController internal _controller;
 
@@ -44,11 +43,9 @@ contract Liquidations is ILiquidations, Orchestrated(), Delegable(), DecimalMath
 
     /// @dev The Liquidations constructor links it to the Dai, Treasury and Controller contracts.
     constructor (
-        address dai_,
         address treasury_,
         address controller_
     ) public {
-        _dai = IERC20(dai_);
         _treasury = ITreasury(treasury_);
         _controller = IController(controller_);
     }

--- a/migrations/3_deploy_common.js
+++ b/migrations/3_deploy_common.js
@@ -80,7 +80,6 @@ module.exports = async (deployer, network, accounts) => {
   // Setup Liquidations
   await deployer.deploy(
     Liquidations,
-    daiAddress,
     treasuryAddress,
     controllerAddress,
   )

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -221,7 +221,7 @@ export class YieldEnvironment extends YieldEnvironmentLite {
   public static async setup() {
     const { maker, treasury, controller } = await YieldEnvironmentLite.setup();
 
-    const liquidations = await Liquidations.new(maker.dai.address, treasury.address, controller.address)
+    const liquidations = await Liquidations.new(treasury.address, controller.address)
     await controller.orchestrate(liquidations.address)
     await treasury.orchestrate(liquidations.address)
 


### PR DESCRIPTION
As discovered during the audit, the _dai variable in Liquidations is no longer needed.