### PR TITLE
Fix FYDai Flashmint bug

### DIFF
--- a/contracts/FYDai.sol
+++ b/contracts/FYDai.sol
@@ -139,13 +139,12 @@ contract FYDai is IFYDai, Orchestrated(), Delegable(), DecimalMath, ERC20Permit 
     }
 
     /// @dev Flash-mint fyDai. Calls back on `IFlashMinter.executeOnFlashMint()`
-    /// @param to Wallet to mint the fyDai in.
     /// @param fyDaiAmount Amount of fyDai to mint.
     /// @param data User-defined data to pass on to `executeOnFlashMint()`
-    function flashMint(address to, uint256 fyDaiAmount, bytes calldata data) external lock override {
-        _mint(to, fyDaiAmount);
-        IFlashMinter(msg.sender).executeOnFlashMint(to, fyDaiAmount, data);
-        _burn(to, fyDaiAmount);
+    function flashMint(uint256 fyDaiAmount, bytes calldata data) external lock override {
+        _mint(msg.sender, fyDaiAmount);
+        IFlashMinter(msg.sender).executeOnFlashMint(fyDaiAmount, data);
+        _burn(msg.sender, fyDaiAmount);
     }
 
     /// @dev Mint fyDai. Only callable by Controller contracts.

--- a/contracts/interfaces/IFYDai.sol
+++ b/contracts/interfaces/IFYDai.sol
@@ -15,7 +15,7 @@ interface IFYDai is IERC20, IERC2612 {
     function unlocked() external view returns (uint);
     function mint(address, uint) external;
     function burn(address, uint) external;
-    function flashMint(address, uint, bytes calldata) external;
+    function flashMint(uint, bytes calldata) external;
     function redeem(address, address, uint256) external returns (uint256);
     // function transfer(address, uint) external returns (bool);
     // function transferFrom(address, address, uint) external returns (bool);

--- a/contracts/interfaces/IFlashMinter.sol
+++ b/contracts/interfaces/IFlashMinter.sol
@@ -3,5 +3,5 @@ pragma solidity ^0.6.10;
 
 
 interface IFlashMinter {
-    function executeOnFlashMint(address to, uint256 fyDaiAmount, bytes calldata data) external;
+    function executeOnFlashMint(uint256 fyDaiAmount, bytes calldata data) external;
 }

--- a/contracts/mocks/FlashMintRedeemerMock.sol
+++ b/contracts/mocks/FlashMintRedeemerMock.sol
@@ -7,17 +7,17 @@ import "../interfaces/IFYDai.sol";
 
 contract FlashMintRedeemerMock is IFlashMinter {
 
-    event Parameters(address user, uint256 amount, bytes data);
+    event Parameters(uint256 amount, bytes data);
 
     uint256 public flashBalance;
 
-    function executeOnFlashMint(address to, uint256 fyDaiAmount, bytes calldata data) external override {
+    function executeOnFlashMint(uint256 fyDaiAmount, bytes calldata data) external override {
         flashBalance = IFYDai(msg.sender).balanceOf(address(this));
         IFYDai(msg.sender).redeem(address(this), address(this), flashBalance);
-        emit Parameters(to, fyDaiAmount, data);
+        emit Parameters(fyDaiAmount, data);
     }
 
     function flashMint(address fyDai, uint256 amount, bytes calldata data) public {
-        IFYDai(fyDai).flashMint(address(this), amount, data);
+        IFYDai(fyDai).flashMint(amount, data);
     }
 }

--- a/contracts/mocks/FlashMinterMock.sol
+++ b/contracts/mocks/FlashMinterMock.sol
@@ -7,16 +7,16 @@ import "../interfaces/IFYDai.sol";
 
 contract FlashMinterMock is IFlashMinter {
 
-    event Parameters(address user, uint256 amount, bytes data);
+    event Parameters(uint256 amount, bytes data);
 
     uint256 public flashBalance;
 
-    function executeOnFlashMint(address to, uint256 fyDaiAmount, bytes calldata data) external override {
+    function executeOnFlashMint(uint256 fyDaiAmount, bytes calldata data) external override {
         flashBalance = IFYDai(msg.sender).balanceOf(address(this));
-        emit Parameters(to, fyDaiAmount, data);
+        emit Parameters(fyDaiAmount, data);
     }
 
     function flashMint(address fyDai, uint256 amount, bytes calldata data) public {
-        IFYDai(fyDai).flashMint(address(this), amount, data);
+        IFYDai(fyDai).flashMint(amount, data);
     }
 }

--- a/contracts/peripheral/YieldProxy.sol
+++ b/contracts/peripheral/YieldProxy.sol
@@ -540,7 +540,6 @@ contract YieldProxy is DecimalMath, IFlashMinter {
         // Flash mint the fyDai
         IFYDai fyDai = IPool(pool).fyDai();
         fyDai.flashMint(
-            address(this),
             fyDaiForDai(pool, daiAmount),
             abi.encode(MTY, pool, user, wethAmount, daiAmount)
         );
@@ -568,14 +567,13 @@ contract YieldProxy is DecimalMath, IFlashMinter {
         );
         // Flash mint the fyDai
         fyDai.flashMint(
-            address(this),
             fyDaiAmount,
             abi.encode(YTM, pool, user, wethAmount, 0)
         ); // The daiAmount encoded is ignored
     }
 
     /// @dev Callback from `FYDai.flashMint()`
-    function executeOnFlashMint(address, uint256 fyDaiAmount, bytes calldata data) external override {
+    function executeOnFlashMint(uint256 fyDaiAmount, bytes calldata data) external override {
         (bool direction, address pool, address user, uint256 wethAmount, uint256 daiAmount) = 
             abi.decode(data, (bool, address, address, uint256, uint256));
         if(direction == MTY) _makerToYield(pool, user, wethAmount, daiAmount);

--- a/test/121_edai.ts
+++ b/test/121_edai.ts
@@ -113,7 +113,6 @@ contract('fyDai', async (accounts) => {
       await flashMinter.flashMint(fyDai1.address, daiTokens1, web3.utils.fromAscii('DATA'), { from: user1 }),
       'Parameters',
       {
-        user: flashMinter.address,
         amount: daiTokens1,
         data: web3.utils.fromAscii('DATA'),
       }
@@ -155,7 +154,6 @@ contract('fyDai', async (accounts) => {
         await flashMinter.flashMint(fyDai1.address, daiTokens1, web3.utils.fromAscii('DATA'), { from: user1 }),
         'Parameters',
         {
-          user: flashMinter.address,
           amount: daiTokens1,
           data: web3.utils.fromAscii('DATA'),
         }


### PR DESCRIPTION
Only allow flashminting to `msg.sender`. 

This prevents messing with the reserves of pools and getting mispriced quotes. 

Luckily, our proxies still work, since we always used `address(this)` as the `to` field, which would always be the same as `msg.sender`.