### PR TITLE
Upgradeable Yield Proxy

### DIFF
--- a/contracts/mocks/YieldProxyMockV2.sol
+++ b/contracts/mocks/YieldProxyMockV2.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.6.10;
+
+import { StorageV2 } from "./YieldProxyStorageV2.sol";
+import "../peripheral/ProxyV1.sol";
+
+// Inherits from V1 proxy, and exposes a new method
+// as well as its own initializer
+contract ProxyV2 is StorageV2, ProxyV1 {
+    function init(uint256 _foo) external {
+        require(_foo > 0, "foo must be zero");
+        require(
+            foo == 0,
+            "foo already initialized to non zero value"
+        );
+        foo = _foo;
+
+    }
+
+    function get() external view returns (uint) {
+        return foo;
+    }
+}

--- a/contracts/mocks/YieldProxyMockV2.sol
+++ b/contracts/mocks/YieldProxyMockV2.sol
@@ -13,10 +13,14 @@ contract ProxyV2 is StorageV2, ProxyV1 {
             "foo already initialized to non zero value"
         );
         foo = _foo;
-
     }
 
     function get() external view returns (uint) {
         return foo;
+    }
+
+    /// @dev Overwrite a V1 function
+    function addLiquidity(IPool, uint256, uint256) external override returns (uint256) {
+        return 42;
     }
 }

--- a/contracts/mocks/YieldProxyStorageV2.sol
+++ b/contracts/mocks/YieldProxyStorageV2.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.6.10;
+
+import "../peripheral/ProxyStorage.sol";
+
+// Add a new storage var
+contract StorageV2 is ProxyStorage {
+    uint foo;
+}

--- a/contracts/peripheral/ProxyStorage.sol
+++ b/contracts/peripheral/ProxyStorage.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.6.10;
+
+import "../interfaces/IWeth.sol";
+import "../interfaces/IDai.sol";
+import "../interfaces/IGemJoin.sol";
+import "../interfaces/IDaiJoin.sol";
+import "../interfaces/IVat.sol";
+import "../interfaces/IPot.sol";
+import "../interfaces/IPool.sol";
+import "../interfaces/IFYDai.sol";
+import "../interfaces/IChai.sol";
+import "../interfaces/IDelegable.sol";
+import "../interfaces/ITreasury.sol";
+
+interface ControllerLike is IDelegable {
+    function treasury() external view returns (ITreasury);
+    function series(uint256) external view returns (IFYDai);
+    function seriesIterator(uint256) external view returns (uint256);
+    function totalSeries() external view returns (uint256);
+    function containsSeries(uint256) external view returns (bool);
+    function posted(bytes32, address) external view returns (uint256);
+    function locked(bytes32, address) external view returns (uint256);
+    function debtFYDai(bytes32, uint256, address) external view returns (uint256);
+    function debtDai(bytes32, uint256, address) external view returns (uint256);
+    function totalDebtDai(bytes32, address) external view returns (uint256);
+    function isCollateralized(bytes32, address) external view returns (bool);
+    function inDai(bytes32, uint256, uint256) external view returns (uint256);
+    function inFYDai(bytes32, uint256, uint256) external view returns (uint256);
+    function erase(bytes32, address) external returns (uint256, uint256);
+    function shutdown() external;
+    function post(bytes32, address, address, uint256) external;
+    function withdraw(bytes32, address, address, uint256) external;
+    function borrow(bytes32, uint256, address, address, uint256) external;
+    function repayFYDai(bytes32, uint256, address, address, uint256) external returns (uint256);
+    function repayDai(bytes32, uint256, address, address, uint256) external returns (uint256);
+}
+
+// V1 Proxy Storage. V2 or more should inherit this.
+contract ProxyStorage {
+    IVat public vat;
+    IWeth public weth;
+    IDai public dai;
+    IGemJoin public wethJoin;
+    IDaiJoin public daiJoin;
+    IChai public chai;
+    ControllerLike public controller;
+    ITreasury public treasury;
+
+    IPool[] public pools;
+    mapping (address => bool) public poolsMap;
+
+    bytes32 public constant CHAI = "CHAI";
+    bytes32 public constant WETH = "ETH-A";
+    bool constant public MTY = true;
+    bool constant public YTM = false;
+
+    // ABI helpers for integrating with the authorization
+    // logic in the main proxy
+    function onboard(address,address,address,bytes memory,bytes memory) external {}
+    function authorizePool(address, address, address, bytes memory, bytes memory, bytes memory) public {}
+}

--- a/contracts/peripheral/ProxyV1.sol
+++ b/contracts/peripheral/ProxyV1.sol
@@ -1,0 +1,462 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.6.10;
+
+import "./ProxyStorage.sol";
+import "./SafeCast.sol";
+
+import "../interfaces/IWeth.sol";
+import "../interfaces/IDai.sol";
+import "../interfaces/IGemJoin.sol";
+import "../interfaces/IDaiJoin.sol";
+import "../interfaces/IVat.sol";
+import "../interfaces/IPot.sol";
+import "../interfaces/IPool.sol";
+import "../interfaces/IFYDai.sol";
+import "../interfaces/IChai.sol";
+import "../interfaces/IDelegable.sol";
+import "../interfaces/ITreasury.sol";
+import "../helpers/DecimalMath.sol";
+
+contract ProxyV1 is ProxyStorage, DecimalMath {
+    using SafeCast for uint256;
+
+    function init(address controller_, IPool[] memory _pools) public {
+        // prevent double initialization
+        require(address(controller) == address(0), "already initialized");
+
+        controller = ControllerLike(controller_);
+        treasury = controller.treasury();
+
+        weth = treasury.weth();
+        dai = IDai(address(treasury.dai()));
+        chai = treasury.chai();
+        daiJoin = treasury.daiJoin();
+        wethJoin = treasury.wethJoin();
+        vat = treasury.vat();
+
+        // for repaying debt
+        dai.approve(address(treasury), uint(-1));
+
+        // for posting to the controller
+        chai.approve(address(treasury), uint(-1));
+        weth.approve(address(treasury), uint(-1));
+
+        // for converting DAI to CHAI
+        dai.approve(address(chai), uint(-1));
+
+        vat.hope(address(daiJoin));
+        vat.hope(address(wethJoin));
+
+        dai.approve(address(daiJoin), uint(-1));
+        weth.approve(address(wethJoin), uint(-1));
+        weth.approve(address(treasury), uint(-1));
+
+        // allow all the pools to pull FYDai/dai from us for LPing
+        for (uint i = 0 ; i < _pools.length; i++) {
+            dai.approve(address(_pools[i]), uint(-1));
+            _pools[i].fyDai().approve(address(_pools[i]), uint(-1));
+            poolsMap[address(_pools[i])]= true;
+        }
+
+        pools = _pools;
+    }
+
+    /// @dev Users use `post` in YieldProxy to post ETH to the Controller (amount = msg.value), which will be converted to Weth here.
+    /// @param to Yield Vault to deposit collateral in.
+    function post(address to)
+        public payable {
+        weth.deposit{ value: msg.value }();
+        controller.post(WETH, address(this), to, msg.value);
+    }
+
+    /// @dev Users wishing to withdraw their Weth as ETH from the Controller should use this function.
+    /// Users must have called `controller.addDelegate(yieldProxy.address)` to authorize YieldProxy to act in their behalf.
+    /// @param to Wallet to send Eth to.
+    /// @param amount Amount of weth to move.
+    function withdraw(address payable to, uint256 amount)
+        public {
+        controller.withdraw(WETH, msg.sender, address(this), amount);
+        weth.withdraw(amount);
+        to.transfer(amount);
+    }
+
+    /// @dev Mints liquidity with provided Dai by borrowing fyDai with some of the Dai.
+    /// Caller must have approved the proxy using`controller.addDelegate(yieldProxy)`
+    /// Caller must have approved the dai transfer with `dai.approve(daiUsed)`
+    /// @param daiUsed amount of Dai to use to mint liquidity. 
+    /// @param maxFYDai maximum amount of fyDai to be borrowed to mint liquidity. 
+    /// @return The amount of liquidity tokens minted.  
+    function addLiquidity(IPool pool, uint256 daiUsed, uint256 maxFYDai) external returns (uint256) {
+        onlyKnownPool(pool);
+        IFYDai fyDai = pool.fyDai();
+        require(fyDai.isMature() != true, "YieldProxy: Only before maturity");
+        require(dai.transferFrom(msg.sender, address(this), daiUsed), "YieldProxy: Transfer Failed");
+
+        // calculate needed fyDai
+        uint256 daiReserves = dai.balanceOf(address(pool));
+        uint256 fyDaiReserves = fyDai.balanceOf(address(pool));
+        uint256 daiToAdd = daiUsed.mul(daiReserves).div(fyDaiReserves.add(daiReserves));
+        uint256 daiToConvert = daiUsed.sub(daiToAdd);
+        require(
+            daiToConvert <= maxFYDai,
+            "YieldProxy: maxFYDai exceeded"
+        ); // 1 Dai == 1 fyDai
+
+        // convert dai to chai and borrow needed fyDai
+        chai.join(address(this), daiToConvert);
+        // look at the balance of chai in dai to avoid rounding issues
+        uint256 toBorrow = chai.dai(address(this));
+        controller.post(CHAI, address(this), msg.sender, chai.balanceOf(address(this)));
+        controller.borrow(CHAI, fyDai.maturity(), msg.sender, address(this), toBorrow);
+        
+        // mint liquidity tokens
+        return pool.mint(address(this), msg.sender, daiToAdd);
+    }
+
+    /// @dev Burns tokens and sells Dai proceedings for fyDai. Pays as much debt as possible, then sells back any remaining fyDai for Dai. Then returns all Dai, and if there is no debt in the Controller, all posted Chai.
+    /// Caller must have approved the proxy using`controller.addDelegate(yieldProxy)` and `pool.addDelegate(yieldProxy)`
+    /// Caller must have approved the liquidity burn with `pool.approve(poolTokens)`
+    /// @param poolTokens amount of pool tokens to burn. 
+    /// @param minimumDaiPrice minimum fyDai/Dai price to be accepted when internally selling Dai.
+    /// @param minimumFYDaiPrice minimum Dai/fyDai price to be accepted when internally selling fyDai.
+    function removeLiquidityEarlyDaiPool(IPool pool, uint256 poolTokens, uint256 minimumDaiPrice, uint256 minimumFYDaiPrice) external {
+        onlyKnownPool(pool);
+        IFYDai fyDai = pool.fyDai();
+        uint256 maturity = fyDai.maturity();
+        (uint256 daiObtained, uint256 fyDaiObtained) = pool.burn(msg.sender, address(this), poolTokens);
+
+        // Exchange Dai for fyDai to pay as much debt as possible
+        uint256 fyDaiBought = pool.sellDai(address(this), address(this), daiObtained.toUint128());
+        require(
+            fyDaiBought >= muld(daiObtained, minimumDaiPrice),
+            "YieldProxy: minimumDaiPrice not reached"
+        );
+        fyDaiObtained = fyDaiObtained.add(fyDaiBought);
+        
+        uint256 fyDaiUsed;
+        if (fyDaiObtained > 0 && controller.debtFYDai(CHAI, maturity, msg.sender) > 0) {
+            fyDaiUsed = controller.repayFYDai(CHAI, maturity, address(this), msg.sender, fyDaiObtained);
+        }
+        uint256 fyDaiRemaining = fyDaiObtained.sub(fyDaiUsed);
+
+        if (fyDaiRemaining > 0) {// There is fyDai left, so exchange it for Dai to withdraw only Dai and Chai
+            require(
+                pool.sellFYDai(address(this), address(this), uint128(fyDaiRemaining)) >= muld(fyDaiRemaining, minimumFYDaiPrice),
+                "YieldProxy: minimumFYDaiPrice not reached"
+            );
+        }
+        withdrawAssets(fyDai);
+    }
+
+    /// @dev Burns tokens and repays debt with proceedings. Sells any excess fyDai for Dai, then returns all Dai, and if there is no debt in the Controller, all posted Chai.
+    /// Caller must have approved the proxy using`controller.addDelegate(yieldProxy)` and `pool.addDelegate(yieldProxy)`
+    /// Caller must have approved the liquidity burn with `pool.approve(poolTokens)`
+    /// @param poolTokens amount of pool tokens to burn. 
+    /// @param minimumFYDaiPrice minimum Dai/fyDai price to be accepted when internally selling fyDai.
+    function removeLiquidityEarlyDaiFixed(IPool pool, uint256 poolTokens, uint256 minimumFYDaiPrice) external {
+        onlyKnownPool(pool);
+        IFYDai fyDai = pool.fyDai();
+        uint256 maturity = fyDai.maturity();
+        (uint256 daiObtained, uint256 fyDaiObtained) = pool.burn(msg.sender, address(this), poolTokens);
+
+        uint256 fyDaiUsed;
+        if (fyDaiObtained > 0 && controller.debtFYDai(CHAI, maturity, msg.sender) > 0) {
+            fyDaiUsed = controller.repayFYDai(CHAI, maturity, address(this), msg.sender, fyDaiObtained);
+        }
+
+        uint256 fyDaiRemaining = fyDaiObtained.sub(fyDaiUsed);
+        if (fyDaiRemaining == 0) { // We used all the fyDai, so probably there is debt left, so pay with Dai
+            if (daiObtained > 0 && controller.debtFYDai(CHAI, maturity, msg.sender) > 0) {
+                controller.repayDai(CHAI, maturity, address(this), msg.sender, daiObtained);
+            }
+        } else { // Exchange remaining fyDai for Dai to withdraw only Dai and Chai
+            require(
+                pool.sellFYDai(address(this), address(this), uint128(fyDaiRemaining)) >= muld(fyDaiRemaining, minimumFYDaiPrice),
+                "YieldProxy: minimumFYDaiPrice not reached"
+            );
+        }
+        withdrawAssets(fyDai);
+    }
+
+    /// @dev Burns tokens and repays fyDai debt after Maturity. 
+    /// Caller must have approved the proxy using`controller.addDelegate(yieldProxy)`
+    /// Caller must have approved the liquidity burn with `pool.approve(poolTokens)`
+    /// @param poolTokens amount of pool tokens to burn.
+    function removeLiquidityMature(IPool pool, uint256 poolTokens) external {
+        onlyKnownPool(pool);
+        IFYDai fyDai = pool.fyDai();
+        uint256 maturity = fyDai.maturity();
+        (uint256 daiObtained, uint256 fyDaiObtained) = pool.burn(msg.sender, address(this), poolTokens);
+        if (fyDaiObtained > 0) {
+            daiObtained = daiObtained.add(fyDai.redeem(address(this), address(this), fyDaiObtained));
+        }
+        
+        // Repay debt
+        if (daiObtained > 0 && controller.debtFYDai(CHAI, maturity, msg.sender) > 0) {
+            controller.repayDai(CHAI, maturity, address(this), msg.sender, daiObtained);
+        }
+        withdrawAssets(fyDai);
+    }
+
+    /// @dev Return to caller all posted chai if there is no debt, converted to dai, plus any dai remaining in the contract.
+    function withdrawAssets(IFYDai fyDai) internal {
+        if (controller.debtFYDai(CHAI, fyDai.maturity(), msg.sender) == 0) {
+            uint256 posted = controller.posted(CHAI, msg.sender);
+            uint256 locked = controller.locked(CHAI, msg.sender);
+            require (posted >= locked, "YieldProxy: Undercollateralized");
+            controller.withdraw(CHAI, msg.sender, address(this), posted - locked);
+            chai.exit(address(this), chai.balanceOf(address(this)));
+        }
+        require(dai.transfer(msg.sender, dai.balanceOf(address(this))), "YieldProxy: Dai Transfer Failed");
+    }
+
+    /// @dev Borrow fyDai from Controller and sell it immediately for Dai, for a maximum fyDai debt.
+    /// Must have approved the operator with `controller.addDelegate(yieldProxy.address)`.
+    /// @param collateral Valid collateral type.
+    /// @param maturity Maturity of an added series
+    /// @param to Wallet to send the resulting Dai to.
+    /// @param maximumFYDai Maximum amount of FYDai to borrow.
+    /// @param daiToBorrow Exact amount of Dai that should be obtained.
+    function borrowDaiForMaximumFYDai(
+        IPool pool,
+        bytes32 collateral,
+        uint256 maturity,
+        address to,
+        uint256 maximumFYDai,
+        uint256 daiToBorrow
+    )
+        public
+        returns (uint256)
+    {
+        onlyKnownPool(pool);
+        uint256 fyDaiToBorrow = pool.buyDaiPreview(daiToBorrow.toUint128());
+        require (fyDaiToBorrow <= maximumFYDai, "YieldProxy: Too much fyDai required");
+
+        // The collateral for this borrow needs to have been posted beforehand
+        controller.borrow(collateral, maturity, msg.sender, address(this), fyDaiToBorrow);
+        pool.buyDai(address(this), to, daiToBorrow.toUint128());
+
+        return fyDaiToBorrow;
+    }
+
+    /// @dev Borrow fyDai from Controller and sell it immediately for Dai, if a minimum amount of Dai can be obtained such.
+    /// Must have approved the operator with `controller.addDelegate(yieldProxy.address)`.
+    /// @param collateral Valid collateral type.
+    /// @param maturity Maturity of an added series
+    /// @param to Wallet to sent the resulting Dai to.
+    /// @param fyDaiToBorrow Amount of fyDai to borrow.
+    /// @param minimumDaiToBorrow Minimum amount of Dai that should be borrowed.
+    function borrowMinimumDaiForFYDai(
+        IPool pool,
+        bytes32 collateral,
+        uint256 maturity,
+        address to,
+        uint256 fyDaiToBorrow,
+        uint256 minimumDaiToBorrow
+    )
+        public
+        returns (uint256)
+    {
+        onlyKnownPool(pool);
+        // The collateral for this borrow needs to have been posted beforehand
+        controller.borrow(collateral, maturity, msg.sender, address(this), fyDaiToBorrow);
+        uint256 boughtDai = pool.sellFYDai(address(this), to, fyDaiToBorrow.toUint128());
+        require (boughtDai >= minimumDaiToBorrow, "YieldProxy: Not enough Dai obtained");
+
+        return boughtDai;
+    }
+
+    /// @dev Repay an amount of fyDai debt in Controller using Dai exchanged for fyDai at pool rates, up to a maximum amount of Dai spent.
+    /// Must have approved the operator with `pool.addDelegate(yieldProxy.address)`.
+    /// If `fyDaiRepayment` exceeds the existing debt, only the necessary fyDai will be used.
+    /// @param collateral Valid collateral type.
+    /// @param maturity Maturity of an added series
+    /// @param to Yield Vault to repay fyDai debt for.
+    /// @param fyDaiRepayment Amount of fyDai debt to repay.
+    /// @param maximumRepaymentInDai Maximum amount of Dai that should be spent on the repayment.
+    function repayFYDaiDebtForMaximumDai(
+        IPool pool,
+        bytes32 collateral,
+        uint256 maturity,
+        address to,
+        uint256 fyDaiRepayment,
+        uint256 maximumRepaymentInDai
+    )
+        public
+        returns (uint256)
+    {
+        onlyKnownPool(pool);
+        uint256 fyDaiDebt = controller.debtFYDai(collateral, maturity, to);
+        uint256 fyDaiToUse = fyDaiDebt < fyDaiRepayment ? fyDaiDebt : fyDaiRepayment; // Use no more fyDai than debt
+        uint256 repaymentInDai = pool.buyFYDai(msg.sender, address(this), fyDaiToUse.toUint128());
+        require (repaymentInDai <= maximumRepaymentInDai, "YieldProxy: Too much Dai required");
+        controller.repayFYDai(collateral, maturity, address(this), to, fyDaiToUse);
+
+        return repaymentInDai;
+    }
+
+    /// @dev Repay an amount of fyDai debt in Controller using a given amount of Dai exchanged for fyDai at pool rates, with a minimum of fyDai debt required to be paid.
+    /// Must have approved the operator with `pool.addDelegate(yieldProxy.address)`.
+    /// If `repaymentInDai` exceeds the existing debt, only the necessary Dai will be used.
+    /// @param collateral Valid collateral type.
+    /// @param maturity Maturity of an added series
+    /// @param to Yield Vault to repay fyDai debt for.
+    /// @param minimumFYDaiRepayment Minimum amount of fyDai debt to repay.
+    /// @param repaymentInDai Exact amount of Dai that should be spent on the repayment.
+    function repayMinimumFYDaiDebtForDai(
+        IPool pool,
+        bytes32 collateral,
+        uint256 maturity,
+        address to,
+        uint256 minimumFYDaiRepayment,
+        uint256 repaymentInDai
+    )
+        public
+        returns (uint256)
+    {
+        onlyKnownPool(pool);
+        uint256 fyDaiRepayment = pool.sellDaiPreview(repaymentInDai.toUint128());
+        uint256 fyDaiDebt = controller.debtFYDai(collateral, maturity, to);
+        if(fyDaiRepayment <= fyDaiDebt) { // Sell no more Dai than needed to cancel all the debt
+            pool.sellDai(msg.sender, address(this), repaymentInDai.toUint128());
+        } else { // If we have too much Dai, then don't sell it all and buy the exact amount of fyDai needed instead.
+            pool.buyFYDai(msg.sender, address(this), fyDaiDebt.toUint128());
+            fyDaiRepayment = fyDaiDebt;
+        }
+        require (fyDaiRepayment >= minimumFYDaiRepayment, "YieldProxy: Not enough fyDai debt repaid");
+        controller.repayFYDai(collateral, maturity, address(this), to, fyDaiRepayment);
+
+        return fyDaiRepayment;
+    }
+
+    /// @dev Sell Dai for fyDai
+    /// @param to Wallet receiving the fyDai being bought
+    /// @param daiIn Amount of dai being sold
+    /// @param minFYDaiOut Minimum amount of fyDai being bought
+    function sellDai(IPool pool, address to, uint128 daiIn, uint128 minFYDaiOut)
+        external
+        returns(uint256)
+    {
+        onlyKnownPool(pool);
+        uint256 fyDaiOut = pool.sellDai(msg.sender, to, daiIn);
+        require(
+            fyDaiOut >= minFYDaiOut,
+            "YieldProxy: Limit not reached"
+        );
+        return fyDaiOut;
+    }
+
+    /// @dev Buy Dai for fyDai
+    /// @param to Wallet receiving the dai being bought
+    /// @param daiOut Amount of dai being bought
+    /// @param maxFYDaiIn Maximum amount of fyDai being sold
+    function buyDai(IPool pool, address to, uint128 daiOut, uint128 maxFYDaiIn)
+        public
+        returns(uint256)
+    {
+        onlyKnownPool(pool);
+        uint256 fyDaiIn = pool.buyDai(msg.sender, to, daiOut);
+        require(
+            maxFYDaiIn >= fyDaiIn,
+            "YieldProxy: Limit exceeded"
+        );
+        return fyDaiIn;
+    }
+
+    /// @dev Buy Dai for fyDai and permits infinite fyDai to the pool
+    /// @param to Wallet receiving the dai being bought
+    /// @param daiOut Amount of dai being bought
+    /// @param maxFYDaiIn Maximum amount of fyDai being sold
+    /// @param signature The `permit` call's signature
+    function buyDaiWithSignature(IPool pool, address to, uint128 daiOut, uint128 maxFYDaiIn, bytes memory signature)
+        external
+        returns(uint256)
+    {
+        onlyKnownPool(pool);
+        (bytes32 r, bytes32 s, uint8 v) = unpack(signature);
+        pool.fyDai().permit(msg.sender, address(pool), uint(-1), uint(-1), v, r, s);
+
+        return buyDai(pool, to, daiOut, maxFYDaiIn);
+    }
+
+    /// @dev Sell fyDai for Dai
+    /// @param to Wallet receiving the dai being bought
+    /// @param fyDaiIn Amount of fyDai being sold
+    /// @param minDaiOut Minimum amount of dai being bought
+    function sellFYDai(IPool pool, address to, uint128 fyDaiIn, uint128 minDaiOut)
+        public
+        returns(uint256)
+    {
+        onlyKnownPool(pool);
+        uint256 daiOut = pool.sellFYDai(msg.sender, to, fyDaiIn);
+        require(
+            daiOut >= minDaiOut,
+            "YieldProxy: Limit not reached"
+        );
+        return daiOut;
+    }
+
+    /// @dev Sell fyDai for Dai and permits infinite Dai to the pool
+    /// @param to Wallet receiving the dai being bought
+    /// @param fyDaiIn Amount of fyDai being sold
+    /// @param minDaiOut Minimum amount of dai being bought
+    /// @param signature The `permit` call's signature
+    function sellFYDaiWithSignature(IPool pool, address to, uint128 fyDaiIn, uint128 minDaiOut, bytes memory signature)
+        external
+        returns(uint256)
+    {
+        onlyKnownPool(pool);
+        (bytes32 r, bytes32 s, uint8 v) = unpack(signature);
+        pool.fyDai().permit(msg.sender, address(pool), uint(-1), uint(-1), v, r, s);
+
+        return sellFYDai(pool, to, fyDaiIn, minDaiOut);
+    }
+
+    /// @dev Buy fyDai for dai
+    /// @param to Wallet receiving the fyDai being bought
+    /// @param fyDaiOut Amount of fyDai being bought
+    /// @param maxDaiIn Maximum amount of dai being sold
+    function buyFYDai(IPool pool, address to, uint128 fyDaiOut, uint128 maxDaiIn)
+        external
+        returns(uint256)
+    {
+        onlyKnownPool(pool);
+        uint256 daiIn = pool.buyFYDai(msg.sender, to, fyDaiOut);
+        require(
+            maxDaiIn >= daiIn,
+            "YieldProxy: Limit exceeded"
+        );
+        return daiIn;
+    }
+
+    /// @dev Burns Dai from caller to repay debt in a Yield Vault.
+    /// User debt is decreased for the given collateral and fyDai series, in Yield vault `to`.
+    /// The amount of debt repaid changes according to series maturity and MakerDAO rate and chi, depending on collateral type.
+    /// `A signature is provided as a parameter to this function, so that `dai.approve()` doesn't need to be called.
+    /// @param collateral Valid collateral type.
+    /// @param maturity Maturity of an added series
+    /// @param to Yield vault to repay debt for.
+    /// @param daiAmount Amount of Dai to use for debt repayment.
+    /// @param signature The `permit` call's signature
+    function repayDaiWithSignature(bytes32 collateral, uint256 maturity, address to, uint256 daiAmount, bytes memory signature)
+        external
+        returns(uint256)
+    {
+        (bytes32 r, bytes32 s, uint8 v) = unpack(signature);
+        dai.permit(msg.sender, address(treasury), dai.nonces(msg.sender), uint(-1), true, v, r, s);
+        controller.repayDai(collateral, maturity, msg.sender, to, daiAmount);
+    }
+
+    function onlyKnownPool(IPool pool) private view {
+        require(poolsMap[address(pool)], "YieldProxy: Unknown pool");
+    }
+
+    /// @dev Unpack r, s and v from a `bytes` signature
+    function unpack(bytes memory signature) private pure returns (bytes32 r, bytes32 s, uint8 v) {
+        assembly {
+            r := mload(add(signature, 0x20))
+            s := mload(add(signature, 0x40))
+            v := byte(0, mload(add(signature, 0x60)))
+        }
+    }
+}

--- a/contracts/peripheral/ProxyV1.sol
+++ b/contracts/peripheral/ProxyV1.sol
@@ -86,7 +86,7 @@ contract ProxyV1 is ProxyStorage, DecimalMath {
     /// @param daiUsed amount of Dai to use to mint liquidity. 
     /// @param maxFYDai maximum amount of fyDai to be borrowed to mint liquidity. 
     /// @return The amount of liquidity tokens minted.  
-    function addLiquidity(IPool pool, uint256 daiUsed, uint256 maxFYDai) external returns (uint256) {
+    function addLiquidity(IPool pool, uint256 daiUsed, uint256 maxFYDai) external virtual returns (uint256) {
         onlyKnownPool(pool);
         IFYDai fyDai = pool.fyDai();
         require(fyDai.isMature() != true, "YieldProxy: Only before maturity");

--- a/contracts/peripheral/SafeCast.sol
+++ b/contracts/peripheral/SafeCast.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.6.10;
+library SafeCast {
+    /// @dev Safe casting from uint256 to uint128
+    function toUint128(uint256 x) internal pure returns(uint128) {
+        require(
+            x <= type(uint128).max,
+            "YieldProxy: Cast overflow"
+        );
+        return uint128(x);
+    }
+
+    /// @dev Safe casting from uint256 to int256
+    function toInt256(uint256 x) internal pure returns(int256) {
+        require(
+            x <= uint256(type(int256).max),
+            "YieldProxy: Cast overflow"
+        );
+        return int256(x);
+    }
+}
+
+

--- a/contracts/peripheral/YieldProxy.sol
+++ b/contracts/peripheral/YieldProxy.sol
@@ -109,7 +109,7 @@ contract YieldProxy is YieldAuth {
 
     /// @dev Choose a proxy `version` to use for the caller, using the sequential identifier.
     function chooseVersion(uint256 version) public {
-        require(version <= getLatestVersion(), "Invalid version");
+        require(version <= getLatestVersion(), "YieldProxy: Invalid version");
         userChoices[msg.sender] = version;
     }
 

--- a/contracts/peripheral/YieldProxy.sol
+++ b/contracts/peripheral/YieldProxy.sol
@@ -92,6 +92,24 @@ contract YieldProxy is YieldAuth {
 	}
 
     /// @dev Get the identifier of the latest version from `VERSION_SLOT`.
+    function getAdmin() public view returns (address admin) {
+		bytes32 slot = ADMIN_SLOT;
+		// solhint-disable-next-line no-inline-assembly
+		assembly {
+			admin := sload(slot)
+		}
+	}
+
+    /// @dev Get the identifier of the latest version from `VERSION_SLOT`.
+    function getProposedAdmin() public view returns (address proposedAdmin) {
+		bytes32 slot = PROPOSED_ADMIN_SLOT;
+		// solhint-disable-next-line no-inline-assembly
+		assembly {
+			proposedAdmin := sload(slot)
+		}
+	}
+
+    /// @dev Get the identifier of the latest version from `VERSION_SLOT`.
     function getLatestVersion() public view returns (uint256 version) {
 		bytes32 slot = VERSION_SLOT;
 		// solhint-disable-next-line no-inline-assembly

--- a/contracts/peripheral/YieldProxy.sol
+++ b/contracts/peripheral/YieldProxy.sol
@@ -1,122 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-import "../interfaces/IWeth.sol";
+import "./ProxyStorage.sol";
+import "./SafeCast.sol";
+
 import "../interfaces/IDai.sol";
-import "../interfaces/IGemJoin.sol";
-import "../interfaces/IDaiJoin.sol";
-import "../interfaces/IVat.sol";
-import "../interfaces/IPot.sol";
 import "../interfaces/IPool.sol";
-import "../interfaces/IFYDai.sol";
-import "../interfaces/IChai.sol";
-import "../interfaces/IDelegable.sol";
 import "../interfaces/ITreasury.sol";
+import "../interfaces/IController.sol";
 import "../helpers/DecimalMath.sol";
 
-
-interface ControllerLike is IDelegable {
-    function treasury() external view returns (ITreasury);
-    function series(uint256) external view returns (IFYDai);
-    function seriesIterator(uint256) external view returns (uint256);
-    function totalSeries() external view returns (uint256);
-    function containsSeries(uint256) external view returns (bool);
-    function posted(bytes32, address) external view returns (uint256);
-    function locked(bytes32, address) external view returns (uint256);
-    function debtFYDai(bytes32, uint256, address) external view returns (uint256);
-    function debtDai(bytes32, uint256, address) external view returns (uint256);
-    function totalDebtDai(bytes32, address) external view returns (uint256);
-    function isCollateralized(bytes32, address) external view returns (bool);
-    function inDai(bytes32, uint256, uint256) external view returns (uint256);
-    function inFYDai(bytes32, uint256, uint256) external view returns (uint256);
-    function erase(bytes32, address) external returns (uint256, uint256);
-    function shutdown() external;
-    function post(bytes32, address, address, uint256) external;
-    function withdraw(bytes32, address, address, uint256) external;
-    function borrow(bytes32, uint256, address, address, uint256) external;
-    function repayFYDai(bytes32, uint256, address, address, uint256) external returns (uint256);
-    function repayDai(bytes32, uint256, address, address, uint256) external returns (uint256);
-}
-
-library SafeCast {
-    /// @dev Safe casting from uint256 to uint128
-    function toUint128(uint256 x) internal pure returns(uint128) {
-        require(
-            x <= type(uint128).max,
-            "YieldProxy: Cast overflow"
-        );
-        return uint128(x);
-    }
-
-    /// @dev Safe casting from uint256 to int256
-    function toInt256(uint256 x) internal pure returns(int256) {
-        require(
-            x <= uint256(type(int256).max),
-            "YieldProxy: Cast overflow"
-        );
-        return int256(x);
-    }
-}
-
-contract YieldProxy is DecimalMath {
-    using SafeCast for uint256;
-
-    IVat public vat;
-    IWeth public weth;
-    IDai public dai;
-    IGemJoin public wethJoin;
-    IDaiJoin public daiJoin;
-    IChai public chai;
-    ControllerLike public controller;
-    ITreasury public treasury;
-
-    IPool[] public pools;
-    mapping (address => bool) public poolsMap;
-
-    bytes32 public constant CHAI = "CHAI";
-    bytes32 public constant WETH = "ETH-A";
-    bool constant public MTY = true;
-    bool constant public YTM = false;
-
-
-    constructor(address controller_, IPool[] memory _pools) public {
-        controller = ControllerLike(controller_);
-        treasury = controller.treasury();
-
-        weth = treasury.weth();
-        dai = IDai(address(treasury.dai()));
-        chai = treasury.chai();
-        daiJoin = treasury.daiJoin();
-        wethJoin = treasury.wethJoin();
-        vat = treasury.vat();
-
-        // for repaying debt
-        dai.approve(address(treasury), uint(-1));
-
-        // for posting to the controller
-        chai.approve(address(treasury), uint(-1));
-        weth.approve(address(treasury), uint(-1));
-
-        // for converting DAI to CHAI
-        dai.approve(address(chai), uint(-1));
-
-        vat.hope(address(daiJoin));
-        vat.hope(address(wethJoin));
-
-        dai.approve(address(daiJoin), uint(-1));
-        weth.approve(address(wethJoin), uint(-1));
-        weth.approve(address(treasury), uint(-1));
-
-        // allow all the pools to pull FYDai/dai from us for LPing
-        for (uint i = 0 ; i < _pools.length; i++) {
-            dai.approve(address(_pools[i]), uint(-1));
-            _pools[i].fyDai().approve(address(_pools[i]), uint(-1));
-            poolsMap[address(_pools[i])]= true;
-        }
-
-        pools = _pools;
-    }
-
+// Contains all the authorization logic
+contract YieldAuth {
     /// @dev Unpack r, s and v from a `bytes` signature
     function unpack(bytes memory signature) private pure returns (bytes32 r, bytes32 s, uint8 v) {
         assembly {
@@ -127,7 +22,7 @@ contract YieldProxy is DecimalMath {
     }
 
     /// @dev Performs the initial onboarding of the user. It `permit`'s DAI to be used by the proxy, and adds the proxy as a delegate in the controller
-    function onboard(address from, bytes memory daiSignature, bytes memory controllerSig) external {
+    function onboard(IDai dai, IController controller, address from, bytes memory daiSignature, bytes memory controllerSig) external {
         bytes32 r;
         bytes32 s;
         uint8 v;
@@ -140,8 +35,7 @@ contract YieldProxy is DecimalMath {
     }
 
     /// @dev Given a pool and 3 signatures, it `permit`'s dai and fyDai for that pool and adds it as a delegate
-    function authorizePool(IPool pool, address from, bytes memory daiSig, bytes memory fyDaiSig, bytes memory poolSig) public {
-        onlyKnownPool(pool);
+    function authorizePool(IPool pool, IDai dai, address from, bytes memory daiSig, bytes memory fyDaiSig, bytes memory poolSig) public {
         bytes32 r;
         bytes32 s;
         uint8 v;
@@ -158,394 +52,71 @@ contract YieldProxy is DecimalMath {
 
     /// @dev The WETH9 contract will send ether to YieldProxy on `weth.withdraw` using this function.
     receive() external payable { }
+}
 
-    /// @dev Users use `post` in YieldProxy to post ETH to the Controller (amount = msg.value), which will be converted to Weth here.
-    /// @param to Yield Vault to deposit collateral in.
-    function post(address to)
-        public payable {
-        weth.deposit{ value: msg.value }();
-        controller.post(WETH, address(this), to, msg.value);
-    }
+// proxy contract with no storage
+contract YieldProxy is YieldAuth {
+    // EIP1967 storage slots to avoid conflicts
+    bytes32 private constant ADMIN_SLOT = bytes32(uint256(keccak256("eip1967.proxy.admin")) - 1);
+    bytes32 private  constant IMPL_SLOT = bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1);
 
-    /// @dev Users wishing to withdraw their Weth as ETH from the Controller should use this function.
-    /// Users must have called `controller.addDelegate(yieldProxy.address)` to authorize YieldProxy to act in their behalf.
-    /// @param to Wallet to send Eth to.
-    /// @param amount Amount of weth to move.
-    function withdraw(address payable to, uint256 amount)
-        public {
-        controller.withdraw(WETH, msg.sender, address(this), amount);
-        weth.withdraw(amount);
-        to.transfer(amount);
-    }
-
-    /// @dev Mints liquidity with provided Dai by borrowing fyDai with some of the Dai.
-    /// Caller must have approved the proxy using`controller.addDelegate(yieldProxy)`
-    /// Caller must have approved the dai transfer with `dai.approve(daiUsed)`
-    /// @param daiUsed amount of Dai to use to mint liquidity. 
-    /// @param maxFYDai maximum amount of fyDai to be borrowed to mint liquidity. 
-    /// @return The amount of liquidity tokens minted.  
-    function addLiquidity(IPool pool, uint256 daiUsed, uint256 maxFYDai) external returns (uint256) {
-        onlyKnownPool(pool);
-        IFYDai fyDai = pool.fyDai();
-        require(fyDai.isMature() != true, "YieldProxy: Only before maturity");
-        require(dai.transferFrom(msg.sender, address(this), daiUsed), "YieldProxy: Transfer Failed");
-
-        // calculate needed fyDai
-        uint256 daiReserves = dai.balanceOf(address(pool));
-        uint256 fyDaiReserves = fyDai.balanceOf(address(pool));
-        uint256 daiToAdd = daiUsed.mul(daiReserves).div(fyDaiReserves.add(daiReserves));
-        uint256 daiToConvert = daiUsed.sub(daiToAdd);
-        require(
-            daiToConvert <= maxFYDai,
-            "YieldProxy: maxFYDai exceeded"
-        ); // 1 Dai == 1 fyDai
-
-        // convert dai to chai and borrow needed fyDai
-        chai.join(address(this), daiToConvert);
-        // look at the balance of chai in dai to avoid rounding issues
-        uint256 toBorrow = chai.dai(address(this));
-        controller.post(CHAI, address(this), msg.sender, chai.balanceOf(address(this)));
-        controller.borrow(CHAI, fyDai.maturity(), msg.sender, address(this), toBorrow);
-        
-        // mint liquidity tokens
-        return pool.mint(address(this), msg.sender, daiToAdd);
-    }
-
-    /// @dev Burns tokens and sells Dai proceedings for fyDai. Pays as much debt as possible, then sells back any remaining fyDai for Dai. Then returns all Dai, and if there is no debt in the Controller, all posted Chai.
-    /// Caller must have approved the proxy using`controller.addDelegate(yieldProxy)` and `pool.addDelegate(yieldProxy)`
-    /// Caller must have approved the liquidity burn with `pool.approve(poolTokens)`
-    /// @param poolTokens amount of pool tokens to burn. 
-    /// @param minimumDaiPrice minimum fyDai/Dai price to be accepted when internally selling Dai.
-    /// @param minimumFYDaiPrice minimum Dai/fyDai price to be accepted when internally selling fyDai.
-    function removeLiquidityEarlyDaiPool(IPool pool, uint256 poolTokens, uint256 minimumDaiPrice, uint256 minimumFYDaiPrice) external {
-        onlyKnownPool(pool);
-        IFYDai fyDai = pool.fyDai();
-        uint256 maturity = fyDai.maturity();
-        (uint256 daiObtained, uint256 fyDaiObtained) = pool.burn(msg.sender, address(this), poolTokens);
-
-        // Exchange Dai for fyDai to pay as much debt as possible
-        uint256 fyDaiBought = pool.sellDai(address(this), address(this), daiObtained.toUint128());
-        require(
-            fyDaiBought >= muld(daiObtained, minimumDaiPrice),
-            "YieldProxy: minimumDaiPrice not reached"
-        );
-        fyDaiObtained = fyDaiObtained.add(fyDaiBought);
-        
-        uint256 fyDaiUsed;
-        if (fyDaiObtained > 0 && controller.debtFYDai(CHAI, maturity, msg.sender) > 0) {
-            fyDaiUsed = controller.repayFYDai(CHAI, maturity, address(this), msg.sender, fyDaiObtained);
+    constructor() public {
+        address sender = msg.sender;
+        bytes32 slot = ADMIN_SLOT;
+        assembly {
+            sstore(slot, sender)
         }
-        uint256 fyDaiRemaining = fyDaiObtained.sub(fyDaiUsed);
-
-        if (fyDaiRemaining > 0) {// There is fyDai left, so exchange it for Dai to withdraw only Dai and Chai
-            require(
-                pool.sellFYDai(address(this), address(this), uint128(fyDaiRemaining)) >= muld(fyDaiRemaining, minimumFYDaiPrice),
-                "YieldProxy: minimumFYDaiPrice not reached"
-            );
-        }
-        withdrawAssets(fyDai);
     }
 
-    /// @dev Burns tokens and repays debt with proceedings. Sells any excess fyDai for Dai, then returns all Dai, and if there is no debt in the Controller, all posted Chai.
-    /// Caller must have approved the proxy using`controller.addDelegate(yieldProxy)` and `pool.addDelegate(yieldProxy)`
-    /// Caller must have approved the liquidity burn with `pool.approve(poolTokens)`
-    /// @param poolTokens amount of pool tokens to burn. 
-    /// @param minimumFYDaiPrice minimum Dai/fyDai price to be accepted when internally selling fyDai.
-    function removeLiquidityEarlyDaiFixed(IPool pool, uint256 poolTokens, uint256 minimumFYDaiPrice) external {
-        onlyKnownPool(pool);
-        IFYDai fyDai = pool.fyDai();
-        uint256 maturity = fyDai.maturity();
-        (uint256 daiObtained, uint256 fyDaiObtained) = pool.burn(msg.sender, address(this), poolTokens);
-
-        uint256 fyDaiUsed;
-        if (fyDaiObtained > 0 && controller.debtFYDai(CHAI, maturity, msg.sender) > 0) {
-            fyDaiUsed = controller.repayFYDai(CHAI, maturity, address(this), msg.sender, fyDaiObtained);
+    function upgradeTo(address implementation, bytes calldata data) public {
+        // load the admin
+        address admin;
+        bytes32 slot = ADMIN_SLOT;
+        assembly {
+            admin := sload(slot)
         }
 
-        uint256 fyDaiRemaining = fyDaiObtained.sub(fyDaiUsed);
-        if (fyDaiRemaining == 0) { // We used all the fyDai, so probably there is debt left, so pay with Dai
-            if (daiObtained > 0 && controller.debtFYDai(CHAI, maturity, msg.sender) > 0) {
-                controller.repayDai(CHAI, maturity, address(this), msg.sender, daiObtained);
-            }
-        } else { // Exchange remaining fyDai for Dai to withdraw only Dai and Chai
-            require(
-                pool.sellFYDai(address(this), address(this), uint128(fyDaiRemaining)) >= muld(fyDaiRemaining, minimumFYDaiPrice),
-                "YieldProxy: minimumFYDaiPrice not reached"
-            );
+        // check it
+        require(msg.sender == admin);
+
+        // change it
+        slot = IMPL_SLOT;
+        assembly {
+            sstore(slot, implementation)
         }
-        withdrawAssets(fyDai);
+
+        (bool success,) = implementation.delegatecall(data);
+        require(success);
     }
 
-    /// @dev Burns tokens and repays fyDai debt after Maturity. 
-    /// Caller must have approved the proxy using`controller.addDelegate(yieldProxy)`
-    /// Caller must have approved the liquidity burn with `pool.approve(poolTokens)`
-    /// @param poolTokens amount of pool tokens to burn.
-    function removeLiquidityMature(IPool pool, uint256 poolTokens) external {
-        onlyKnownPool(pool);
-        IFYDai fyDai = pool.fyDai();
-        uint256 maturity = fyDai.maturity();
-        (uint256 daiObtained, uint256 fyDaiObtained) = pool.burn(msg.sender, address(this), poolTokens);
-        if (fyDaiObtained > 0) {
-            daiObtained = daiObtained.add(fyDai.redeem(address(this), address(this), fyDaiObtained));
+    function changeAdmin(address newAdmin) public {
+        // load the admin
+        address admin;
+        bytes32 slot = ADMIN_SLOT;
+        assembly {
+            admin := sload(slot)
         }
-        
-        // Repay debt
-        if (daiObtained > 0 && controller.debtFYDai(CHAI, maturity, msg.sender) > 0) {
-            controller.repayDai(CHAI, maturity, address(this), msg.sender, daiObtained);
+
+        // check it
+        require(msg.sender == admin);
+
+        // change it
+        assembly {
+            sstore(slot, newAdmin)
         }
-        withdrawAssets(fyDai);
     }
 
-    /// @dev Return to caller all posted chai if there is no debt, converted to dai, plus any dai remaining in the contract.
-    function withdrawAssets(IFYDai fyDai) internal {
-        if (controller.debtFYDai(CHAI, fyDai.maturity(), msg.sender) == 0) {
-            uint256 posted = controller.posted(CHAI, msg.sender);
-            uint256 locked = controller.locked(CHAI, msg.sender);
-            require (posted >= locked, "YieldProxy: Undercollateralized");
-            controller.withdraw(CHAI, msg.sender, address(this), posted - locked);
-            chai.exit(address(this), chai.balanceOf(address(this)));
+    fallback() external payable {
+        bytes32 slot = IMPL_SLOT;
+        assembly {
+            let _target := sload(slot)
+            calldatacopy(0, 0, calldatasize())
+            let result := delegatecall(gas(), _target, 0x0, calldatasize(), 0x0, 0)
+            let retSize := returndatasize()
+            returndatacopy(0x0, 0x0, retSize)
+            switch result
+            case 0 {revert(0, retSize)}
+            default {return (0, retSize)}
         }
-        require(dai.transfer(msg.sender, dai.balanceOf(address(this))), "YieldProxy: Dai Transfer Failed");
-    }
-
-    /// @dev Borrow fyDai from Controller and sell it immediately for Dai, for a maximum fyDai debt.
-    /// Must have approved the operator with `controller.addDelegate(yieldProxy.address)`.
-    /// @param collateral Valid collateral type.
-    /// @param maturity Maturity of an added series
-    /// @param to Wallet to send the resulting Dai to.
-    /// @param maximumFYDai Maximum amount of FYDai to borrow.
-    /// @param daiToBorrow Exact amount of Dai that should be obtained.
-    function borrowDaiForMaximumFYDai(
-        IPool pool,
-        bytes32 collateral,
-        uint256 maturity,
-        address to,
-        uint256 maximumFYDai,
-        uint256 daiToBorrow
-    )
-        public
-        returns (uint256)
-    {
-        onlyKnownPool(pool);
-        uint256 fyDaiToBorrow = pool.buyDaiPreview(daiToBorrow.toUint128());
-        require (fyDaiToBorrow <= maximumFYDai, "YieldProxy: Too much fyDai required");
-
-        // The collateral for this borrow needs to have been posted beforehand
-        controller.borrow(collateral, maturity, msg.sender, address(this), fyDaiToBorrow);
-        pool.buyDai(address(this), to, daiToBorrow.toUint128());
-
-        return fyDaiToBorrow;
-    }
-
-    /// @dev Borrow fyDai from Controller and sell it immediately for Dai, if a minimum amount of Dai can be obtained such.
-    /// Must have approved the operator with `controller.addDelegate(yieldProxy.address)`.
-    /// @param collateral Valid collateral type.
-    /// @param maturity Maturity of an added series
-    /// @param to Wallet to sent the resulting Dai to.
-    /// @param fyDaiToBorrow Amount of fyDai to borrow.
-    /// @param minimumDaiToBorrow Minimum amount of Dai that should be borrowed.
-    function borrowMinimumDaiForFYDai(
-        IPool pool,
-        bytes32 collateral,
-        uint256 maturity,
-        address to,
-        uint256 fyDaiToBorrow,
-        uint256 minimumDaiToBorrow
-    )
-        public
-        returns (uint256)
-    {
-        onlyKnownPool(pool);
-        // The collateral for this borrow needs to have been posted beforehand
-        controller.borrow(collateral, maturity, msg.sender, address(this), fyDaiToBorrow);
-        uint256 boughtDai = pool.sellFYDai(address(this), to, fyDaiToBorrow.toUint128());
-        require (boughtDai >= minimumDaiToBorrow, "YieldProxy: Not enough Dai obtained");
-
-        return boughtDai;
-    }
-
-    /// @dev Repay an amount of fyDai debt in Controller using Dai exchanged for fyDai at pool rates, up to a maximum amount of Dai spent.
-    /// Must have approved the operator with `pool.addDelegate(yieldProxy.address)`.
-    /// If `fyDaiRepayment` exceeds the existing debt, only the necessary fyDai will be used.
-    /// @param collateral Valid collateral type.
-    /// @param maturity Maturity of an added series
-    /// @param to Yield Vault to repay fyDai debt for.
-    /// @param fyDaiRepayment Amount of fyDai debt to repay.
-    /// @param maximumRepaymentInDai Maximum amount of Dai that should be spent on the repayment.
-    function repayFYDaiDebtForMaximumDai(
-        IPool pool,
-        bytes32 collateral,
-        uint256 maturity,
-        address to,
-        uint256 fyDaiRepayment,
-        uint256 maximumRepaymentInDai
-    )
-        public
-        returns (uint256)
-    {
-        onlyKnownPool(pool);
-        uint256 fyDaiDebt = controller.debtFYDai(collateral, maturity, to);
-        uint256 fyDaiToUse = fyDaiDebt < fyDaiRepayment ? fyDaiDebt : fyDaiRepayment; // Use no more fyDai than debt
-        uint256 repaymentInDai = pool.buyFYDai(msg.sender, address(this), fyDaiToUse.toUint128());
-        require (repaymentInDai <= maximumRepaymentInDai, "YieldProxy: Too much Dai required");
-        controller.repayFYDai(collateral, maturity, address(this), to, fyDaiToUse);
-
-        return repaymentInDai;
-    }
-
-    /// @dev Repay an amount of fyDai debt in Controller using a given amount of Dai exchanged for fyDai at pool rates, with a minimum of fyDai debt required to be paid.
-    /// Must have approved the operator with `pool.addDelegate(yieldProxy.address)`.
-    /// If `repaymentInDai` exceeds the existing debt, only the necessary Dai will be used.
-    /// @param collateral Valid collateral type.
-    /// @param maturity Maturity of an added series
-    /// @param to Yield Vault to repay fyDai debt for.
-    /// @param minimumFYDaiRepayment Minimum amount of fyDai debt to repay.
-    /// @param repaymentInDai Exact amount of Dai that should be spent on the repayment.
-    function repayMinimumFYDaiDebtForDai(
-        IPool pool,
-        bytes32 collateral,
-        uint256 maturity,
-        address to,
-        uint256 minimumFYDaiRepayment,
-        uint256 repaymentInDai
-    )
-        public
-        returns (uint256)
-    {
-        onlyKnownPool(pool);
-        uint256 fyDaiRepayment = pool.sellDaiPreview(repaymentInDai.toUint128());
-        uint256 fyDaiDebt = controller.debtFYDai(collateral, maturity, to);
-        if(fyDaiRepayment <= fyDaiDebt) { // Sell no more Dai than needed to cancel all the debt
-            pool.sellDai(msg.sender, address(this), repaymentInDai.toUint128());
-        } else { // If we have too much Dai, then don't sell it all and buy the exact amount of fyDai needed instead.
-            pool.buyFYDai(msg.sender, address(this), fyDaiDebt.toUint128());
-            fyDaiRepayment = fyDaiDebt;
-        }
-        require (fyDaiRepayment >= minimumFYDaiRepayment, "YieldProxy: Not enough fyDai debt repaid");
-        controller.repayFYDai(collateral, maturity, address(this), to, fyDaiRepayment);
-
-        return fyDaiRepayment;
-    }
-
-    /// @dev Sell Dai for fyDai
-    /// @param to Wallet receiving the fyDai being bought
-    /// @param daiIn Amount of dai being sold
-    /// @param minFYDaiOut Minimum amount of fyDai being bought
-    function sellDai(IPool pool, address to, uint128 daiIn, uint128 minFYDaiOut)
-        external
-        returns(uint256)
-    {
-        onlyKnownPool(pool);
-        uint256 fyDaiOut = pool.sellDai(msg.sender, to, daiIn);
-        require(
-            fyDaiOut >= minFYDaiOut,
-            "YieldProxy: Limit not reached"
-        );
-        return fyDaiOut;
-    }
-
-    /// @dev Buy Dai for fyDai
-    /// @param to Wallet receiving the dai being bought
-    /// @param daiOut Amount of dai being bought
-    /// @param maxFYDaiIn Maximum amount of fyDai being sold
-    function buyDai(IPool pool, address to, uint128 daiOut, uint128 maxFYDaiIn)
-        public
-        returns(uint256)
-    {
-        onlyKnownPool(pool);
-        uint256 fyDaiIn = pool.buyDai(msg.sender, to, daiOut);
-        require(
-            maxFYDaiIn >= fyDaiIn,
-            "YieldProxy: Limit exceeded"
-        );
-        return fyDaiIn;
-    }
-
-    /// @dev Buy Dai for fyDai and permits infinite fyDai to the pool
-    /// @param to Wallet receiving the dai being bought
-    /// @param daiOut Amount of dai being bought
-    /// @param maxFYDaiIn Maximum amount of fyDai being sold
-    /// @param signature The `permit` call's signature
-    function buyDaiWithSignature(IPool pool, address to, uint128 daiOut, uint128 maxFYDaiIn, bytes memory signature)
-        external
-        returns(uint256)
-    {
-        onlyKnownPool(pool);
-        (bytes32 r, bytes32 s, uint8 v) = unpack(signature);
-        pool.fyDai().permit(msg.sender, address(pool), uint(-1), uint(-1), v, r, s);
-
-        return buyDai(pool, to, daiOut, maxFYDaiIn);
-    }
-
-    /// @dev Sell fyDai for Dai
-    /// @param to Wallet receiving the dai being bought
-    /// @param fyDaiIn Amount of fyDai being sold
-    /// @param minDaiOut Minimum amount of dai being bought
-    function sellFYDai(IPool pool, address to, uint128 fyDaiIn, uint128 minDaiOut)
-        public
-        returns(uint256)
-    {
-        onlyKnownPool(pool);
-        uint256 daiOut = pool.sellFYDai(msg.sender, to, fyDaiIn);
-        require(
-            daiOut >= minDaiOut,
-            "YieldProxy: Limit not reached"
-        );
-        return daiOut;
-    }
-
-    /// @dev Sell fyDai for Dai and permits infinite Dai to the pool
-    /// @param to Wallet receiving the dai being bought
-    /// @param fyDaiIn Amount of fyDai being sold
-    /// @param minDaiOut Minimum amount of dai being bought
-    /// @param signature The `permit` call's signature
-    function sellFYDaiWithSignature(IPool pool, address to, uint128 fyDaiIn, uint128 minDaiOut, bytes memory signature)
-        external
-        returns(uint256)
-    {
-        onlyKnownPool(pool);
-        (bytes32 r, bytes32 s, uint8 v) = unpack(signature);
-        pool.fyDai().permit(msg.sender, address(pool), uint(-1), uint(-1), v, r, s);
-
-        return sellFYDai(pool, to, fyDaiIn, minDaiOut);
-    }
-
-    /// @dev Buy fyDai for dai
-    /// @param to Wallet receiving the fyDai being bought
-    /// @param fyDaiOut Amount of fyDai being bought
-    /// @param maxDaiIn Maximum amount of dai being sold
-    function buyFYDai(IPool pool, address to, uint128 fyDaiOut, uint128 maxDaiIn)
-        external
-        returns(uint256)
-    {
-        onlyKnownPool(pool);
-        uint256 daiIn = pool.buyFYDai(msg.sender, to, fyDaiOut);
-        require(
-            maxDaiIn >= daiIn,
-            "YieldProxy: Limit exceeded"
-        );
-        return daiIn;
-    }
-
-    /// @dev Burns Dai from caller to repay debt in a Yield Vault.
-    /// User debt is decreased for the given collateral and fyDai series, in Yield vault `to`.
-    /// The amount of debt repaid changes according to series maturity and MakerDAO rate and chi, depending on collateral type.
-    /// `A signature is provided as a parameter to this function, so that `dai.approve()` doesn't need to be called.
-    /// @param collateral Valid collateral type.
-    /// @param maturity Maturity of an added series
-    /// @param to Yield vault to repay debt for.
-    /// @param daiAmount Amount of Dai to use for debt repayment.
-    /// @param signature The `permit` call's signature
-    function repayDaiWithSignature(bytes32 collateral, uint256 maturity, address to, uint256 daiAmount, bytes memory signature)
-        external
-        returns(uint256)
-    {
-        (bytes32 r, bytes32 s, uint8 v) = unpack(signature);
-        dai.permit(msg.sender, address(treasury), dai.nonces(msg.sender), uint(-1), true, v, r, s);
-        controller.repayDai(collateral, maturity, msg.sender, to, daiAmount);
-    }
-
-    function onlyKnownPool(IPool pool) private view {
-        require(poolsMap[address(pool)], "YieldProxy: Unknown pool");
     }
 }

--- a/migrations/6_deploy_peripheral.js
+++ b/migrations/6_deploy_peripheral.js
@@ -1,8 +1,9 @@
 const Migrations = artifacts.require('Migrations')
 const Controller = artifacts.require('Controller')
+const ProxyV1 = artifacts.require('ProxyV1')
 const YieldProxy = artifacts.require('YieldProxy')
 
-module.exports = async (deployer, network) => {
+module.exports = async (deployer) => {
   const migrations = await Migrations.deployed()
 
   const controller = await Controller.deployed()
@@ -15,10 +16,24 @@ module.exports = async (deployer, network) => {
       poolAddresses.push(await migrations.contracts(web3.utils.fromAscii(contractName)))
   }
 
-  await deployer.deploy(YieldProxy, controllerAddress, poolAddresses)
+  // Deploy v1
+  await deployer.deploy(ProxyV1)
+  const v1 = await ProxyV1.deployed()
+
+  // Deploy the fallback proxy
+  await deployer.deploy(YieldProxy)
+  const proxy = await YieldProxy.deployed()
+
+  // set the implementation and call the initializer
+  const initArgs = v1.contract.methods.init(controllerAddress, poolAddresses).encodeABI()
+  await proxy.upgradeTo(v1.address, initArgs)
+
+  // Deploy the Proxy contract
+  await deployer.deploy(YieldProxy)
   const yieldProxy = await YieldProxy.deployed()
 
   const deployment = {
+    ProxyV1: v1.address,
     YieldProxy: yieldProxy.address,
   }
 

--- a/test/peripheral/521_limitPool.ts
+++ b/test/peripheral/521_limitPool.ts
@@ -1,9 +1,9 @@
 const Pool = artifacts.require('Pool')
-const YieldProxy = artifacts.require('YieldProxy')
 
 import { keccak256, toUtf8Bytes } from 'ethers/lib/utils'
 import { toWad, toRay, mulRay, chainId, bnify, MAX, name } from '../shared/utils'
 import { getPermitDigest, sign, userPrivateKey } from '../shared/signatures'
+import { setupProxy } from '../shared/proxies'
 import { YieldEnvironmentLite, Contract } from '../shared/fixtures'
 // @ts-ignore
 import { BN, expectRevert } from '@openzeppelin/test-helpers'
@@ -37,7 +37,7 @@ contract('YieldProxy - LimitPool', async (accounts) => {
     pool = await Pool.new(dai.address, fyDai1.address, 'Name', 'Symbol', { from: owner })
 
     // Setup LimitPool
-    limitPool = await YieldProxy.new(env.controller.address, [pool.address], { from: owner })
+    limitPool = await setupProxy(env.controller.address, [pool.address])
 
     // Allow owner to mint fyDai the sneaky way, without recording a debt in controller
     await fyDai1.orchestrate(owner, keccak256(toUtf8Bytes('mint(address,uint256)')), { from: owner })

--- a/test/peripheral/531_ethProxy.ts
+++ b/test/peripheral/531_ethProxy.ts
@@ -1,12 +1,10 @@
-// Peripheral
-const EthProxy = artifacts.require('YieldProxy')
-
 // @ts-ignore
 import helper from 'ganache-time-traveler'
 // @ts-ignore
 import { balance } from '@openzeppelin/test-helpers'
 import { WETH, spot, daiTokens1, wethTokens1, mulRay } from '../shared/utils'
 import { Contract, YieldEnvironmentLite } from '../shared/fixtures'
+import { setupProxy } from '../shared/proxies'
 import { getSignatureDigest } from '../shared/signatures'
 import { keccak256, toUtf8Bytes } from 'ethers/lib/utils'
 import { ecsign } from 'ethereumjs-util'
@@ -51,8 +49,7 @@ contract('YieldProxy - EthProxy', async (accounts) => {
     vat = env.maker.vat
     weth = env.maker.weth
 
-    // Setup EthProxy
-    ethProxy = await EthProxy.new(env.controller.address, [])
+    ethProxy = await setupProxy(env.controller.address, [])
   })
 
   afterEach(async () => {

--- a/test/peripheral/541_daiProxy.ts
+++ b/test/peripheral/541_daiProxy.ts
@@ -184,29 +184,29 @@ contract('YieldProxy - DaiProxy', async (accounts) => {
     })
 
     describe('can be upgraded', async () => {
-        beforeEach(async () => {
-            daiProxy = await upgradeToV2(daiProxy)
-        })
+      beforeEach(async () => {
+        daiProxy = await upgradeToV2(daiProxy)
+      })
 
-        it('can call new functions', async () => {
-            const ret = await daiProxy.get()
-            expect(ret.toString()).to.eq("123")
-        })
+      it('can call new functions', async () => {
+        const ret = await daiProxy.get()
+        expect(ret.toString()).to.eq('123')
+      })
 
-        // this would call to weth which we did not explicitly
-        // store in the new dai proxy
-        it('can call old functions', async () => {
-            await daiProxy.post(user1, { from: user1, value: bnify(wethTokens1).mul(2).toString() })
-        })
+      // this would call to weth which we did not explicitly
+      // store in the new dai proxy
+      it('can call old functions', async () => {
+        await daiProxy.post(user1, { from: user1, value: bnify(wethTokens1).mul(2).toString() })
+      })
 
-        it('maintains `onboard` permissions', async () => {
-            await daiProxy.post(user1, { from: user1, value: bnify(wethTokens1).mul(2).toString() })
-            // `onboard` must be called in order to borrow. even though we
-            // upgraded, we are still able to call the function without re-onboarding!
-            await daiProxy.borrowDaiForMaximumFYDai(pool.address, WETH, maturity1, user2, fyDaiTokens1, one, {
-                from: user1,
-            })
+      it('maintains `onboard` permissions', async () => {
+        await daiProxy.post(user1, { from: user1, value: bnify(wethTokens1).mul(2).toString() })
+        // `onboard` must be called in order to borrow. even though we
+        // upgraded, we are still able to call the function without re-onboarding!
+        await daiProxy.borrowDaiForMaximumFYDai(pool.address, WETH, maturity1, user2, fyDaiTokens1, one, {
+          from: user1,
         })
+      })
     })
 
     it('fails on unknown pools', async () => {

--- a/test/peripheral/541_daiProxy.ts
+++ b/test/peripheral/541_daiProxy.ts
@@ -184,8 +184,17 @@ contract('YieldProxy - DaiProxy', async (accounts) => {
     })
 
     describe('can be upgraded', async () => {
+      const YieldProxy = artifacts.require('YieldProxy')
+      let proxy : Contract
+      
       beforeEach(async () => {
+        proxy = await YieldProxy.at(daiProxy.address)
         daiProxy = await upgradeToV2(daiProxy)
+      })
+
+      it('returns the latest version', async () => {
+        const ret = await proxy.getLatestVersion()
+        expect(ret.toString()).to.eq('2')
       })
 
       it('can call new functions', async () => {
@@ -219,6 +228,23 @@ contract('YieldProxy - DaiProxy', async (accounts) => {
         await daiProxy.borrowMinimumDaiForFYDai(pool.address, WETH, maturity1, user2, fyDaiTokens1, one, {
           from: user1,
         })
+      })
+
+      it('can choose old versions', async () => {
+        await proxy.chooseVersion(1, { from: user1 })
+        let ret = await daiProxy.addLiquidity.call(pool.address, 0, 0, { from: user1 });
+        expect(ret.toString()).to.eq('0')
+
+        await proxy.chooseVersion(2, { from: user1 })
+        ret = await daiProxy.addLiquidity.call(pool.address, 0, 0, { from: user1 });
+        expect(ret.toString()).to.eq('42')
+      })
+
+      it('cannot choose versions that have not been implemented yet', async () => {
+        await expectRevert(
+          proxy.chooseVersion(bnify(await proxy.getLatestVersion()).add(1).toString(), { from: user1 }),
+          "YieldProxy: Invalid version"
+        )
       })
     })
 

--- a/test/peripheral/541_daiProxy.ts
+++ b/test/peripheral/541_daiProxy.ts
@@ -193,6 +193,11 @@ contract('YieldProxy - DaiProxy', async (accounts) => {
         expect(ret.toString()).to.eq('123')
       })
 
+      it('can call upgraded functions', async () => {
+        const ret = await daiProxy.addLiquidity.call(pool.address, 0, 0);
+        expect(ret.toString()).to.eq('42')
+      })
+
       // this would call to weth which we did not explicitly
       // store in the new dai proxy
       it('can call old functions', async () => {

--- a/test/peripheral/541_daiProxy.ts
+++ b/test/peripheral/541_daiProxy.ts
@@ -207,6 +207,14 @@ contract('YieldProxy - DaiProxy', async (accounts) => {
           from: user1,
         })
       })
+
+      it('maintains `authorizePool` permissions', async () => {
+        // `authorizePool` must be called in order to borrow. even though we
+        // upgraded, we are still able to call the function without re-authorizing!
+        await daiProxy.borrowMinimumDaiForFYDai(pool.address, WETH, maturity1, user2, fyDaiTokens1, one, {
+          from: user1,
+        })
+      })
     })
 
     it('fails on unknown pools', async () => {

--- a/test/peripheral/551_liquidityProxy.ts
+++ b/test/peripheral/551_liquidityProxy.ts
@@ -1,5 +1,4 @@
 const Pool = artifacts.require('Pool')
-const LiquidityProxy = artifacts.require('YieldProxy')
 
 import { keccak256, toUtf8Bytes } from 'ethers/lib/utils'
 // @ts-ignore
@@ -18,6 +17,7 @@ import {
   ZERO,
 } from '../shared/utils'
 import { MakerEnvironment, YieldEnvironmentLite, Contract } from '../shared/fixtures'
+import { setupProxy } from '../shared/proxies'
 // @ts-ignore
 import { BN, expectRevert } from '@openzeppelin/test-helpers'
 import { assert, expect } from 'chai'
@@ -90,7 +90,7 @@ contract('YieldProxy - LiquidityProxy', async (accounts) => {
     await fyDai1.orchestrate(owner, keccak256(toUtf8Bytes('mint(address,uint256)')), { from: owner })
 
     // Setup LiquidityProxy
-    proxy = await LiquidityProxy.new(env.controller.address, [pool0.address, pool1.address])
+    proxy = await setupProxy(env.controller.address, [pool0.address, pool1.address])
 
     const MAX = bnify('0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
     await env.maker.chai.approve(proxy.address, MAX, { from: user1 })

--- a/test/peripheral/561_upgradableProxy.ts
+++ b/test/peripheral/561_upgradableProxy.ts
@@ -133,7 +133,10 @@ contract('YieldProxy - DaiProxy', async (accounts) => {
     })
   })
 
-  describe('with liquidity', () => {
+  describe('can be upgraded', async () => {
+    const YieldProxy = artifacts.require('YieldProxy')
+    let proxy: Contract
+
     beforeEach(async () => {
       // Init pool
       const daiReserves = daiTokens1
@@ -148,76 +151,102 @@ contract('YieldProxy - DaiProxy', async (accounts) => {
 
       // Give some fyDai to user1
       await fyDai1.mint(user1, fyDaiTokens1, { from: owner })
+      
+      proxy = await YieldProxy.at(daiProxy.address)
+      daiProxy = await upgradeToV2(daiProxy)
     })
 
-    describe('can be upgraded', async () => {
-      const YieldProxy = artifacts.require('YieldProxy')
-      let proxy: Contract
+    it('returns the latest version', async () => {
+      const ret = await proxy.getLatestVersion()
+      expect(ret.toString()).to.eq('2')
+    })
 
-      beforeEach(async () => {
-        proxy = await YieldProxy.at(daiProxy.address)
-        daiProxy = await upgradeToV2(daiProxy)
+    it('returns the admin', async () => {
+      const ret = await proxy.getAdmin()
+      expect(ret.toString()).to.eq(owner)
+    })
+
+    it('can propose a new admin', async () => {
+      await proxy.proposeAdmin(user1)
+      const ret = await proxy.getProposedAdmin()
+      expect(ret.toString()).to.eq(user1)
+    })
+
+    it('only admin can propose a new admin', async () => {
+      await expectRevert(
+        proxy.proposeAdmin(user1, { from: user1 }),
+        "YieldProxy: Restricted to admin"
+      )
+    })
+
+    it('can change admin', async () => {
+      await proxy.proposeAdmin(user1)
+      await proxy.changeAdmin({ from: user1 })
+      const ret = await proxy.getAdmin()
+      expect(ret.toString()).to.eq(user1)
+    })
+
+    it('only proposed admin can change admin', async () => {
+      await proxy.proposeAdmin(user2)
+      await expectRevert(
+        proxy.changeAdmin({ from: user1 }),
+        "YieldProxy: Restricted to proposed admin"
+      )
+    })
+
+    it('can call new functions', async () => {
+      const ret = await daiProxy.get()
+      expect(ret.toString()).to.eq('123')
+    })
+
+    it('can call upgraded functions', async () => {
+      const ret = await daiProxy.addLiquidity.call(pool.address, 0, 0)
+      expect(ret.toString()).to.eq('42')
+    })
+
+    // this would call to weth which we did not explicitly
+    // store in the new dai proxy
+    it('can call old functions', async () => {
+      await daiProxy.post(user1, { from: user1, value: bnify(wethTokens1).mul(2).toString() })
+    })
+
+    it('maintains `onboard` permissions', async () => {
+      await daiProxy.post(user1, { from: user1, value: bnify(wethTokens1).mul(2).toString() })
+      // `onboard` must be called in order to borrow. even though we
+      // upgraded, we are still able to call the function without re-onboarding!
+      await daiProxy.borrowDaiForMaximumFYDai(pool.address, WETH, maturity1, user2, fyDaiTokens1, one, {
+        from: user1,
       })
+    })
 
-      it('returns the latest version', async () => {
-        const ret = await proxy.getLatestVersion()
-        expect(ret.toString()).to.eq('2')
+    it('maintains `authorizePool` permissions', async () => {
+      // `authorizePool` must be called in order to borrow. even though we
+      // upgraded, we are still able to call the function without re-authorizing!
+      await daiProxy.borrowMinimumDaiForFYDai(pool.address, WETH, maturity1, user2, fyDaiTokens1, one, {
+        from: user1,
       })
+    })
 
-      it('can call new functions', async () => {
-        const ret = await daiProxy.get()
-        expect(ret.toString()).to.eq('123')
-      })
+    it('can choose old versions', async () => {
+      await proxy.chooseVersion(1, { from: user1 })
+      let ret = await daiProxy.addLiquidity.call(pool.address, 0, 0, { from: user1 })
+      expect(ret.toString()).to.eq('0')
 
-      it('can call upgraded functions', async () => {
-        const ret = await daiProxy.addLiquidity.call(pool.address, 0, 0)
-        expect(ret.toString()).to.eq('42')
-      })
+      await proxy.chooseVersion(2, { from: user1 })
+      ret = await daiProxy.addLiquidity.call(pool.address, 0, 0, { from: user1 })
+      expect(ret.toString()).to.eq('42')
+    })
 
-      // this would call to weth which we did not explicitly
-      // store in the new dai proxy
-      it('can call old functions', async () => {
-        await daiProxy.post(user1, { from: user1, value: bnify(wethTokens1).mul(2).toString() })
-      })
-
-      it('maintains `onboard` permissions', async () => {
-        await daiProxy.post(user1, { from: user1, value: bnify(wethTokens1).mul(2).toString() })
-        // `onboard` must be called in order to borrow. even though we
-        // upgraded, we are still able to call the function without re-onboarding!
-        await daiProxy.borrowDaiForMaximumFYDai(pool.address, WETH, maturity1, user2, fyDaiTokens1, one, {
-          from: user1,
-        })
-      })
-
-      it('maintains `authorizePool` permissions', async () => {
-        // `authorizePool` must be called in order to borrow. even though we
-        // upgraded, we are still able to call the function without re-authorizing!
-        await daiProxy.borrowMinimumDaiForFYDai(pool.address, WETH, maturity1, user2, fyDaiTokens1, one, {
-          from: user1,
-        })
-      })
-
-      it('can choose old versions', async () => {
-        await proxy.chooseVersion(1, { from: user1 })
-        let ret = await daiProxy.addLiquidity.call(pool.address, 0, 0, { from: user1 })
-        expect(ret.toString()).to.eq('0')
-
-        await proxy.chooseVersion(2, { from: user1 })
-        ret = await daiProxy.addLiquidity.call(pool.address, 0, 0, { from: user1 })
-        expect(ret.toString()).to.eq('42')
-      })
-
-      it('cannot choose versions that have not been implemented yet', async () => {
-        await expectRevert(
-          proxy.chooseVersion(
-            bnify(await proxy.getLatestVersion())
-              .add(1)
-              .toString(),
-            { from: user1 }
-          ),
-          'YieldProxy: Invalid version'
-        )
-      })
+    it('cannot choose versions that have not been implemented yet', async () => {
+      await expectRevert(
+        proxy.chooseVersion(
+          bnify(await proxy.getLatestVersion())
+            .add(1)
+            .toString(),
+          { from: user1 }
+        ),
+        'YieldProxy: Invalid version'
+      )
     })
   })
 })

--- a/test/peripheral/561_upgradableProxy.ts
+++ b/test/peripheral/561_upgradableProxy.ts
@@ -151,7 +151,7 @@ contract('YieldProxy - DaiProxy', async (accounts) => {
 
       // Give some fyDai to user1
       await fyDai1.mint(user1, fyDaiTokens1, { from: owner })
-      
+
       proxy = await YieldProxy.at(daiProxy.address)
       daiProxy = await upgradeToV2(daiProxy)
     })
@@ -173,10 +173,7 @@ contract('YieldProxy - DaiProxy', async (accounts) => {
     })
 
     it('only admin can propose a new admin', async () => {
-      await expectRevert(
-        proxy.proposeAdmin(user1, { from: user1 }),
-        "YieldProxy: Restricted to admin"
-      )
+      await expectRevert(proxy.proposeAdmin(user1, { from: user1 }), 'YieldProxy: Restricted to admin')
     })
 
     it('can change admin', async () => {
@@ -188,10 +185,7 @@ contract('YieldProxy - DaiProxy', async (accounts) => {
 
     it('only proposed admin can change admin', async () => {
       await proxy.proposeAdmin(user2)
-      await expectRevert(
-        proxy.changeAdmin({ from: user1 }),
-        "YieldProxy: Restricted to proposed admin"
-      )
+      await expectRevert(proxy.changeAdmin({ from: user1 }), 'YieldProxy: Restricted to proposed admin')
     })
 
     it('can call new functions', async () => {

--- a/test/peripheral/561_upgradableProxy.ts
+++ b/test/peripheral/561_upgradableProxy.ts
@@ -1,0 +1,218 @@
+const Pool = artifacts.require('Pool')
+
+import { WETH, rate1, daiTokens1, wethTokens1, toWad, subBN, bnify, MAX, chainId, name, ZERO } from '../shared/utils'
+import { MakerEnvironment, YieldEnvironmentLite, Contract } from '../shared/fixtures'
+import { getSignatureDigest, getPermitDigest, getDaiDigest, userPrivateKey, sign } from '../shared/signatures'
+import { setupProxy, upgradeToV2 } from '../shared/proxies'
+import { keccak256, toUtf8Bytes } from 'ethers/lib/utils'
+
+// @ts-ignore
+import { expectRevert } from '@openzeppelin/test-helpers'
+import { assert, expect } from 'chai'
+
+contract('YieldProxy - DaiProxy', async (accounts) => {
+  let [owner, user1, user2, operator] = accounts
+
+  let maturity1: number
+  let dai: Contract
+  let controller: Contract
+  let fyDai1: Contract
+  let pool: Contract
+  let daiProxy: Contract
+  let maker: MakerEnvironment
+  let env: YieldEnvironmentLite
+
+  const one = toWad(1)
+  const two = toWad(2)
+  const fyDaiTokens1 = daiTokens1
+  const fyDaiDebt = daiTokens1
+
+  let digest: any
+
+  beforeEach(async () => {
+    const block = await web3.eth.getBlockNumber()
+    maturity1 = (await web3.eth.getBlock(block)).timestamp + 31556952 // One year
+    env = await YieldEnvironmentLite.setup([maturity1])
+    maker = env.maker
+    dai = env.maker.dai
+    controller = env.controller
+
+    fyDai1 = env.fyDais[0]
+
+    // Setup Pool
+    pool = await Pool.new(dai.address, fyDai1.address, 'Name', 'Symbol', { from: owner })
+
+    // Setup DaiProxy
+    daiProxy = await setupProxy(env.controller.address, [pool.address])
+
+    // Allow owner to mint fyDai the sneaky way, without recording a debt in controller
+    await fyDai1.orchestrate(owner, keccak256(toUtf8Bytes('mint(address,uint256)')), { from: owner })
+
+    const deadline = MAX
+
+    // Authorize the proxy for the controller
+    digest = getSignatureDigest(
+      name,
+      controller.address,
+      chainId,
+      {
+        user: user1,
+        delegate: daiProxy.address,
+      },
+      await controller.signatureCount(user1),
+      MAX
+    )
+    const controllerSig = sign(digest, userPrivateKey)
+
+    // Authorize DAI
+    digest = getDaiDigest(
+      await dai.name(),
+      dai.address,
+      chainId,
+      {
+        owner: user1,
+        spender: daiProxy.address,
+        can: true,
+      },
+      bnify(await dai.nonces(user1)),
+      deadline
+    )
+    let daiSig = sign(digest, userPrivateKey)
+
+    // Send it! (note how it's not necessarily the user broadcasting it)
+    await daiProxy.onboard(env.maker.dai.address, env.controller.address, user1, daiSig, controllerSig, {
+      from: operator,
+    })
+
+    // Authorize the proxy for the pool
+    digest = getSignatureDigest(
+      name,
+      pool.address,
+      chainId,
+      {
+        user: user1,
+        delegate: daiProxy.address,
+      },
+      bnify(await pool.signatureCount(user1)),
+      MAX
+    )
+    const poolSig = sign(digest, userPrivateKey)
+
+    // Authorize FYDai for the pool
+    digest = getPermitDigest(
+      await fyDai1.name(),
+      await pool.fyDai(),
+      chainId,
+      {
+        owner: user1,
+        spender: daiProxy.address,
+        value: MAX,
+      },
+      bnify(await fyDai1.nonces(user1)),
+      MAX
+    )
+    const fyDaiSig = sign(digest, userPrivateKey)
+
+    // Authorize DAI for the pool
+    digest = getDaiDigest(
+      await dai.name(),
+      dai.address,
+      chainId,
+      {
+        owner: user1,
+        spender: pool.address,
+        can: true,
+      },
+      bnify(await dai.nonces(user1)),
+      deadline
+    )
+    const daiSig2 = sign(digest, userPrivateKey)
+    // Send it!
+    await daiProxy.authorizePool(pool.address, env.maker.dai.address, user1, daiSig2, fyDaiSig, poolSig, {
+      from: operator,
+    })
+  })
+
+  describe('with liquidity', () => {
+    beforeEach(async () => {
+      // Init pool
+      const daiReserves = daiTokens1
+      await env.maker.getDai(user1, daiReserves, rate1)
+      await dai.approve(pool.address, MAX, { from: user1 })
+      await fyDai1.approve(pool.address, MAX, { from: user1 })
+      await pool.mint(user1, user1, daiReserves, { from: user1 })
+
+      // Post some weth to controller via the proxy to be able to borrow
+      // without requiring an `approve`!
+      await daiProxy.post(user1, { from: user1, value: bnify(wethTokens1).mul(2).toString() })
+
+      // Give some fyDai to user1
+      await fyDai1.mint(user1, fyDaiTokens1, { from: owner })
+    })
+
+    describe('can be upgraded', async () => {
+      const YieldProxy = artifacts.require('YieldProxy')
+      let proxy : Contract
+      
+      beforeEach(async () => {
+        proxy = await YieldProxy.at(daiProxy.address)
+        daiProxy = await upgradeToV2(daiProxy)
+      })
+
+      it('returns the latest version', async () => {
+        const ret = await proxy.getLatestVersion()
+        expect(ret.toString()).to.eq('2')
+      })
+
+      it('can call new functions', async () => {
+        const ret = await daiProxy.get()
+        expect(ret.toString()).to.eq('123')
+      })
+
+      it('can call upgraded functions', async () => {
+        const ret = await daiProxy.addLiquidity.call(pool.address, 0, 0);
+        expect(ret.toString()).to.eq('42')
+      })
+
+      // this would call to weth which we did not explicitly
+      // store in the new dai proxy
+      it('can call old functions', async () => {
+        await daiProxy.post(user1, { from: user1, value: bnify(wethTokens1).mul(2).toString() })
+      })
+
+      it('maintains `onboard` permissions', async () => {
+        await daiProxy.post(user1, { from: user1, value: bnify(wethTokens1).mul(2).toString() })
+        // `onboard` must be called in order to borrow. even though we
+        // upgraded, we are still able to call the function without re-onboarding!
+        await daiProxy.borrowDaiForMaximumFYDai(pool.address, WETH, maturity1, user2, fyDaiTokens1, one, {
+          from: user1,
+        })
+      })
+
+      it('maintains `authorizePool` permissions', async () => {
+        // `authorizePool` must be called in order to borrow. even though we
+        // upgraded, we are still able to call the function without re-authorizing!
+        await daiProxy.borrowMinimumDaiForFYDai(pool.address, WETH, maturity1, user2, fyDaiTokens1, one, {
+          from: user1,
+        })
+      })
+
+      it('can choose old versions', async () => {
+        await proxy.chooseVersion(1, { from: user1 })
+        let ret = await daiProxy.addLiquidity.call(pool.address, 0, 0, { from: user1 });
+        expect(ret.toString()).to.eq('0')
+
+        await proxy.chooseVersion(2, { from: user1 })
+        ret = await daiProxy.addLiquidity.call(pool.address, 0, 0, { from: user1 });
+        expect(ret.toString()).to.eq('42')
+      })
+
+      it('cannot choose versions that have not been implemented yet', async () => {
+        await expectRevert(
+          proxy.chooseVersion(bnify(await proxy.getLatestVersion()).add(1).toString(), { from: user1 }),
+          "YieldProxy: Invalid version"
+        )
+      })
+    })
+  })
+})

--- a/test/peripheral/561_upgradableProxy.ts
+++ b/test/peripheral/561_upgradableProxy.ts
@@ -152,8 +152,8 @@ contract('YieldProxy - DaiProxy', async (accounts) => {
 
     describe('can be upgraded', async () => {
       const YieldProxy = artifacts.require('YieldProxy')
-      let proxy : Contract
-      
+      let proxy: Contract
+
       beforeEach(async () => {
         proxy = await YieldProxy.at(daiProxy.address)
         daiProxy = await upgradeToV2(daiProxy)
@@ -170,7 +170,7 @@ contract('YieldProxy - DaiProxy', async (accounts) => {
       })
 
       it('can call upgraded functions', async () => {
-        const ret = await daiProxy.addLiquidity.call(pool.address, 0, 0);
+        const ret = await daiProxy.addLiquidity.call(pool.address, 0, 0)
         expect(ret.toString()).to.eq('42')
       })
 
@@ -199,18 +199,23 @@ contract('YieldProxy - DaiProxy', async (accounts) => {
 
       it('can choose old versions', async () => {
         await proxy.chooseVersion(1, { from: user1 })
-        let ret = await daiProxy.addLiquidity.call(pool.address, 0, 0, { from: user1 });
+        let ret = await daiProxy.addLiquidity.call(pool.address, 0, 0, { from: user1 })
         expect(ret.toString()).to.eq('0')
 
         await proxy.chooseVersion(2, { from: user1 })
-        ret = await daiProxy.addLiquidity.call(pool.address, 0, 0, { from: user1 });
+        ret = await daiProxy.addLiquidity.call(pool.address, 0, 0, { from: user1 })
         expect(ret.toString()).to.eq('42')
       })
 
       it('cannot choose versions that have not been implemented yet', async () => {
         await expectRevert(
-          proxy.chooseVersion(bnify(await proxy.getLatestVersion()).add(1).toString(), { from: user1 }),
-          "YieldProxy: Invalid version"
+          proxy.chooseVersion(
+            bnify(await proxy.getLatestVersion())
+              .add(1)
+              .toString(),
+            { from: user1 }
+          ),
+          'YieldProxy: Invalid version'
         )
       })
     })

--- a/test/shared/proxies.ts
+++ b/test/shared/proxies.ts
@@ -1,0 +1,17 @@
+const ProxyV1 = artifacts.require('ProxyV1')
+const YieldProxy = artifacts.require('YieldProxy')
+
+// Deploys the v1 proxy
+export const setupProxy = async (controllerAddress: string, pools: string[]) => {
+  const v1 = await ProxyV1.new()
+  // deploy the proxy
+  let proxy = await YieldProxy.new()
+
+  // set the implementation and call the initializer
+  const initArgs = v1.contract.methods.init(controllerAddress, pools).encodeABI()
+  await proxy.upgradeTo(v1.address, initArgs)
+
+  // rebind the ABI
+  proxy = await ProxyV1.at(proxy.address)
+  return proxy
+}

--- a/test/shared/proxies.ts
+++ b/test/shared/proxies.ts
@@ -1,6 +1,8 @@
 const ProxyV1 = artifacts.require('ProxyV1')
 const YieldProxy = artifacts.require('YieldProxy')
 
+const ProxyV2 = artifacts.require('ProxyV2')
+
 // Deploys the v1 proxy
 export const setupProxy = async (controllerAddress: string, pools: string[]) => {
   const v1 = await ProxyV1.new()
@@ -13,5 +15,22 @@ export const setupProxy = async (controllerAddress: string, pools: string[]) => 
 
   // rebind the ABI
   proxy = await ProxyV1.at(proxy.address)
+  return proxy
+}
+
+// Upgrades to another proxy
+export const upgradeToV2 = async (proxy: any) => {
+  const v2 = await ProxyV2.new()
+
+  // set the implementation and call the initializer
+  const initArgs = v2.contract.methods.init(123).encodeABI()
+
+  // need to override here to access the `upgradeTo` method
+  // since we may be given
+  proxy = await YieldProxy.at(proxy.address)
+  await proxy.upgradeTo(v2.address, initArgs)
+
+  // rebind the ABI
+  proxy = await ProxyV2.at(proxy.address)
   return proxy
 }


### PR DESCRIPTION
This PR separates the authorization flow of the proxy from the actual proxy implementation.

Users will always authorize 1 version of the proxy via the `onboard` and `authorizePool` calls, and then any subsequent calls will be forwarded to the address stored at `IMPL_SLOT`, which is set by an admin that's stored at the `ADMIN_SLOT` storage slots. These are made to be EIP1967 compatible to avoid storage collisions.

TODO:
- Test that upgrading to another proxy does not require re-authorizing.