### PR TITLE
fix: eDai matures at the end of the day

### DIFF
--- a/migrations/3_deploy_eDai.js
+++ b/migrations/3_deploy_eDai.js
@@ -26,7 +26,7 @@ module.exports = async (deployer, network) => {
   let treasuryAddress
 
   const toDate = (timestamp) => new Date(timestamp * 1000).toISOString().slice(0, 10)
-  const toTimestamp = (date) => new Date(date).getTime() / 1000
+  const toTimestamp = (date) => new Date(date).getTime() / 1000 + 86399
   const toSymbol = (date) =>
     new Intl.DateTimeFormat('en', { year: 'numeric' }).format(new Date(date)).slice(2) +
     new Intl.DateTimeFormat('en', { month: 'short' }).format(new Date(date))


### PR DESCRIPTION
eDai now mature at the end of the day.

Tested using ganache, [add a second to the dates below](https://www.unixtimestamp.com/index.php): 
```
truffle(development)> (await eDai1.maturity()).toString()
'1601510399'
truffle(development)> (await eDai4.maturity()).toString()
'1640995199'
```