### PR TITLE
fix: disallow Unwind.redeem during flashloans

### DIFF
--- a/contracts/Unwind.sol
+++ b/contracts/Unwind.sol
@@ -18,7 +18,6 @@ import "./interfaces/ILiquidations.sol";
 import "./helpers/DecimalMath.sol";
 
 
-
 /**
  * @dev Unwind allows everyone to recover their assets from the Yield protocol in the event of a MakerDAO shutdown.
  * During the unwind process, the system debt to MakerDAO is settled first with `settleTreasury`, extracting all free weth.
@@ -203,6 +202,7 @@ contract Unwind is Ownable(), DecimalMath {
     function redeem(uint256 maturity, address user) public {
         require(settled && cashedOut, "Unwind: Not ready");
         IYDai yDai = controller.series(maturity);
+        require(yDai.unlocked() == 1, "YDAI is still locked");
         uint256 yDaiAmount = yDai.balanceOf(user);
         yDai.burn(user, yDaiAmount);
         require(

--- a/contracts/YDai.sol
+++ b/contracts/YDai.sol
@@ -41,7 +41,7 @@ contract YDai is IYDai, Orchestrated(), Delegable(), DecimalMath, ERC20Permit  {
     uint256 public override chi0;      // Chi at maturity
     uint256 public override rate0;     // Rate at maturity
 
-    uint private unlocked = 1;
+    uint public override unlocked = 1;
     modifier lock() {
         require(unlocked == 1, 'YDai: Locked');
         unlocked = 0;

--- a/contracts/interfaces/IYDai.sol
+++ b/contracts/interfaces/IYDai.sol
@@ -12,6 +12,7 @@ interface IYDai is IERC20, IERC2612 {
     function chiGrowth() external view returns(uint);
     function rateGrowth() external view returns(uint);
     function mature() external;
+    function unlocked() external view returns (uint);
     function mint(address, uint) external;
     function burn(address, uint) external;
     function flashMint(address, uint, bytes calldata) external;


### PR DESCRIPTION
Disallows `redeem` from being called during a flashloan, preventing unintentional usage of ETH funds in Unwind.sol as flashloan capital