### PR TITLE
Made all contract links public

### DIFF
--- a/contracts/Unwind.sol
+++ b/contracts/Unwind.sol
@@ -32,16 +32,16 @@ contract Unwind is Ownable(), DecimalMath {
     bytes32 public constant CHAI = "CHAI";
     bytes32 public constant WETH = "ETH-A";
 
-    IVat internal _vat;
-    IDaiJoin internal _daiJoin;
-    IERC20 internal _weth;
-    IGemJoin internal _wethJoin;
-    IPot internal _pot;
-    IEnd internal _end;
-    IChai internal _chai;
-    ITreasury internal _treasury;
-    IController internal _controller;
-    ILiquidations internal _liquidations;
+    IVat public vat;
+    IDaiJoin public daiJoin;
+    IERC20 public weth;
+    IGemJoin public wethJoin;
+    IPot public pot;
+    IEnd public end;
+    IChai public chai;
+    ITreasury public treasury;
+    IController public controller;
+    ILiquidations public liquidations;
 
     uint256 public _fix; // Dai to weth price on DSS Unwind
     uint256 public _chi; // Chai to dai price on DSS Unwind
@@ -68,19 +68,19 @@ contract Unwind is Ownable(), DecimalMath {
         address liquidations_
     ) public {
         // These could be hardcoded for mainnet deployment.
-        _vat = IVat(vat_);
-        _daiJoin = IDaiJoin(daiJoin_);
-        _weth = IERC20(weth_);
-        _wethJoin = IGemJoin(wethJoin_);
-        _pot = IPot(pot_);
-        _end = IEnd(end_);
-        _chai = IChai(chai_);
-        _treasury = ITreasury(treasury_);
-        _controller = IController(controller_);
-        _liquidations = ILiquidations(liquidations_);
+        vat = IVat(vat_);
+        daiJoin = IDaiJoin(daiJoin_);
+        weth = IERC20(weth_);
+        wethJoin = IGemJoin(wethJoin_);
+        pot = IPot(pot_);
+        end = IEnd(end_);
+        chai = IChai(chai_);
+        treasury = ITreasury(treasury_);
+        controller = IController(controller_);
+        liquidations = ILiquidations(liquidations_);
 
-        _vat.hope(address(_treasury));
-        _vat.hope(address(_end));
+        vat.hope(address(treasury));
+        vat.hope(address(end));
     }
 
     /// @dev max(0, x - y)
@@ -101,13 +101,13 @@ contract Unwind is Ownable(), DecimalMath {
     /// @dev Disables treasury, controller and liquidations.
     function unwind() public {
         require(
-            _end.tag(WETH) != 0,
+            end.tag(WETH) != 0,
             "Unwind: MakerDAO not shutting down"
         );
         live = false;
-        _treasury.shutdown();
-        _controller.shutdown();
-        _liquidations.shutdown();
+        treasury.shutdown();
+        controller.shutdown();
+        liquidations.shutdown();
     }
 
     /// @dev Return the Dai equivalent value to a Chai amount.
@@ -130,43 +130,43 @@ contract Unwind is Ownable(), DecimalMath {
             live == false,
             "Unwind: Unwind first"
         );
-        (uint256 ink, uint256 art) = _vat.urns(WETH, address(_treasury));
+        (uint256 ink, uint256 art) = vat.urns(WETH, address(treasury));
         _treasuryWeth = ink;                            // We will need this to skim profits
-        _vat.fork(                                      // Take the treasury vault
+        vat.fork(                                      // Take the treasury vault
             WETH,
-            address(_treasury),
+            address(treasury),
             address(this),
             toInt(ink),
             toInt(art)
         );
-        _end.skim(WETH, address(this));                // Settle debts
-        _end.free(WETH);                               // Free collateral
-        uint256 gem = _vat.gem(WETH, address(this));   // Find out how much collateral we have now
-        _wethJoin.exit(address(this), gem);            // Take collateral out
+        end.skim(WETH, address(this));                // Settle debts
+        end.free(WETH);                               // Free collateral
+        uint256 gem = vat.gem(WETH, address(this));   // Find out how much collateral we have now
+        wethJoin.exit(address(this), gem);            // Take collateral out
         settled = true;
     }
 
     /// @dev Put all chai savings in MakerDAO and exchange them for weth
     function cashSavings() public {
         require(
-            _end.tag(WETH) != 0,
+            end.tag(WETH) != 0,
             "Unwind: End.sol not caged"
         );
         require(
-            _end.fix(WETH) != 0,
+            end.fix(WETH) != 0,
             "Unwind: End.sol not ready"
         );
-        uint256 daiTokens = _chai.dai(address(_treasury));   // Find out how much is the chai worth
-        _chai.draw(address(_treasury), _treasury.savings()); // Get the chai as dai
-        _daiJoin.join(address(this), daiTokens);             // Put the dai into MakerDAO
-        _end.pack(daiTokens);                                // Into End.sol, more exactly
-        _end.cash(WETH, daiTokens);                          // Exchange the dai for weth
-        uint256 gem = _vat.gem(WETH, address(this));         // Find out how much collateral we have now
-        _wethJoin.exit(address(this), gem);                  // Take collateral out
+        uint256 daiTokens = chai.dai(address(treasury));   // Find out how much is the chai worth
+        chai.draw(address(treasury), treasury.savings()); // Get the chai as dai
+        daiJoin.join(address(this), daiTokens);             // Put the dai into MakerDAO
+        end.pack(daiTokens);                                // Into End.sol, more exactly
+        end.cash(WETH, daiTokens);                          // Exchange the dai for weth
+        uint256 gem = vat.gem(WETH, address(this));         // Find out how much collateral we have now
+        wethJoin.exit(address(this), gem);                  // Take collateral out
         cashedOut = true;
 
-        _fix = _end.fix(WETH);
-        _chi = _pot.chi();
+        _fix = end.fix(WETH);
+        _chi = pot.chi();
     }
 
     /// @dev Settles a series position in Controller for any user, and then returns any remaining collateral as weth using the unwind Dai to Weth price.
@@ -175,7 +175,7 @@ contract Unwind is Ownable(), DecimalMath {
     function settle(bytes32 collateral, address user) public {
         require(settled && cashedOut, "Unwind: Not ready");
 
-        (uint256 tokens, uint256 debt) = _controller.erase(collateral, user);
+        (uint256 tokens, uint256 debt) = controller.erase(collateral, user);
 
         uint256 remainder;
         if (collateral == WETH) {
@@ -183,7 +183,7 @@ contract Unwind is Ownable(), DecimalMath {
         } else if (collateral == CHAI) {
             remainder = daiToFixWeth(subFloorZero(chaiToDai(tokens, _chi), debt), _fix);
         }
-        require(_weth.transfer(user, remainder));
+        require(weth.transfer(user, remainder));
     }
 
     /// @dev Settles a user vault in Liquidations, and then returns any remaining collateral as weth using the unwind Dai to Weth price.
@@ -191,10 +191,10 @@ contract Unwind is Ownable(), DecimalMath {
     function settleLiquidations(address user) public {
         require(settled && cashedOut, "Unwind: Not ready");
 
-        (uint256 weth, uint256 debt) = _liquidations.erase(user);
-        uint256 remainder = subFloorZero(weth, daiToFixWeth(debt, _fix));
+        (uint256 wethAmount, uint256 debt) = liquidations.erase(user);
+        uint256 remainder = subFloorZero(wethAmount, daiToFixWeth(debt, _fix));
 
-        require(_weth.transfer(user, remainder));
+        require(weth.transfer(user, remainder));
     }
 
     /// @dev Redeems YDai for weth for any user. YDai.redeem won't work if MakerDAO is in shutdown.
@@ -202,11 +202,11 @@ contract Unwind is Ownable(), DecimalMath {
     /// @param user Wallet containing the yDai to burn.
     function redeem(uint256 maturity, address user) public {
         require(settled && cashedOut, "Unwind: Not ready");
-        IYDai yDai = _controller.series(maturity);
+        IYDai yDai = controller.series(maturity);
         uint256 yDaiAmount = yDai.balanceOf(user);
         yDai.burn(user, yDaiAmount);
         require(
-            _weth.transfer(
+            weth.transfer(
                 user,
                 daiToFixWeth(muld(yDaiAmount, yDai.chiGrowth()), _fix)
             )

--- a/contracts/YDai.sol
+++ b/contracts/YDai.sol
@@ -32,9 +32,9 @@ contract YDai is Orchestrated(), Delegable(), DecimalMath, ERC20Permit, IYDai  {
 
     uint256 constant internal MAX_TIME_TO_MATURITY = 126144000; // seconds in four years
 
-    IVat internal _vat;
-    IPot internal _pot;
-    ITreasury internal _treasury;
+    IVat public vat;
+    IPot public pot;
+    ITreasury public treasury;
 
     bool public override isMature;
     uint256 public override maturity;
@@ -64,9 +64,9 @@ contract YDai is Orchestrated(), Delegable(), DecimalMath, ERC20Permit, IYDai  {
     ) public ERC20(name, symbol) {
         // solium-disable-next-line security/no-block-members
         require(maturity_ > now && maturity_ < now + MAX_TIME_TO_MATURITY, "YDai: Invalid maturity");
-        _vat = IVat(vat_);
-        _pot = IPot(pot_);
-        _treasury = ITreasury(treasury_);
+        vat = IVat(vat_);
+        pot = IPot(pot_);
+        treasury = ITreasury(treasury_);
         maturity = maturity_;
         chi0 = UNIT;
         rate0 = UNIT;
@@ -81,7 +81,7 @@ contract YDai is Orchestrated(), Delegable(), DecimalMath, ERC20Permit, IYDai  {
     //
     function chiGrowth() public view override returns(uint256){
         if (isMature != true) return chi0;
-        return Math.min(rateGrowth(), divd(_pot.chi(), chi0)); // Rounding in favour of the protocol
+        return Math.min(rateGrowth(), divd(pot.chi(), chi0)); // Rounding in favour of the protocol
     }
 
     /// @dev Rate differential between maturity and now in RAY. Returns 1.0 if not mature.
@@ -93,7 +93,7 @@ contract YDai is Orchestrated(), Delegable(), DecimalMath, ERC20Permit, IYDai  {
     //
     function rateGrowth() public view override returns(uint256){
         if (isMature != true) return rate0;
-        (, uint256 rate,,,) = _vat.ilks(WETH);
+        (, uint256 rate,,,) = vat.ilks(WETH);
         return Math.max(UNIT, divdrup(rate, rate0)); // Rounding in favour of the protocol
     }
 
@@ -108,15 +108,15 @@ contract YDai is Orchestrated(), Delegable(), DecimalMath, ERC20Permit, IYDai  {
             isMature != true,
             "YDai: Already matured"
         );
-        (, rate0,,,) = _vat.ilks(WETH); // Retrieve the MakerDAO Vat
+        (, rate0,,,) = vat.ilks(WETH); // Retrieve the MakerDAO Vat
         rate0 = Math.max(rate0, UNIT); // Floor it at 1.0
-        chi0 = _pot.chi();
+        chi0 = pot.chi();
         isMature = true;
         emit Matured(rate0, chi0);
     }
 
     /// @dev Burn yTokens and return their dai equivalent value, pulled from the Treasury
-    /// During unwind, `_treasury.pullDai()` will revert which is right.
+    /// During unwind, `treasury.pullDai()` will revert which is right.
     /// `from` needs to tell yDai to approve the burning of the yDai tokens.
     /// `from` can delegate to other addresses to redeem his yDai and put the Dai proceeds in the `to` wallet.
     /// The collateral needed changes according to series maturity and MakerDAO rate and chi, depending on collateral type.
@@ -133,7 +133,7 @@ contract YDai is Orchestrated(), Delegable(), DecimalMath, ERC20Permit, IYDai  {
         );
         _burn(from, yDaiAmount);                              // Burn yDai from `from`
         uint256 daiAmount = muld(yDaiAmount, chiGrowth());    // User gets interest for holding after maturity
-        _treasury.pullDai(to, daiAmount);                     // Give dai to `to`, from Treasury
+        treasury.pullDai(to, daiAmount);                     // Give dai to `to`, from Treasury
         emit Redeemed(from, to, yDaiAmount, daiAmount);
     }
 

--- a/contracts/interfaces/IController.sol
+++ b/contracts/interfaces/IController.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
+import "./ITreasury.sol";
 import "./IYDai.sol";
 
 
 interface IController {
+    function treasury() external view returns (ITreasury);
     function series(uint256) external view returns (IYDai);
     function seriesIterator(uint256) external view returns (uint256);
     function totalSeries() external view returns (uint256);


### PR DESCRIPTION
This was discussed and agreed with ToB in the context of showing users that our contracts link to each other as we say they do, and that they have the permissions that we say they have.

I've made all state variables holding contract addresses public, so that by checking any contract it is possible to verify that it connects to the right treasury, vat, dai, etc...

This also has the added benefit that don't need all the addresses passed on to them in the constructor. For example if some contract needs `Controller` and `Treasury`, it can receive the `Controller` address in the constructor, and use it to pull the `Treasury` address.

I won't use that to change the constructors in core contracts, but for the proxies might be quite useful.