### PR TITLE
revert on invalid collateral

### DIFF
--- a/contracts/Controller.sol
+++ b/contracts/Controller.sol
@@ -234,8 +234,9 @@ contract Controller is IController, Orchestrated(), Delegable(), DecimalMath {
         } else if (collateral == CHAI) {
             uint256 chi = _pot.chi();
             return muld(posted[collateral][user], chi);
+        } else {
+            revert("Controller: Invalid collateral type");
         }
-        return 0;
     }
 
     /// @dev Returns the amount of collateral locked in borrowing operations.

--- a/test/132_controller_weth.ts
+++ b/test/132_controller_weth.ts
@@ -2,7 +2,7 @@
 import helper from 'ganache-time-traveler';
 // @ts-ignore
 import { BN, expectRevert } from '@openzeppelin/test-helpers';
-import { WETH, rate1, daiTokens1, wethTokens1, toRay, mulRay, divrupRay, addBN, subBN } from './shared/utils';
+import { WETH, INVALID_COLLATERAL, rate1, daiTokens1, wethTokens1, toRay, mulRay, divrupRay, addBN, subBN } from './shared/utils';
 import { MakerEnvironment, YieldEnvironmentLite, Contract } from "./shared/fixtures";
 import { BigNumber } from 'ethers'
 
@@ -66,6 +66,13 @@ contract('Controller - Weth', async (accounts) =>  {
             "|" + ("" + sizeOfC).padStart(16, ' ') + "  |");
         console.log("    ·--------------------|------------------|------------------|------------------·");
         console.log();
+    });
+
+    it("reverts on invalid collateral types", async () => {
+        await expectRevert(
+            controller.powerOf(INVALID_COLLATERAL, user1),
+            "Controller: Invalid collateral type",
+        );
     });
 
     it("it doesn't allow to post weth below dust level", async() => {

--- a/test/shared/utils.ts
+++ b/test/shared/utils.ts
@@ -54,6 +54,7 @@ export function divrupRay(x: BigNumberish, ray: BigNumberish): BigNumber {
 
 export const CHAI = formatBytes32String('CHAI')
 export const WETH = formatBytes32String('ETH-A')
+export const INVALID_COLLATERAL = formatBytes32String('INVALID')
 export const Line = formatBytes32String('Line')
 export const spotName = formatBytes32String('spot')
 export const linel = formatBytes32String('line')


### PR DESCRIPTION
As pointed out in the audit, reverting when called with an invalid collateral type might be safer than returning 0.