### PR TITLE
fix: proxy repay

### DIFF
--- a/test/peripheral/541_daiProxy.ts
+++ b/test/peripheral/541_daiProxy.ts
@@ -239,7 +239,7 @@ contract('YieldProxy - DaiProxy', async (accounts) => {
       )
     })
 
-    describe.only('with extra eDai reserves', () => {
+    describe('with extra eDai reserves', () => {
       beforeEach(async () => {
         // Set up the pool to allow buying eDai
         const additionalEDaiReserves = toWad(34.4)


### PR DESCRIPTION
Previously,  in a `yieldProxy.repay*` function all Dai offered by the user would be exchanged for eDai in the market, and then the proceeds used to repay debt. However, if the user debt was below the eDai that was obtained in the market, `YieldProxy` kept the difference.

Fixed `YieldProxy` so that it checks the user debt levels and market returned eDai and gives to the market only what is needed.