### PR TITLE
test: as we approach maturity, prices converge to more or less 1

### DIFF
--- a/test/pool/206_yield_math.ts
+++ b/test/pool/206_yield_math.ts
@@ -462,10 +462,12 @@ contract('YieldMath', async (accounts) => {
           }
 
           // console.log("      " + result[1].toString())
-          if (j == 0) { // Test that when we are very close to maturity, price is very close to 1 minus flat fee.
+          if (j == 0) {
+            // Test that when we are very close to maturity, price is very close to 1 minus flat fee.
             expect(result[1]).to.be.bignumber.lt(maximum.mul(new BN('1000000')).div(new BN('999999')).toString())
             expect(result[1]).to.be.bignumber.gt(maximum.mul(new BN('999999')).div(new BN('1000000')).toString())
-          } else { // Easier to test prices diverging from 1
+          } else {
+            // Easier to test prices diverging from 1
             expect(result[1]).to.be.bignumber.lt(previousResult.toString())
           }
           previousResult = result[1]
@@ -704,10 +706,12 @@ contract('YieldMath', async (accounts) => {
           }
 
           // console.log("      " + result[1].toString())
-          if (j == 0) { // Test that when we are very close to maturity, price is very close to 1 minus flat fee.
+          if (j == 0) {
+            // Test that when we are very close to maturity, price is very close to 1 minus flat fee.
             expect(result[1]).to.be.bignumber.gt(minimum.mul(new BN('999999')).div(new BN('1000000')).toString())
             expect(result[1]).to.be.bignumber.lt(minimum.mul(new BN('1000000')).div(new BN('999999')).toString())
-          } else { // Easier to test prices diverging from 1
+          } else {
+            // Easier to test prices diverging from 1
             expect(result[1]).to.be.bignumber.gt(previousResult.toString())
           }
           previousResult = result[1]
@@ -964,7 +968,8 @@ contract('YieldMath', async (accounts) => {
             // Test that when we are very close to maturity, price is very close to 1 plus flat fee.
             expect(result[1]).to.be.bignumber.lt(maximum.mul(new BN('1000000')).div(new BN('999999')).toString())
             expect(result[1]).to.be.bignumber.gt(maximum.mul(new BN('999999')).div(new BN('1000000')).toString())
-          } else { // Easier to test prices diverging from 1
+          } else {
+            // Easier to test prices diverging from 1
             expect(result[1]).to.be.bignumber.lt(previousResult.toString())
           }
           previousResult = result[1]
@@ -1216,10 +1221,12 @@ contract('YieldMath', async (accounts) => {
           }
 
           // console.log("      " + result[1].toString())
-          if (j == 0) { // Test that when we are very close to maturity, price is very close to 1 plus flat fee.
+          if (j == 0) {
+            // Test that when we are very close to maturity, price is very close to 1 plus flat fee.
             expect(result[1]).to.be.bignumber.gt(minimum.mul(new BN('999999')).div(new BN('1000000')).toString())
             expect(result[1]).to.be.bignumber.lt(minimum.mul(new BN('1000000')).div(new BN('999999')).toString())
-          } else { // Easier to test prices diverging from 1
+          } else {
+            // Easier to test prices diverging from 1
             expect(result[1]).to.be.bignumber.gt(previousResult.toString())
           }
           previousResult = result[1]


### PR DESCRIPTION
For each function, I got three trades (of 10^18, 10^19 and 10^20), and executed them against the same reserves, with time to maturity from 40 seconds to 40 million seconds (one year)

Prices converge to 1, modified by the flat fee, making some prices flip beyond 1 very close to maturity.

Which strangely, is right, otherwise the whitepaper invariant fails. What happens is that, for example, in yDaiInForDaiOut, at maturity, we want users to put in more yDai that they get out, so the price flips from below to over one.

In daiOutForYDaiIn, at maturity, we want users to get out less dai than the yDai they put in, so the price flips from over one to below one.

So basically, the price at maturity is not 1 for any trade, it's just below one when we calculate an amount to give out from the pool, and just above one when we calculate an amount to take in to the pool.

And from that price at maturity, it diverges up or down depending on whether what is taken from the pool is yDai (up) or Dai (down).