### PR TITLE
feat: made `Unwind` more robust, particularly `cashSavings`

### DIFF
--- a/test/152_unwind_controller.ts
+++ b/test/152_unwind_controller.ts
@@ -102,14 +102,6 @@ contract('Unwind - Controller', async (accounts) => {
       )
     })
 
-    it('does not allow to redeem EDai if treasury not settled and cashed', async () => {
-      await expectRevert(unwind.redeem(maturity1, user2, { from: user2 }), 'Unwind: Not ready')
-    })
-
-    it('does not allow to settle users if treasury not settled and cashed', async () => {
-      await expectRevert(unwind.settle(WETH, user2, { from: user2 }), 'Unwind: Not ready')
-    })
-
     describe('with Dss unwind initiated and treasury settled', () => {
       beforeEach(async () => {
         await env.shutdown(owner, user1, user2)

--- a/test/153_unwind_liquidations.ts
+++ b/test/153_unwind_liquidations.ts
@@ -3,7 +3,20 @@ import { id } from 'ethers/lib/utils'
 import helper from 'ganache-time-traveler'
 // @ts-ignore
 import { BN } from '@openzeppelin/test-helpers'
-import { WETH, spot, rate1, daiTokens1, wethTokens1, toRay, subBN, mulRay, divRay, bnify, ZERO } from './shared/utils'
+import {
+  WETH,
+  spot,
+  rate1,
+  chi1,
+  chaiTokens1,
+  wethTokens1,
+  toRay,
+  subBN,
+  mulRay,
+  divRay,
+  bnify,
+  ZERO,
+} from './shared/utils'
 import { YieldEnvironment, Contract } from './shared/fixtures'
 
 contract('Unwind - Liquidations', async (accounts) => {
@@ -70,6 +83,8 @@ contract('Unwind - Liquidations', async (accounts) => {
         .toString()
       await controller.borrow(WETH, maturity1, user3, user3, toBorrow, { from: user3 })
       await controller.borrow(WETH, maturity2, user3, user3, toBorrow, { from: user3 })
+
+      await env.postChai(user1, chaiTokens1, chi1, rate1)
 
       // Make sure that end.sol will have enough weth to cash chai savings
       await env.maker.getDai(owner, bnify(wethTokens1).mul(10), rate1)


### PR DESCRIPTION
Two changes in this PR:
1. Previously, `settleTreasury` and `cashSavings` were required to run before any of the `settle*` or `redeem` functions could be called. This meant that if `cashSavings` would be unsuccessful (because of a bug, or a MakerDAO event), `Unwind` could end with a large amount of locked Weth. Now `settle*` and `redeem` can be called at any time, and if `Unwind` has weth, they will work. This also opens the door to directly feeding Weth to `Unwind` if desired to allow settlements to continue.

2. `cashSavings` took a leap of faith in that `chai.dai` would return exactly the same amount as `chai.draw`. While this is probably the case, we run the risk that a rounding could jam `cashSavings`. Reading current balances of chai and dai at the right times avoids any assumptions.