### PR TITLE
fix: paying all debt gets users out of liquidation

### DIFF
--- a/contracts/Liquidations.sol
+++ b/contracts/Liquidations.sol
@@ -160,6 +160,8 @@ contract Liquidations is ILiquidations, Orchestrated(), Delegable(), DecimalMath
         });
         vaults[liquidated] = vault;
 
+        if (vaults[liquidated].debt == 0) delete liquidations[liquidated];
+
         treasury.pullWeth(to, tokenAmount);
 
         require(
@@ -171,6 +173,7 @@ contract Liquidations is ILiquidations, Orchestrated(), Delegable(), DecimalMath
     }
 
     /// @dev Retrieve weth from a liquidations account. This weth could be a remainder from liquidations.
+    /// If any weth is not withdrawn, it will be auctioned if the user gets liquidated again.
     /// `from` can delegate to other addresses to withdraw from him.
     /// @param from Address of the liquidations user vault to withdraw weth from.
     /// @param to Address of the wallet receiving the withdrawn weth.

--- a/test/141_liquidations.ts
+++ b/test/141_liquidations.ts
@@ -236,6 +236,20 @@ contract('Liquidations', async (accounts) => {
           )
         })
 
+        it('when all debt is repaid, the user is not in liquidation anymore', async () => {
+          const liquidatorBuys = bnify(userDebt)
+
+          await dai.approve(treasury.address, liquidatorBuys, { from: buyer })
+          await liquidations.buy(buyer, receiver, user2, liquidatorBuys, { from: buyer })
+
+          assert.equal(
+            (await liquidations.vaults(user2, { from: buyer })).debt,
+            0,
+            'User debt should be 0, instead is ' + (await liquidations.vaults(user2, { from: buyer })).debt
+          )
+          assert.equal(await liquidations.liquidations(user2, { from: buyer }), 0)
+        })
+
         describe('once the liquidation time is complete', () => {
           beforeEach(async () => {
             await helper.advanceTime(5000) // Better to test well beyond the limit


### PR DESCRIPTION
Users were never taken out of `liquidations`.

After users get liquidated, even after all debt is repaid, if they get liquidated a second time the auctions will start immediately at the final price.

The fix is to delete the auction start time if all debt is repaid.

Liquidated users need to be careful of removing all remaining collateral once all debt is repaid, or the remaining collateral will get added into the auctioned amounts if they get liquidated again.