### PR TITLE
`EthProxy.post` doesn't need `addDelegate`

### DIFF
--- a/contracts/peripheral/EthProxy.sol
+++ b/contracts/peripheral/EthProxy.sol
@@ -28,7 +28,6 @@ contract EthProxy {
     receive() external payable { }
 
     /// @dev Users use `post` in EthProxy to post ETH to the Controller, which will be converted to Weth here.
-    /// Users must have called `controller.addDelegate(ethProxy.address)` to authorize EthProxy to act in their behalf.
     /// @param to Yield Vault to deposit collateral in.
     /// @param amount Amount of collateral to move.
     function post(address to, uint256 amount)

--- a/test/peripheral/531_ethProxy.ts
+++ b/test/peripheral/531_ethProxy.ts
@@ -47,7 +47,6 @@ contract('Controller - EthProxy', async (accounts) =>  {
             controller.address,
             { from: owner },
         );
-        await controller.addDelegate(ethProxy.address, { from: user1 });
     });
 
     afterEach(async() => {
@@ -104,6 +103,7 @@ contract('Controller - EthProxy', async (accounts) =>  {
         });
 
         it("allows user to withdraw weth", async() => {
+            await controller.addDelegate(ethProxy.address, { from: user1 });
             const previousBalance = await balance.current(user2);
             await ethProxy.withdraw(user2, wethTokens1, { from: user1 });
 


### PR DESCRIPTION
Minor fix, found while writing an article on `Delegable.sol`