### PR TITLE
Feat/check proxy approvals

### DIFF
--- a/contracts/Treasury.sol
+++ b/contracts/Treasury.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.6.10;
 
 import "@openzeppelin/contracts/math/Math.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./interfaces/IVat.sol";
+import "./interfaces/IDai.sol";
 import "./interfaces/IDaiJoin.sol";
 import "./interfaces/IGemJoin.sol";
 import "./interfaces/IPot.sol";
@@ -26,7 +26,7 @@ contract Treasury is ITreasury, Orchestrated(), DecimalMath {
 
     IVat public override vat;
     IWeth public override weth;
-    IERC20 public override dai;
+    IDai public override dai;
     IDaiJoin public override daiJoin;
     IGemJoin public override wethJoin;
     IPot public override pot;
@@ -48,7 +48,7 @@ contract Treasury is ITreasury, Orchestrated(), DecimalMath {
         address chai_
     ) public {
         // These could be hardcoded for mainnet deployment.
-        dai = IERC20(dai_);
+        dai = IDai(dai_);
         chai = IChai(chai_);
         pot = IPot(pot_);
         weth = IWeth(weth_);

--- a/contracts/helpers/SafeCast.sol
+++ b/contracts/helpers/SafeCast.sol
@@ -7,7 +7,7 @@ library SafeCast {
     function toUint128(uint256 x) internal pure returns(uint128) {
         require(
             x <= type(uint128).max,
-            "YieldProxy: Cast overflow"
+            "SafeCast: Cast overflow"
         );
         return uint128(x);
     }
@@ -16,7 +16,7 @@ library SafeCast {
     function toInt256(uint256 x) internal pure returns(int256) {
         require(
             x <= uint256(type(int256).max),
-            "YieldProxy: Cast overflow"
+            "SafeCast: Cast overflow"
         );
         return int256(x);
     }

--- a/contracts/interfaces/ITreasury.sol
+++ b/contracts/interfaces/ITreasury.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./IVat.sol";
+import "./IDai.sol";
 import "./IWeth.sol";
 import "./IGemJoin.sol";
 import "./IDaiJoin.sol";
@@ -23,7 +23,7 @@ interface ITreasury {
 
     function vat() external view returns (IVat);
     function weth() external view returns (IWeth);
-    function dai() external view returns (IERC20);
+    function dai() external view returns (IDai);
     function daiJoin() external view returns (IDaiJoin);
     function wethJoin() external view returns (IGemJoin);
     function pot() external view returns (IPot);

--- a/contracts/peripheral/BorrowProxy.sol
+++ b/contracts/peripheral/BorrowProxy.sol
@@ -48,7 +48,7 @@ contract BorrowProxy {
     }
 
     /// @dev Users wishing to withdraw their Weth as ETH from the Controller should use this function.
-    /// Users must have called `controller.addDelegate(yieldProxy.address)` to authorize YieldProxy to act in their behalf.
+    /// Users must have called `controller.addDelegate(borrowProxy.address)` or `withdrawWithSignature` to authorize YieldProxy to act in their behalf.
     /// @param to Wallet to send Eth to.
     /// @param amount Amount of weth to move.
     function withdraw(address payable to, uint256 amount)
@@ -59,7 +59,8 @@ contract BorrowProxy {
     }
 
     /// @dev Borrow fyDai from Controller and sell it immediately for Dai, for a maximum fyDai debt.
-    /// Must have approved the operator with `controller.addDelegate(yieldProxy.address)`.
+    /// Must have approved the operator with `controller.addDelegate(borrowProxy.address)` or with `borrowDaiForMaximumFYDaiWithSignature`.
+    /// Caller must have called `borrowDaiForMaximumFYDaiWithSignature` at least once before to set proxy approvals.
     /// @param collateral Valid collateral type.
     /// @param maturity Maturity of an added series
     /// @param to Wallet to send the resulting Dai to.
@@ -87,6 +88,8 @@ contract BorrowProxy {
     }
 
     /// @dev Sell fyDai for Dai
+    /// Caller must have approved the fyDai transfer with `fyDai.approve(fyDaiUsed)` or with `sellFYDaiWithSignature`.
+    /// Caller must have approved the proxy using`pool.addDelegate(borrowProxy)` or with `sellFYDaiWithSignature`.
     /// @param to Wallet receiving the dai being bought
     /// @param fyDaiIn Amount of fyDai being sold
     /// @param minDaiOut Minimum amount of dai being bought
@@ -103,6 +106,8 @@ contract BorrowProxy {
     }
 
     /// @dev Sell Dai for fyDai
+    /// Caller must have approved the dai transfer with `dai.approve(fyDaiUsed)` or with `sellDaiWithSignature`.
+    /// Caller must have approved the proxy using`pool.addDelegate(borrowProxy)` or with `sellDaiWithSignature`.
     /// @param to Wallet receiving the fyDai being bought
     /// @param daiIn Amount of dai being sold
     /// @param minFYDaiOut Minimum amount of fyDai being bought
@@ -121,7 +126,6 @@ contract BorrowProxy {
     /// --------------------------------------------------
     /// Signature method wrappers
     /// --------------------------------------------------
-
 
     /// @dev Determine whether all approvals and signatures are in place for `withdrawWithSignature`.
     /// `return[0]` is always `true`, meaning that no proxy approvals are ever needed.

--- a/contracts/peripheral/BorrowProxy.sol
+++ b/contracts/peripheral/BorrowProxy.sol
@@ -33,10 +33,10 @@ contract BorrowProxy {
         controller = _controller;
     }
 
-    /// @dev The WETH9 contract will send ether to YieldProxy on `weth.withdraw` using this function.
+    /// @dev The WETH9 contract will send ether to BorrowProxy on `weth.withdraw` using this function.
     receive() external payable { }
 
-    /// @dev Users use `post` in YieldProxy to post ETH to the Controller (amount = msg.value), which will be converted to Weth here.
+    /// @dev Users use `post` in BorrowProxy to post ETH to the Controller (amount = msg.value), which will be converted to Weth here.
     /// @param to Yield Vault to deposit collateral in.
     function post(address to)
         external payable {
@@ -48,7 +48,7 @@ contract BorrowProxy {
     }
 
     /// @dev Users wishing to withdraw their Weth as ETH from the Controller should use this function.
-    /// Users must have called `controller.addDelegate(borrowProxy.address)` or `withdrawWithSignature` to authorize YieldProxy to act in their behalf.
+    /// Users must have called `controller.addDelegate(borrowProxy.address)` or `withdrawWithSignature` to authorize BorrowProxy to act in their behalf.
     /// @param to Wallet to send Eth to.
     /// @param amount Amount of weth to move.
     function withdraw(address payable to, uint256 amount)
@@ -78,7 +78,7 @@ contract BorrowProxy {
         returns (uint256)
     {
         uint256 fyDaiToBorrow = pool.buyDaiPreview(daiToBorrow.toUint128());
-        require (fyDaiToBorrow <= maximumFYDai, "YieldProxy: Too much fyDai required");
+        require (fyDaiToBorrow <= maximumFYDai, "BorrowProxy: Too much fyDai required");
 
         // The collateral for this borrow needs to have been posted beforehand
         controller.borrow(collateral, maturity, msg.sender, address(this), fyDaiToBorrow);

--- a/contracts/peripheral/BorrowProxy.sol
+++ b/contracts/peripheral/BorrowProxy.sol
@@ -121,6 +121,17 @@ contract BorrowProxy {
     /// Signature method wrappers
     /// --------------------------------------------------
 
+
+    /// @dev Determine whether all approvals and signatures are in place for `withdrawWithSignature`.
+    /// `return[0]` is always `true`, meaning that no proxy approvals are ever needed.
+    /// If `return[1]` is `false`, `withdrawWithSignature` must be called with a controller signature.
+    /// If `return` is `(true, true)`, `withdrawWithSignature` won't fail because of missing approvals or signatures.
+    function withdrawCheck() public view returns (bool, bool) {
+        bool approvals = true; // sellFYDai doesn't need proxy approvals
+        bool controllerSig = controller.delegated(msg.sender, address(this));
+        return (approvals, controllerSig);
+    }
+
     /// @dev Users wishing to withdraw their Weth as ETH from the Controller should use this function.
     /// @param to Wallet to send Eth to.
     /// @param amount Amount of weth to move.
@@ -131,7 +142,7 @@ contract BorrowProxy {
         withdraw(to, amount);
     }
 
-    /// @dev Determine whether all approvals and signatures are in place for `borrowDaiForMaximumFYDai` to suceed for a given pool.
+    /// @dev Determine whether all approvals and signatures are in place for `borrowDaiForMaximumFYDai` with a given pool.
     /// If `return[0]` is `false`, calling `borrowDaiForMaximumFYDaiWithSignature` will set the approvals.
     /// If `return[1]` is `false`, `borrowDaiForMaximumFYDaiWithSignature` must be called with a controller signature
     /// If `return` is `(true, true)`, `borrowDaiForMaximumFYDai` won't fail because of missing approvals or signatures.
@@ -167,7 +178,7 @@ contract BorrowProxy {
         return borrowDaiForMaximumFYDai(pool, collateral, maturity, to, maximumFYDai, daiToBorrow);
     }
 
-    /// @dev Determine whether all approvals and signatures are in place for `controller.repayDai` to suceed.
+    /// @dev Determine whether all approvals and signatures are in place for `repayDaiWithSignature`.
     /// `return[0]` is always `true`, meaning that no proxy approvals are ever needed.
     /// If `return[1]` is `false`, `repayDaiWithSignature` must be called with a dai permit signature.
     /// If `return[2]` is `false`, `repayDaiWithSignature` must be called with a controller signature.
@@ -199,7 +210,7 @@ contract BorrowProxy {
         controller.repayDai(collateral, maturity, msg.sender, to, daiAmount);
     }
 
-    /// @dev Determine whether all approvals and signatures are in place for `sellFYDai` to suceed.
+    /// @dev Determine whether all approvals and signatures are in place for `sellFYDai`.
     /// `return[0]` is always `true`, meaning that no proxy approvals are ever needed.
     /// If `return[1]` is `false`, `sellFYDaiWithSignature` must be called with a fyDai permit signature.
     /// If `return[2]` is `false`, `sellFYDaiWithSignature` must be called with a pool signature.
@@ -226,7 +237,7 @@ contract BorrowProxy {
         return sellFYDai(pool, to, fyDaiIn, minDaiOut);
     }
 
-    /// @dev Determine whether all approvals and signatures are in place for `sellDai` to suceed.
+    /// @dev Determine whether all approvals and signatures are in place for `sellDai`.
     /// `return[0]` is always `true`, meaning that no proxy approvals are ever needed.
     /// If `return[1]` is `false`, `sellDaiWithSignature` must be called with a dai permit signature.
     /// If `return[2]` is `false`, `sellDaiWithSignature` must be called with a pool signature.

--- a/contracts/peripheral/BorrowProxy.sol
+++ b/contracts/peripheral/BorrowProxy.sol
@@ -157,6 +157,12 @@ contract BorrowProxy {
         return (approvals, controllerSig);
     }
 
+    /// @dev Set proxy approvals for `borrowDaiForMaximumFYDai` with a given pool.
+    function borrowDaiForMaximumFYDaiApprove(IPool pool) public {
+        // allow the pool to pull FYDai/dai from us for LPing
+        if (pool.fyDai().allowance(address(this), address(pool)) < type(uint112).max) pool.fyDai().approve(address(pool), type(uint256).max);
+    }
+
     /// @dev Borrow fyDai from Controller and sell it immediately for Dai, for a maximum fyDai debt.
     /// @param collateral Valid collateral type.
     /// @param maturity Maturity of an added series
@@ -176,9 +182,7 @@ contract BorrowProxy {
         public
         returns (uint256)
     {
-        // allow the pool to pull FYDai/dai from us for LPing
-        if (pool.fyDai().allowance(address(this), address(pool)) < type(uint112).max) pool.fyDai().approve(address(pool), type(uint256).max);
-
+        borrowDaiForMaximumFYDaiApprove(pool);
         if (controllerSig.length > 0) controller.addDelegatePacked(controllerSig);
         return borrowDaiForMaximumFYDai(pool, collateral, maturity, to, maximumFYDai, daiToBorrow);
     }

--- a/contracts/peripheral/BorrowProxy.sol
+++ b/contracts/peripheral/BorrowProxy.sol
@@ -25,13 +25,10 @@ contract BorrowProxy {
 
     bytes32 public constant WETH = "ETH-A";
 
-    constructor(address controller_) public {
-        IController _controller = IController(controller_);
+    constructor(IController _controller) public {
         ITreasury _treasury = _controller.treasury();
-
         weth = _treasury.weth();
         dai = _treasury.dai();
-
         treasury = address(_treasury);
         controller = _controller;
     }

--- a/contracts/peripheral/BorrowProxy.sol
+++ b/contracts/peripheral/BorrowProxy.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.6.10;
 import "../interfaces/IWeth.sol";
 import "../interfaces/IDai.sol";
 import "../interfaces/IFYDai.sol";
+import "../interfaces/ITreasury.sol";
 import "../interfaces/IController.sol";
 import "../interfaces/IPool.sol";
 import "../helpers/SafeCast.sol";
@@ -24,12 +25,15 @@ contract BorrowProxy {
 
     bytes32 public constant WETH = "ETH-A";
 
-    constructor(address weth_, address dai_, address treasury_, address controller_) public {
-        controller = IController(controller_);
-        treasury = treasury_;
+    constructor(address controller_) public {
+        IController _controller = IController(controller_);
+        ITreasury _treasury = _controller.treasury();
 
-        weth = IWeth(weth_);
-        dai = IDai(dai_);
+        weth = _treasury.weth();
+        dai = _treasury.dai();
+
+        treasury = address(_treasury);
+        controller = _controller;
     }
 
     /// @dev The WETH9 contract will send ether to YieldProxy on `weth.withdraw` using this function.

--- a/contracts/peripheral/PoolProxy.sol
+++ b/contracts/peripheral/PoolProxy.sol
@@ -45,18 +45,6 @@ contract PoolProxy is DecimalMath {
         require(fyDai.isMature() != true, "YieldProxy: Only before maturity");
         require(dai.transferFrom(msg.sender, address(this), daiUsed), "YieldProxy: Transfer Failed");
 
-        // Allow the Treasury to take chai when posting
-        if (chai.allowance(address(this), treasury) < type(uint256).max) chai.approve(treasury, type(uint256).max);
-
-        // Allow Chai to take dai for wrapping
-        if (dai.allowance(address(this), address(chai)) < type(uint256).max) dai.approve(address(chai), type(uint256).max);
-
-        // Allow pool to take dai for minting
-        if (dai.allowance(address(this), address(pool)) < type(uint256).max) dai.approve(address(pool), type(uint256).max);
-
-        // Allow pool to take fyDai for minting
-        if (fyDai.allowance(address(this), address(pool)) < type(uint112).max) fyDai.approve(address(pool), type(uint256).max);
-
         // calculate needed fyDai
         uint256 daiReserves = dai.balanceOf(address(pool));
         uint256 fyDaiReserves = fyDai.balanceOf(address(pool));
@@ -87,12 +75,6 @@ contract PoolProxy is DecimalMath {
 
         IFYDai fyDai = pool.fyDai();
         uint256 maturity = fyDai.maturity();
-
-        // Allow pool to take dai for trading
-        if (dai.allowance(address(this), address(pool)) < type(uint256).max) dai.approve(address(pool), type(uint256).max);
-
-        // Allow pool to take fyDai for trading
-        if (fyDai.allowance(address(this), address(pool)) < type(uint112).max) fyDai.approve(address(pool), type(uint256).max);
 
         (uint256 daiObtained, uint256 fyDaiObtained) = pool.burn(msg.sender, address(this), poolTokens);
 
@@ -129,12 +111,6 @@ contract PoolProxy is DecimalMath {
         IFYDai fyDai = pool.fyDai();
         uint256 maturity = fyDai.maturity();
 
-        // Allow the Treasury to take dai for repaying
-        if (dai.allowance(address(this), treasury) < type(uint256).max) dai.approve(treasury, type(uint256).max);
-
-        // Allow pool to take fyDai for trading
-        if (fyDai.allowance(address(this), address(pool)) < type(uint112).max) fyDai.approve(address(pool), type(uint256).max);
-
         (uint256 daiObtained, uint256 fyDaiObtained) = pool.burn(msg.sender, address(this), poolTokens);
         uint256 fyDaiUsed;
         if (fyDaiObtained > 0 && controller.debtFYDai(CHAI, maturity, msg.sender) > 0) {
@@ -162,9 +138,6 @@ contract PoolProxy is DecimalMath {
 
         IFYDai fyDai = pool.fyDai();
         uint256 maturity = fyDai.maturity();
-
-        // Allow the Treasury to take dai for repaying
-        if (dai.allowance(address(this), treasury) < type(uint256).max) dai.approve(treasury, type(uint256).max);
 
         (uint256 daiObtained, uint256 fyDaiObtained) = pool.burn(msg.sender, address(this), poolTokens);
         if (fyDaiObtained > 0) {
@@ -207,6 +180,18 @@ contract PoolProxy is DecimalMath {
         bytes memory daiSig,
         bytes memory controllerSig
     ) external returns (uint256) {
+        // Allow the Treasury to take chai when posting
+        if (chai.allowance(address(this), treasury) < type(uint256).max) chai.approve(treasury, type(uint256).max);
+
+        // Allow Chai to take dai for wrapping
+        if (dai.allowance(address(this), address(chai)) < type(uint256).max) dai.approve(address(chai), type(uint256).max);
+
+        // Allow pool to take dai for minting
+        if (dai.allowance(address(this), address(pool)) < type(uint256).max) dai.approve(address(pool), type(uint256).max);
+
+        // Allow pool to take fyDai for minting
+        if (pool.fyDai().allowance(address(this), address(pool)) < type(uint112).max) pool.fyDai().approve(address(pool), type(uint256).max);
+
         if (daiSig.length > 0) dai.permitPackedDai(address(this), daiSig);
         if (controllerSig.length > 0) controller.addDelegatePacked(controllerSig);
         return addLiquidity(pool, daiUsed, maxFYDai);
@@ -226,6 +211,12 @@ contract PoolProxy is DecimalMath {
         bytes memory controllerSig,
         bytes memory poolSig
     ) public {
+        // Allow pool to take dai for trading
+        if (dai.allowance(address(this), address(pool)) < type(uint256).max) dai.approve(address(pool), type(uint256).max);
+
+        // Allow pool to take fyDai for trading
+        if (pool.fyDai().allowance(address(this), address(pool)) < type(uint112).max) pool.fyDai().approve(address(pool), type(uint256).max);
+
         if (controllerSig.length > 0) controller.addDelegatePacked(controllerSig);
         if (poolSig.length > 0) pool.addDelegatePacked(poolSig);
         removeLiquidityEarlyDaiPool(pool, poolTokens, minimumDaiPrice, minimumFYDaiPrice);
@@ -243,6 +234,12 @@ contract PoolProxy is DecimalMath {
         bytes memory controllerSig,
         bytes memory poolSig
     ) public {
+        // Allow the Treasury to take dai for repaying
+        if (dai.allowance(address(this), treasury) < type(uint256).max) dai.approve(treasury, type(uint256).max);
+
+        // Allow pool to take fyDai for trading
+        if (pool.fyDai().allowance(address(this), address(pool)) < type(uint112).max) pool.fyDai().approve(address(pool), type(uint256).max);
+
         if (controllerSig.length > 0) controller.addDelegatePacked(controllerSig);
         if (poolSig.length > 0) pool.addDelegatePacked(poolSig);
         removeLiquidityEarlyDaiFixed(pool, poolTokens, minimumFYDaiPrice);
@@ -258,6 +255,9 @@ contract PoolProxy is DecimalMath {
         bytes memory controllerSig,
         bytes memory poolSig
     ) external {
+        // Allow the Treasury to take dai for repaying
+        if (dai.allowance(address(this), treasury) < type(uint256).max) dai.approve(treasury, type(uint256).max);
+
         if (controllerSig.length > 0) controller.addDelegatePacked(controllerSig);
         if (poolSig.length > 0) pool.addDelegatePacked(poolSig);
         removeLiquidityMature(pool, poolTokens);

--- a/contracts/peripheral/PoolProxy.sol
+++ b/contracts/peripheral/PoolProxy.sol
@@ -43,8 +43,8 @@ contract PoolProxy is DecimalMath {
     /// @return The amount of liquidity tokens minted.  
     function addLiquidity(IPool pool, uint256 daiUsed, uint256 maxFYDai) public returns (uint256) {
         IFYDai fyDai = pool.fyDai();
-        require(fyDai.isMature() != true, "YieldProxy: Only before maturity");
-        require(dai.transferFrom(msg.sender, address(this), daiUsed), "YieldProxy: Transfer Failed");
+        require(fyDai.isMature() != true, "PoolProxy: Only before maturity");
+        require(dai.transferFrom(msg.sender, address(this), daiUsed), "PoolProxy: Transfer Failed");
 
         // calculate needed fyDai
         uint256 daiReserves = dai.balanceOf(address(pool));
@@ -53,7 +53,7 @@ contract PoolProxy is DecimalMath {
         uint256 daiToConvert = daiUsed.sub(daiToAdd);
         require(
             daiToConvert <= maxFYDai,
-            "YieldProxy: maxFYDai exceeded"
+            "PoolProxy: maxFYDai exceeded"
         ); // 1 Dai == 1 fyDai
 
         // convert dai to chai and borrow needed fyDai
@@ -84,7 +84,7 @@ contract PoolProxy is DecimalMath {
         uint256 fyDaiBought = pool.sellDai(address(this), address(this), daiObtained.toUint128());
         require(
             fyDaiBought >= muld(daiObtained, minimumDaiPrice),
-            "YieldProxy: minimumDaiPrice not reached"
+            "PoolProxy: minimumDaiPrice not reached"
         );
         fyDaiObtained = fyDaiObtained.add(fyDaiBought);
         
@@ -97,7 +97,7 @@ contract PoolProxy is DecimalMath {
         if (fyDaiRemaining > 0) {// There is fyDai left, so exchange it for Dai to withdraw only Dai and Chai
             require(
                 pool.sellFYDai(address(this), address(this), uint128(fyDaiRemaining)) >= muld(fyDaiRemaining, minimumFYDaiPrice),
-                "YieldProxy: minimumFYDaiPrice not reached"
+                "PoolProxy: minimumFYDaiPrice not reached"
             );
         }
         withdrawAssets();
@@ -127,7 +127,7 @@ contract PoolProxy is DecimalMath {
         } else { // Exchange remaining fyDai for Dai to withdraw only Dai and Chai
             require(
                 pool.sellFYDai(address(this), address(this), uint128(fyDaiRemaining)) >= muld(fyDaiRemaining, minimumFYDaiPrice),
-                "YieldProxy: minimumFYDaiPrice not reached"
+                "PoolProxy: minimumFYDaiPrice not reached"
             );
         }
         withdrawAssets();
@@ -158,10 +158,10 @@ contract PoolProxy is DecimalMath {
     function withdrawAssets() internal {
         uint256 posted = controller.posted(CHAI, msg.sender);
         uint256 locked = controller.locked(CHAI, msg.sender);
-        require (posted >= locked, "YieldProxy: Undercollateralized");
+        require (posted >= locked, "PoolProxy: Undercollateralized");
         controller.withdraw(CHAI, msg.sender, address(this), posted - locked);
         chai.exit(address(this), chai.balanceOf(address(this)));
-        require(dai.transfer(msg.sender, dai.balanceOf(address(this))), "YieldProxy: Dai Transfer Failed");
+        require(dai.transfer(msg.sender, dai.balanceOf(address(this))), "PoolProxy: Dai Transfer Failed");
     }
 
     /// --------------------------------------------------

--- a/contracts/peripheral/PoolProxy.sol
+++ b/contracts/peripheral/PoolProxy.sol
@@ -26,11 +26,12 @@ contract PoolProxy is DecimalMath {
 
     bytes32 public constant CHAI = "CHAI";
 
-    constructor(address dai_, address chai_, address treasury_, address controller_) public {
-        controller = IController(controller_);
-        treasury = treasury_;
-        dai = IDai(dai_);
-        chai = IChai(chai_);
+    constructor(IController _controller) public {
+        ITreasury _treasury = _controller.treasury();
+        dai = _treasury.dai();
+        chai = _treasury.chai();
+        treasury = address(_treasury);
+        controller = _controller;
     }
 
     /// @dev Mints liquidity with provided Dai by borrowing fyDai with some of the Dai.

--- a/migrations/60_deploy_dsProxy.js
+++ b/migrations/60_deploy_dsProxy.js
@@ -1,39 +1,25 @@
 const fixed_addrs = require('./fixed_addrs.json')
 
 const Migrations = artifacts.require('Migrations')
-const Controller = artifacts.require('Controller')
 const DSProxyFactory = artifacts.require('DSProxyFactory')
 const DSProxyRegistry = artifacts.require('ProxyRegistry')
-const BorrowProxy = artifacts.require('BorrowProxy')
-const PoolProxy = artifacts.require('PoolProxy')
 
 module.exports = async (deployer, network) => {
 
-  let controllerAddress, proxyFactoryAddress, proxyRegistryAddress
+  let proxyFactoryAddress, proxyRegistryAddress
   if (network === 'development') {
-    controllerAddress = (await Controller.deployed()).address
-    
     await deployer.deploy(DSProxyFactory)
     proxyFactoryAddress = (await DSProxyFactory.deployed()).address
     await deployer.deploy(DSProxyRegistry, proxyFactoryAddress)
     proxyRegistryAddress = (await DSProxyRegistry.deployed()).address
   } else {
-    controllerAddress = fixed_addrs[network].controllerAddress
     proxyFactoryAddress = fixed_addrs[network].proxyFactoryAddress
     proxyRegistryAddress = fixed_addrs[network].proxyRegistryAddress  
   }
 
-  await deployer.deploy(BorrowProxy, controllerAddress)
-  const borrowProxy = await BorrowProxy.deployed()
-
-  await deployer.deploy(PoolProxy, controllerAddress)
-  const poolProxy = await PoolProxy.deployed()
-
   const deployment = {
     ProxyFactory: proxyFactoryAddress,
     ProxyRegistry: proxyRegistryAddress,
-    BorrowProxy: borrowProxy.address,
-    PoolProxy: poolProxy.address,
   }
 
   let migrations

--- a/migrations/61_deploy_borrowProxy.js
+++ b/migrations/61_deploy_borrowProxy.js
@@ -1,0 +1,43 @@
+const fixed_addrs = require('./fixed_addrs.json')
+
+const Migrations = artifacts.require('Migrations')
+const Controller = artifacts.require('Controller')
+const DSProxyFactory = artifacts.require('DSProxyFactory')
+const DSProxyRegistry = artifacts.require('ProxyRegistry')
+const BorrowProxy = artifacts.require('BorrowProxy')
+
+module.exports = async (deployer, network) => {
+
+  let controllerAddress, proxyFactoryAddress, proxyRegistryAddress
+  if (network === 'development') {
+    controllerAddress = (await Controller.deployed()).address
+    proxyFactoryAddress = (await DSProxyFactory.deployed()).address
+    proxyRegistryAddress = (await DSProxyRegistry.deployed()).address
+  } else {
+    controllerAddress = fixed_addrs[network].controllerAddress
+    proxyFactoryAddress = fixed_addrs[network].proxyFactoryAddress
+    proxyRegistryAddress = fixed_addrs[network].proxyRegistryAddress  
+  }
+
+  await deployer.deploy(BorrowProxy, controllerAddress)
+  const borrowProxy = await BorrowProxy.deployed()
+
+  const deployment = {
+    BorrowProxy: borrowProxy.address,
+  }
+
+  let migrations
+  if (network === 'kovan' && network === 'kovan-fork') {
+    migrations = await Migrations.at(fixed_addrs[network].migrationsAddress)
+  } else if (network === 'development') {
+    migrations = await Migrations.deployed()
+  }
+
+  if (migrations !== undefined) {
+    for (name in deployment) {
+      await migrations.register(web3.utils.fromAscii(name), deployment[name])
+    }
+  }
+
+  console.log(deployment)
+}

--- a/migrations/62_deploy_poolProxy.js
+++ b/migrations/62_deploy_poolProxy.js
@@ -1,0 +1,43 @@
+const fixed_addrs = require('./fixed_addrs.json')
+
+const Migrations = artifacts.require('Migrations')
+const Controller = artifacts.require('Controller')
+const DSProxyFactory = artifacts.require('DSProxyFactory')
+const DSProxyRegistry = artifacts.require('ProxyRegistry')
+const PoolProxy = artifacts.require('PoolProxy')
+
+module.exports = async (deployer, network) => {
+
+  let controllerAddress, proxyFactoryAddress, proxyRegistryAddress
+  if (network === 'development') {
+    controllerAddress = (await Controller.deployed()).address
+    proxyFactoryAddress = (await DSProxyFactory.deployed()).address
+    proxyRegistryAddress = (await DSProxyRegistry.deployed()).address
+  } else {
+    controllerAddress = fixed_addrs[network].controllerAddress
+    proxyFactoryAddress = fixed_addrs[network].proxyFactoryAddress
+    proxyRegistryAddress = fixed_addrs[network].proxyRegistryAddress  
+  }
+
+  await deployer.deploy(PoolProxy, controllerAddress)
+  const poolProxy = await PoolProxy.deployed()
+
+  const deployment = {
+    PoolProxy: poolProxy.address,
+  }
+
+  let migrations
+  if (network === 'kovan' && network === 'kovan-fork') {
+    migrations = await Migrations.at(fixed_addrs[network].migrationsAddress)
+  } else if (network === 'development') {
+    migrations = await Migrations.deployed()
+  }
+
+  if (migrations !== undefined) {
+    for (name in deployment) {
+      await migrations.register(web3.utils.fromAscii(name), deployment[name])
+    }
+  }
+
+  console.log(deployment)
+}

--- a/migrations/6_deploy_peripheral.js
+++ b/migrations/6_deploy_peripheral.js
@@ -1,9 +1,6 @@
 const fixed_addrs = require('./fixed_addrs.json')
 
 const Migrations = artifacts.require('Migrations')
-const Dai = artifacts.require('Dai')
-const Chai = artifacts.require('Chai')
-const Treasury = artifacts.require('Treasury')
 const Controller = artifacts.require('Controller')
 const DSProxyFactory = artifacts.require('DSProxyFactory')
 const DSProxyRegistry = artifacts.require('ProxyRegistry')
@@ -12,11 +9,8 @@ const PoolProxy = artifacts.require('PoolProxy')
 
 module.exports = async (deployer, network) => {
 
-  let daiAddress, chaiAddress, treasuryAddress, controllerAddress, proxyFactoryAddress, proxyRegistryAddress
+  let controllerAddress, proxyFactoryAddress, proxyRegistryAddress
   if (network === 'development') {
-    daiAddress = (await Dai.deployed()).address
-    chaiAddress = (await Chai.deployed()).address
-    treasuryAddress = (await Treasury.deployed()).address
     controllerAddress = (await Controller.deployed()).address
     
     await deployer.deploy(DSProxyFactory)
@@ -24,9 +18,6 @@ module.exports = async (deployer, network) => {
     await deployer.deploy(DSProxyRegistry, proxyFactoryAddress)
     proxyRegistryAddress = (await DSProxyRegistry.deployed()).address
   } else {
-    daiAddress = fixed_addrs[network].daiAddress
-    chaiAddress = fixed_addrs[network].chaiAddress
-    treasuryAddress = fixed_addrs[network].treasuryAddress
     controllerAddress = fixed_addrs[network].controllerAddress
     proxyFactoryAddress = fixed_addrs[network].proxyFactoryAddress
     proxyRegistryAddress = fixed_addrs[network].proxyRegistryAddress  
@@ -35,7 +26,7 @@ module.exports = async (deployer, network) => {
   await deployer.deploy(BorrowProxy, controllerAddress)
   const borrowProxy = await BorrowProxy.deployed()
 
-  await deployer.deploy(PoolProxy, daiAddress, chaiAddress, treasuryAddress, controllerAddress)
+  await deployer.deploy(PoolProxy, controllerAddress)
   const poolProxy = await PoolProxy.deployed()
 
   const deployment = {

--- a/migrations/6_deploy_peripheral.js
+++ b/migrations/6_deploy_peripheral.js
@@ -1,7 +1,6 @@
 const fixed_addrs = require('./fixed_addrs.json')
 
 const Migrations = artifacts.require('Migrations')
-const WETH9 = artifacts.require('WETH9')
 const Dai = artifacts.require('Dai')
 const Chai = artifacts.require('Chai')
 const Treasury = artifacts.require('Treasury')
@@ -13,9 +12,8 @@ const PoolProxy = artifacts.require('PoolProxy')
 
 module.exports = async (deployer, network) => {
 
-  let wethAddress, daiAddress, chaiAddress, treasuryAddress, controllerAddress, proxyFactoryAddress, proxyRegistryAddress
+  let daiAddress, chaiAddress, treasuryAddress, controllerAddress, proxyFactoryAddress, proxyRegistryAddress
   if (network === 'development') {
-    wethAddress = (await WETH9.deployed()).address
     daiAddress = (await Dai.deployed()).address
     chaiAddress = (await Chai.deployed()).address
     treasuryAddress = (await Treasury.deployed()).address
@@ -26,7 +24,6 @@ module.exports = async (deployer, network) => {
     await deployer.deploy(DSProxyRegistry, proxyFactoryAddress)
     proxyRegistryAddress = (await DSProxyRegistry.deployed()).address
   } else {
-    wethAddress = fixed_addrs[network].wethAddress
     daiAddress = fixed_addrs[network].daiAddress
     chaiAddress = fixed_addrs[network].chaiAddress
     treasuryAddress = fixed_addrs[network].treasuryAddress
@@ -35,7 +32,7 @@ module.exports = async (deployer, network) => {
     proxyRegistryAddress = fixed_addrs[network].proxyRegistryAddress  
   }
 
-  await deployer.deploy(BorrowProxy, wethAddress, daiAddress, treasuryAddress, controllerAddress)
+  await deployer.deploy(BorrowProxy, controllerAddress)
   const borrowProxy = await BorrowProxy.deployed()
 
   await deployer.deploy(PoolProxy, daiAddress, chaiAddress, treasuryAddress, controllerAddress)

--- a/test/peripheral/521_borrowProxy_base.ts
+++ b/test/peripheral/521_borrowProxy_base.ts
@@ -96,7 +96,7 @@ contract('BorrowProxy', async (accounts) => {
 
         assert.equal(result[0], true)
         assert.equal(result[1], false)
-        
+
         await controller.addDelegate(proxy.address, { from: user2 })
         result = await proxy.withdrawCheck({ from: user2 })
 
@@ -144,9 +144,18 @@ contract('BorrowProxy', async (accounts) => {
         assert.equal(result[0], false)
         assert.equal(result[1], true)
 
-        await proxy.borrowDaiForMaximumFYDaiWithSignature(pool.address, WETH, maturity1, user2, fyDaiTokens1, oneToken, '0x', {
-          from: user1,
-        })
+        await proxy.borrowDaiForMaximumFYDaiWithSignature(
+          pool.address,
+          WETH,
+          maturity1,
+          user2,
+          fyDaiTokens1,
+          oneToken,
+          '0x',
+          {
+            from: user1,
+          }
+        )
         result = await proxy.borrowDaiForMaximumFYDaiCheck(pool.address, { from: user1 })
 
         assert.equal(result[0], true)
@@ -155,9 +164,18 @@ contract('BorrowProxy', async (accounts) => {
 
       it('borrows dai for maximum fyDai', async () => {
         await controller.addDelegate(proxy.address, { from: user1 })
-        await proxy.borrowDaiForMaximumFYDaiWithSignature(pool.address, WETH, maturity1, user2, fyDaiTokens1, oneToken, '0x', {
-          from: user1,
-        })
+        await proxy.borrowDaiForMaximumFYDaiWithSignature(
+          pool.address,
+          WETH,
+          maturity1,
+          user2,
+          fyDaiTokens1,
+          oneToken,
+          '0x',
+          {
+            from: user1,
+          }
+        )
 
         assert.equal(await dai.balanceOf(user2), oneToken.toString())
       })
@@ -175,11 +193,20 @@ contract('BorrowProxy', async (accounts) => {
       describe('once borrowed', () => {
         beforeEach(async () => {
           await controller.addDelegate(proxy.address, { from: user1 })
-          await proxy.borrowDaiForMaximumFYDaiWithSignature(pool.address, WETH, maturity1, user2, fyDaiTokens1, oneToken, '0x', {
-            from: user1,
-          })
+          await proxy.borrowDaiForMaximumFYDaiWithSignature(
+            pool.address,
+            WETH,
+            maturity1,
+            user2,
+            fyDaiTokens1,
+            oneToken,
+            '0x',
+            {
+              from: user1,
+            }
+          )
         })
-        
+
         it('approvals only need to be set up once', async () => {
           await proxy.borrowDaiForMaximumFYDai(pool.address, WETH, maturity1, user2, fyDaiTokens1, oneToken, {
             from: user1,
@@ -193,14 +220,14 @@ contract('BorrowProxy', async (accounts) => {
           assert.equal(result[0], true)
           assert.equal(result[1], false)
           assert.equal(result[2], false)
-          
+
           await dai.approve(treasury.address, MAX, { from: user1 })
           result = await proxy.repayDaiCheck({ from: user1 })
 
           assert.equal(result[0], true)
           assert.equal(result[1], true)
           assert.equal(result[2], false)
-          
+
           await controller.addDelegate(proxy.address, { from: user1 })
           result = await proxy.repayDaiCheck({ from: user1 })
 
@@ -208,7 +235,7 @@ contract('BorrowProxy', async (accounts) => {
           assert.equal(result[1], true)
           assert.equal(result[2], true)
         })
-  
+
         it('repays debt', async () => {
           await env.maker.getDai(user1, oneToken, rate1)
           await dai.approve(treasury.address, MAX, { from: user1 })
@@ -243,14 +270,14 @@ contract('BorrowProxy', async (accounts) => {
       assert.equal(result[0], true)
       assert.equal(result[1], false)
       assert.equal(result[2], false)
-      
+
       await fyDai1.approve(pool.address, MAX, { from: user2 })
       result = await proxy.sellFYDaiCheck(pool.address, { from: user2 })
 
       assert.equal(result[0], true)
       assert.equal(result[1], true)
       assert.equal(result[2], false)
-      
+
       await pool.addDelegate(proxy.address, { from: user2 })
       result = await proxy.sellFYDaiCheck(pool.address, { from: user2 })
 
@@ -295,21 +322,21 @@ contract('BorrowProxy', async (accounts) => {
 
       it('checks missing approvals and signatures for selling dai', async () => {
         let result = await proxy.sellDaiCheck(pool.address, { from: user2 })
-  
+
         assert.equal(result[0], true)
         assert.equal(result[1], false)
         assert.equal(result[2], false)
-        
+
         await dai.approve(pool.address, MAX, { from: user2 })
         result = await proxy.sellDaiCheck(pool.address, { from: user2 })
-  
+
         assert.equal(result[0], true)
         assert.equal(result[1], true)
         assert.equal(result[2], false)
-        
+
         await pool.addDelegate(proxy.address, { from: user2 })
         result = await proxy.sellDaiCheck(pool.address, { from: user2 })
-  
+
         assert.equal(result[0], true)
         assert.equal(result[1], true)
         assert.equal(result[2], true)

--- a/test/peripheral/521_borrowProxy_base.ts
+++ b/test/peripheral/521_borrowProxy_base.ts
@@ -196,7 +196,7 @@ contract('BorrowProxy', async (accounts) => {
           assert.equal(result[2], true)
         })
   
-        it.only('repays debt', async () => {
+        it('repays debt', async () => {
           await env.maker.getDai(user1, oneToken, rate1)
           await dai.approve(treasury.address, MAX, { from: user1 })
           const debtBefore = await controller.debtDai(WETH, maturity1, user1)
@@ -222,6 +222,28 @@ contract('BorrowProxy', async (accounts) => {
       await fyDai1.approve(pool.address, -1, { from: user1 })
       await dai.approve(pool.address, -1, { from: user1 })
       await pool.addDelegate(proxy.address, { from: user1 })
+    })
+
+    it('checks missing approvals and signatures for selling fyDai', async () => {
+      let result = await proxy.sellFYDaiCheck(pool.address, { from: user2 })
+
+      assert.equal(result[0], true)
+      assert.equal(result[1], false)
+      assert.equal(result[2], false)
+      
+      await fyDai1.approve(pool.address, MAX, { from: user2 })
+      result = await proxy.sellFYDaiCheck(pool.address, { from: user2 })
+
+      assert.equal(result[0], true)
+      assert.equal(result[1], true)
+      assert.equal(result[2], false)
+      
+      await pool.addDelegate(proxy.address, { from: user2 })
+      result = await proxy.sellFYDaiCheck(pool.address, { from: user2 })
+
+      assert.equal(result[0], true)
+      assert.equal(result[1], true)
+      assert.equal(result[2], true)
     })
 
     it('sells fyDai', async () => {
@@ -256,6 +278,28 @@ contract('BorrowProxy', async (accounts) => {
         await pool.sellFYDai(owner, owner, additionalFYDaiReserves, { from: owner })
 
         await env.maker.getDai(user1, daiTokens1, rate1)
+      })
+
+      it('checks missing approvals and signatures for selling dai', async () => {
+        let result = await proxy.sellDaiCheck(pool.address, { from: user2 })
+  
+        assert.equal(result[0], true)
+        assert.equal(result[1], false)
+        assert.equal(result[2], false)
+        
+        await dai.approve(pool.address, MAX, { from: user2 })
+        result = await proxy.sellDaiCheck(pool.address, { from: user2 })
+  
+        assert.equal(result[0], true)
+        assert.equal(result[1], true)
+        assert.equal(result[2], false)
+        
+        await pool.addDelegate(proxy.address, { from: user2 })
+        result = await proxy.sellDaiCheck(pool.address, { from: user2 })
+  
+        assert.equal(result[0], true)
+        assert.equal(result[1], true)
+        assert.equal(result[2], true)
       })
 
       it('sells dai', async () => {

--- a/test/peripheral/521_borrowProxy_base.ts
+++ b/test/peripheral/521_borrowProxy_base.ts
@@ -186,7 +186,7 @@ contract('BorrowProxy', async (accounts) => {
           proxy.borrowDaiForMaximumFYDai(pool.address, WETH, maturity1, user2, fyDaiTokens1, daiTokens1, {
             from: user1,
           }),
-          'YieldProxy: Too much fyDai required'
+          'BorrowProxy: Too much fyDai required'
         )
       })
 

--- a/test/peripheral/521_borrowProxy_base.ts
+++ b/test/peripheral/521_borrowProxy_base.ts
@@ -91,6 +91,19 @@ contract('BorrowProxy', async (accounts) => {
         assert.equal(await weth.balanceOf(user2), 0, 'User2 has collateral in hand')
       })
 
+      it('checks missing approvals and signatures for withdrawing', async () => {
+        let result = await proxy.withdrawCheck({ from: user2 })
+
+        assert.equal(result[0], true)
+        assert.equal(result[1], false)
+        
+        await controller.addDelegate(proxy.address, { from: user2 })
+        result = await proxy.withdrawCheck({ from: user2 })
+
+        assert.equal(result[0], true)
+        assert.equal(result[1], true)
+      })
+
       it('allows user to withdraw weth', async () => {
         await controller.addDelegate(proxy.address, { from: user1 })
         const previousBalance = await balance.current(user2)

--- a/test/peripheral/521_borrowProxy_base.ts
+++ b/test/peripheral/521_borrowProxy_base.ts
@@ -48,7 +48,7 @@ contract('BorrowProxy', async (accounts) => {
     pool = await Pool.new(dai.address, fyDai1.address, 'Name', 'Symbol', { from: owner })
 
     // Setup LimitPool
-    proxy = await BorrowProxy.new(weth.address, dai.address, treasury.address, controller.address, { from: owner })
+    proxy = await BorrowProxy.new(controller.address, { from: owner })
 
     // Allow owner to mint fyDai the sneaky way, without recording a debt in controller
     await fyDai1.orchestrate(owner, keccak256(toUtf8Bytes('mint(address,uint256)')), { from: owner })

--- a/test/peripheral/522_borrowProxy_signatures.ts
+++ b/test/peripheral/522_borrowProxy_signatures.ts
@@ -17,7 +17,6 @@ contract('BorrowProxy - Signatures', async (accounts) => {
   let maker: MakerEnvironment
   let controller: Contract
   let treasury: Contract
-  let weth: Contract
   let dai: Contract
   let vat: Contract
   let fyDai1: Contract
@@ -38,7 +37,6 @@ contract('BorrowProxy - Signatures', async (accounts) => {
     maturity1 = (await web3.eth.getBlock(block)).timestamp + 31556952 // One year
     env = await YieldEnvironmentLite.setup([maturity1])
     maker = env.maker
-    weth = maker.weth
     dai = maker.dai
     vat = maker.vat
     controller = env.controller
@@ -49,7 +47,7 @@ contract('BorrowProxy - Signatures', async (accounts) => {
     pool = await Pool.new(dai.address, fyDai1.address, 'Name', 'Symbol', { from: owner })
 
     // Setup LimitPool
-    proxy = await BorrowProxy.new(weth.address, dai.address, treasury.address, controller.address, { from: owner })
+    proxy = await BorrowProxy.new(controller.address, { from: owner })
 
     // Allow owner to mint fyDai the sneaky way, without recording a debt in controller
     await fyDai1.orchestrate(owner, keccak256(toUtf8Bytes('mint(address,uint256)')), { from: owner })

--- a/test/peripheral/522_borrowProxy_signatures.ts
+++ b/test/peripheral/522_borrowProxy_signatures.ts
@@ -126,7 +126,7 @@ contract('BorrowProxy - Signatures', async (accounts) => {
                 from: user1,
               }
             ),
-            'YieldProxy: Too much fyDai required'
+            'BorrowProxy: Too much fyDai required'
           )
         })
 

--- a/test/peripheral/522_borrowProxy_signatures.ts
+++ b/test/peripheral/522_borrowProxy_signatures.ts
@@ -137,7 +137,7 @@ contract('BorrowProxy - Signatures', async (accounts) => {
 
           beforeEach(async () => {
             await controller.addDelegate(proxy.address, { from: user1 })
-            await proxy.borrowDaiForMaximumFYDai(pool.address, WETH, maturity1, user2, fyDaiTokens1, oneToken, {
+            await proxy.borrowDaiForMaximumFYDaiWithSignature(pool.address, WETH, maturity1, user2, fyDaiTokens1, oneToken, '0x', {
               from: user1,
             })
 
@@ -165,6 +165,20 @@ contract('BorrowProxy - Signatures', async (accounts) => {
 
           it('repays debt using Dai with signatures ', async () => {
             await controller.revokeDelegate(proxy.address, { from: user1 })
+
+            // Authorize the proxy for the controller
+            const controllerDigest = getSignatureDigest(
+              name,
+              controller.address,
+              chainId,
+              {
+                user: user1,
+                delegate: proxy.address,
+              },
+              await controller.signatureCount(user1),
+              MAX
+            )
+            controllerSig = sign(controllerDigest, userPrivateKey)
 
             await proxy.repayDaiWithSignature(WETH, maturity1, user2, oneToken, daiSig, controllerSig, {
               from: user1,

--- a/test/peripheral/522_borrowProxy_signatures.ts
+++ b/test/peripheral/522_borrowProxy_signatures.ts
@@ -135,9 +135,18 @@ contract('BorrowProxy - Signatures', async (accounts) => {
 
           beforeEach(async () => {
             await controller.addDelegate(proxy.address, { from: user1 })
-            await proxy.borrowDaiForMaximumFYDaiWithSignature(pool.address, WETH, maturity1, user2, fyDaiTokens1, oneToken, '0x', {
-              from: user1,
-            })
+            await proxy.borrowDaiForMaximumFYDaiWithSignature(
+              pool.address,
+              WETH,
+              maturity1,
+              user2,
+              fyDaiTokens1,
+              oneToken,
+              '0x',
+              {
+                from: user1,
+              }
+            )
 
             // Authorize DAI
             const daiDigest = getDaiDigest(

--- a/test/peripheral/523_borrowProxy_dsproxy.ts
+++ b/test/peripheral/523_borrowProxy_dsproxy.ts
@@ -34,7 +34,6 @@ contract('YieldProxy - DSProxy', async (accounts) => {
   let maker: MakerEnvironment
   let controller: Contract
   let treasury: Contract
-  let weth: Contract
   let dai: Contract
   let vat: Contract
   let fyDai1: Contract
@@ -57,7 +56,6 @@ contract('YieldProxy - DSProxy', async (accounts) => {
     maturity1 = (await web3.eth.getBlock(block)).timestamp + 31556952 // One year
     env = await YieldEnvironmentLite.setup([maturity1])
     maker = env.maker
-    weth = maker.weth
     dai = maker.dai
     vat = maker.vat
     controller = env.controller
@@ -68,7 +66,7 @@ contract('YieldProxy - DSProxy', async (accounts) => {
     pool = await Pool.new(dai.address, fyDai1.address, 'Name', 'Symbol', { from: owner })
 
     // Setup BorrowProxy
-    borrowProxy = await BorrowProxy.new(weth.address, dai.address, treasury.address, controller.address)
+    borrowProxy = await BorrowProxy.new(controller.address)
 
     // Setup DSProxyFactory and DSProxyCache
     proxyFactory = await DSProxyFactory.new({ from: owner })

--- a/test/peripheral/523_borrowProxy_dsproxy.ts
+++ b/test/peripheral/523_borrowProxy_dsproxy.ts
@@ -27,7 +27,7 @@ import { keccak256, toUtf8Bytes } from 'ethers/lib/utils'
 import { balance, expectRevert } from '@openzeppelin/test-helpers'
 import { assert, expect } from 'chai'
 
-contract('YieldProxy - DSProxy', async (accounts) => {
+contract('BorrowProxy - DSProxy', async (accounts) => {
   let [owner, user1, user2] = accounts
 
   let env: YieldEnvironmentLite

--- a/test/peripheral/523_borrowProxy_dsproxy.ts
+++ b/test/peripheral/523_borrowProxy_dsproxy.ts
@@ -145,7 +145,7 @@ contract('YieldProxy - DSProxy', async (accounts) => {
 
         it('borrows dai for maximum fyDai', async () => {
           const calldata = borrowProxy.contract.methods
-            .borrowDaiForMaximumFYDai(pool.address, WETH, maturity1, user2, fyDaiTokens1, one)
+            .borrowDaiForMaximumFYDaiWithSignature(pool.address, WETH, maturity1, user2, fyDaiTokens1, one, '0x')
             .encodeABI()
           await dsProxy.methods['execute(address,bytes)'](borrowProxy.address, calldata, { from: user1 })
 
@@ -154,7 +154,7 @@ contract('YieldProxy - DSProxy', async (accounts) => {
 
         it("doesn't borrow dai if limit exceeded", async () => {
           const calldata = borrowProxy.contract.methods
-            .borrowDaiForMaximumFYDai(pool.address, WETH, maturity1, user2, fyDaiTokens1, daiTokens1)
+            .borrowDaiForMaximumFYDaiWithSignature(pool.address, WETH, maturity1, user2, fyDaiTokens1, daiTokens1, '0x')
             .encodeABI()
           await expectRevert(
             dsProxy.methods['execute(address,bytes)'](borrowProxy.address, calldata, { from: user1 }),
@@ -165,7 +165,7 @@ contract('YieldProxy - DSProxy', async (accounts) => {
         describe('repaying', () => {
           beforeEach(async () => {
             const calldata = borrowProxy.contract.methods
-              .borrowDaiForMaximumFYDai(pool.address, WETH, maturity1, user2, fyDaiTokens1, one)
+              .borrowDaiForMaximumFYDaiWithSignature(pool.address, WETH, maturity1, user2, fyDaiTokens1, one, '0x')
               .encodeABI()
             await dsProxy.methods['execute(address,bytes)'](borrowProxy.address, calldata, { from: user1 })
 

--- a/test/peripheral/523_borrowProxy_dsproxy.ts
+++ b/test/peripheral/523_borrowProxy_dsproxy.ts
@@ -156,7 +156,7 @@ contract('BorrowProxy - DSProxy', async (accounts) => {
             .encodeABI()
           await expectRevert(
             dsProxy.methods['execute(address,bytes)'](borrowProxy.address, calldata, { from: user1 }),
-            'YieldProxy: Too much fyDai required'
+            'BorrowProxy: Too much fyDai required'
           )
         })
 

--- a/test/peripheral/531_poolProxy_base.ts
+++ b/test/peripheral/531_poolProxy_base.ts
@@ -426,27 +426,28 @@ contract('PoolProxy', async (accounts) => {
     })
 
     it('checks missing approvals and signatures for removing liquidity by repaying', async () => {
-      let result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool2.address, { from: user9 })
+      await controller.revokeDelegate(proxy.address, { from: user2 })
+      let result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool0.address, { from: user2 })
 
       assert.equal(result[0], false)
       assert.equal(result[1], false)
       assert.equal(result[2], false)
 
-      await controller.addDelegate(proxy.address, { from: user9 })
-      result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool2.address, { from: user9 })
+      await controller.addDelegate(proxy.address, { from: user2 })
+      result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool0.address, { from: user2 })
       assert.equal(result[0], false)
       assert.equal(result[1], true)
       assert.equal(result[2], false)
 
-      await pool2.addDelegate(proxy.address, { from: user9 })
-      result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool2.address, { from: user9 })
+      await pool0.addDelegate(proxy.address, { from: user2 })
+      result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool0.address, { from: user2 })
       assert.equal(result[0], false)
       assert.equal(result[1], true)
       assert.equal(result[2], true)
 
-      // Calling `addLiquidityWithSignature` also sets the right approvals
-      await pool0.addDelegate(proxy.address, { from: user1 })
-      result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool0.address, { from: user1 })
+      const poolTokens = await pool0.balanceOf(user2)
+      await proxy.removeLiquidityEarlyDaiFixedWithSignature(pool0.address, poolTokens, '0', '0x', '0x', { from: user2 })
+      result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool0.address, { from: user2 })
       assert.equal(result[0], true)
       assert.equal(result[1], true)
       assert.equal(result[2], true)

--- a/test/peripheral/531_poolProxy_base.ts
+++ b/test/peripheral/531_poolProxy_base.ts
@@ -210,7 +210,7 @@ contract('PoolProxy', async (accounts) => {
     assert.equal(result[0], false)
     assert.equal(result[1], false)
     assert.equal(result[2], false)
-    
+
     await dai.approve(proxy.address, MAX, { from: user9 })
     result = await proxy.addLiquidityCheck(pool0.address, { from: user9 })
     assert.equal(result[0], false)
@@ -239,10 +239,7 @@ contract('PoolProxy', async (accounts) => {
     await dai.mint(user2, oneToken, { from: owner })
     await dai.approve(proxy.address, oneToken, { from: user2 })
     await controller.addDelegate(proxy.address, { from: user2 })
-    await expectRevert(
-      proxy.addLiquidity(pool0.address, oneToken, 1, { from: user2 }),
-      'YieldProxy: maxFYDai exceeded'
-    )
+    await expectRevert(proxy.addLiquidity(pool0.address, oneToken, 1, { from: user2 }), 'YieldProxy: maxFYDai exceeded')
   })
 
   describe('with proxied liquidity', () => {
@@ -334,7 +331,7 @@ contract('PoolProxy', async (accounts) => {
       assert.equal(result[0], false)
       assert.equal(result[1], false)
       assert.equal(result[2], false)
-      
+
       await controller.addDelegate(proxy.address, { from: user9 })
       result = await proxy.removeLiquidityEarlyDaiPoolCheck(pool2.address, { from: user9 })
       assert.equal(result[0], false)
@@ -434,7 +431,7 @@ contract('PoolProxy', async (accounts) => {
       assert.equal(result[0], false)
       assert.equal(result[1], false)
       assert.equal(result[2], false)
-      
+
       await controller.addDelegate(proxy.address, { from: user9 })
       result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool2.address, { from: user9 })
       assert.equal(result[0], false)
@@ -559,7 +556,9 @@ contract('PoolProxy', async (accounts) => {
         // the proxy must be a delegate in the pool0 because in order to remove
         // liquidity via the proxy we must authorize the proxy to burn from our balance
         await pool0.addDelegate(proxy.address, { from: users[i] })
-        await proxy.removeLiquidityEarlyDaiFixedWithSignature(pool0.address, poolTokens, '0', '0x', '0x', { from: users[i] }) // TODO: Test limits
+        await proxy.removeLiquidityEarlyDaiFixedWithSignature(pool0.address, poolTokens, '0', '0x', '0x', {
+          from: users[i],
+        }) // TODO: Test limits
 
         // Doesn't have pool0 tokens
         expect(await pool0.balanceOf(users[i])).to.be.bignumber.eq(ZERO)
@@ -658,7 +657,7 @@ contract('PoolProxy', async (accounts) => {
       assert.equal(result[0], false)
       assert.equal(result[1], false)
       assert.equal(result[2], false)
-      
+
       await controller.addDelegate(proxy.address, { from: user9 })
       result = await proxy.removeLiquidityMatureCheck(pool2.address, { from: user9 })
       assert.equal(result[0], false)

--- a/test/peripheral/531_poolProxy_base.ts
+++ b/test/peripheral/531_poolProxy_base.ts
@@ -96,7 +96,7 @@ contract('PoolProxy', async (accounts) => {
     await fyDai1.orchestrate(owner, keccak256(toUtf8Bytes('mint(address,uint256)')), { from: owner })
 
     // Setup PoolProxy
-    proxy = await PoolProxy.new(dai.address, chai.address, treasury.address, controller.address)
+    proxy = await PoolProxy.new(controller.address)
   })
 
   afterEach(async () => {

--- a/test/peripheral/531_poolProxy_base.ts
+++ b/test/peripheral/531_poolProxy_base.ts
@@ -239,7 +239,7 @@ contract('PoolProxy', async (accounts) => {
     await dai.mint(user2, oneToken, { from: owner })
     await dai.approve(proxy.address, oneToken, { from: user2 })
     await controller.addDelegate(proxy.address, { from: user2 })
-    await expectRevert(proxy.addLiquidity(pool0.address, oneToken, 1, { from: user2 }), 'YieldProxy: maxFYDai exceeded')
+    await expectRevert(proxy.addLiquidity(pool0.address, oneToken, 1, { from: user2 }), 'PoolProxy: maxFYDai exceeded')
   })
 
   describe('with proxied liquidity', () => {
@@ -639,11 +639,11 @@ contract('PoolProxy', async (accounts) => {
       await pool0.addDelegate(proxy.address, { from: user2 })
       await expectRevert(
         proxy.removeLiquidityEarlyDaiPool(pool0.address, poolTokens, toRay(2), '0', { from: user2 }),
-        'YieldProxy: minimumDaiPrice not reached'
+        'PoolProxy: minimumDaiPrice not reached'
       )
       await expectRevert(
         proxy.removeLiquidityEarlyDaiPool(pool0.address, poolTokens, '0', toRay(2), { from: user2 }),
-        'YieldProxy: minimumFYDaiPrice not reached'
+        'PoolProxy: minimumFYDaiPrice not reached'
       )
     })
 

--- a/test/peripheral/531_poolProxy_base.ts
+++ b/test/peripheral/531_poolProxy_base.ts
@@ -161,7 +161,7 @@ contract('PoolProxy', async (accounts) => {
       await dai.mint(user2, oneToken, { from: owner })
       await dai.approve(proxy.address, oneToken, { from: user2 })
       await controller.addDelegate(proxy.address, { from: user2 })
-      await proxy.addLiquidity(pool0.address, daiUsed, maxFYDai, { from: user2 })
+      await proxy.addLiquidityWithSignature(pool0.address, daiUsed, maxFYDai, '0x', '0x', { from: user2 })
 
       const debt = bnify((await controller.debtFYDai(CHAI, maturity0, user2)).toString())
       const posted = bnify((await controller.posted(CHAI, user2)).toString())
@@ -226,8 +226,8 @@ contract('PoolProxy', async (accounts) => {
 
           await dai.mint(users[i], oneToken.mul(2), { from: owner })
           await dai.approve(proxy.address, MAX, { from: users[i] })
-          await proxy.addLiquidity(pool0.address, oneToken, maxBorrow, { from: users[i] })
-          await proxy.addLiquidity(pool1.address, oneToken, maxBorrow, { from: users[i] })
+          await proxy.addLiquidityWithSignature(pool0.address, oneToken, maxBorrow, '0x', '0x', { from: users[i] })
+          await proxy.addLiquidityWithSignature(pool1.address, oneToken, maxBorrow, '0x', '0x', { from: users[i] })
         }
 
         // Add some funds to the system to allow for rounding losses when withdrawing chai
@@ -387,7 +387,7 @@ contract('PoolProxy', async (accounts) => {
         // the proxy must be a delegate in the pool0 because in order to remove
         // liquidity via the proxy we must authorize the proxy to burn from our balance
         await pool0.addDelegate(proxy.address, { from: user2 })
-        await proxy.removeLiquidityEarlyDaiFixed(pool0.address, poolTokens, '0', { from: user2 }) // TODO: Test limits
+        await proxy.removeLiquidityEarlyDaiFixedWithSignature(pool0.address, poolTokens, '0', '0x', '0x', { from: user2 }) // TODO: Test limits
 
         // Doesn't have pool0 tokens
         expect(await pool0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
@@ -426,7 +426,7 @@ contract('PoolProxy', async (accounts) => {
         // the proxy must be a delegate in the pool0 because in order to remove
         // liquidity via the proxy we must authorize the proxy to burn from our balance
         await pool0.addDelegate(proxy.address, { from: user2 })
-        await proxy.removeLiquidityEarlyDaiFixed(pool0.address, poolTokens, '0', { from: user2 }) // TODO: Test limits
+        await proxy.removeLiquidityEarlyDaiFixedWithSignature(pool0.address, poolTokens, '0', '0x', '0x', { from: user2 }) // TODO: Test limits
 
         // Doesn't have pool0 tokens
         expect(await pool0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
@@ -463,7 +463,7 @@ contract('PoolProxy', async (accounts) => {
           // the proxy must be a delegate in the pool0 because in order to remove
           // liquidity via the proxy we must authorize the proxy to burn from our balance
           await pool0.addDelegate(proxy.address, { from: users[i] })
-          await proxy.removeLiquidityEarlyDaiFixed(pool0.address, poolTokens, '0', { from: users[i] }) // TODO: Test limits
+          await proxy.removeLiquidityEarlyDaiFixedWithSignature(pool0.address, poolTokens, '0', '0x', '0x', { from: users[i] }) // TODO: Test limits
 
           // Doesn't have pool0 tokens
           expect(await pool0.balanceOf(users[i])).to.be.bignumber.eq(ZERO)
@@ -507,7 +507,7 @@ contract('PoolProxy', async (accounts) => {
         // the proxy must be a delegate in the pool0 because in order to remove
         // liquidity via the proxy we must authorize the proxy to burn from our balance
         await pool0.addDelegate(proxy.address, { from: user2 })
-        await proxy.removeLiquidityEarlyDaiFixed(pool0.address, poolTokens, '0', { from: user2 }) // TODO: Test limits
+        await proxy.removeLiquidityEarlyDaiFixedWithSignature(pool0.address, poolTokens, '0', '0x', '0x', { from: user2 }) // TODO: Test limits
 
         // Doesn't have pool0 tokens
         expect(await pool0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
@@ -572,7 +572,7 @@ contract('PoolProxy', async (accounts) => {
 
         await pool0.addDelegate(proxy.address, { from: user2 })
 
-        await proxy.removeLiquidityMature(pool0.address, poolTokens, { from: user2 })
+        await proxy.removeLiquidityMatureWithSignature(pool0.address, poolTokens, '0x', '0x', { from: user2 })
 
         // Doesn't have pool0 tokens
         expect(await pool0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
@@ -613,7 +613,7 @@ contract('PoolProxy', async (accounts) => {
           // the proxy must be a delegate in the pool0 because in order to remove
           // liquidity via the proxy we must authorize the proxy to burn from our balance
           await pool0.addDelegate(proxy.address, { from: users[i] })
-          await proxy.removeLiquidityMature(pool0.address, poolTokens, { from: users[i] })
+          await proxy.removeLiquidityMatureWithSignature(pool0.address, poolTokens, '0x', '0x', { from: users[i] })
 
           // Doesn't have pool0 tokens
           expect(await pool0.balanceOf(users[i])).to.be.bignumber.eq(ZERO)
@@ -639,7 +639,7 @@ contract('PoolProxy', async (accounts) => {
         for (let i in users) {
           const poolTokens = await pool0.balanceOf(users[i])
           await pool0.addDelegate(proxy.address, { from: users[i] })
-          await proxy.removeLiquidityMature(pool0.address, poolTokens, { from: users[i] })
+          await proxy.removeLiquidityMatureWithSignature(pool0.address, poolTokens, '0x', '0x', { from: users[i] })
         }
         console.log(`           Remaining Dai:   ${(await pool0.getDaiReserves()).toString()}`)
         console.log(`           Remaining fyDai: ${(await pool0.getFYDaiReserves()).toString()}`)

--- a/test/peripheral/531_poolProxy_base.ts
+++ b/test/peripheral/531_poolProxy_base.ts
@@ -45,10 +45,13 @@ contract('PoolProxy', async (accounts) => {
   let fyDai0: Contract
   let pool1: Contract
   let fyDai1: Contract
+  let pool2: Contract
+  let fyDai2: Contract
   let proxy: Contract
 
   let maturity0: number
   let maturity1: number
+  let maturity2: number
 
   const roundingProfit: any = new BN('100') // Some wei remain in proxy with each operation due to rounding
 
@@ -76,8 +79,9 @@ contract('PoolProxy', async (accounts) => {
     const block = await web3.eth.getBlockNumber()
     maturity0 = (await web3.eth.getBlock(block)).timestamp + 15778476 // Six months
     maturity1 = (await web3.eth.getBlock(block)).timestamp + 31556952 // One year
+    maturity2 = (await web3.eth.getBlock(block)).timestamp + 63113904 // Two years
 
-    env = await YieldEnvironmentLite.setup([maturity0, maturity1])
+    env = await YieldEnvironmentLite.setup([maturity0, maturity1, maturity2])
     maker = env.maker
     weth = env.maker.weth
     dai = env.maker.dai
@@ -86,103 +90,236 @@ contract('PoolProxy', async (accounts) => {
     controller = env.controller
     fyDai0 = env.fyDais[0]
     fyDai1 = env.fyDais[1]
+    fyDai2 = env.fyDais[2]
 
     // Setup Pools
     pool0 = await Pool.new(dai.address, fyDai0.address, 'Name', 'Symbol', { from: owner })
     pool1 = await Pool.new(dai.address, fyDai1.address, 'Name', 'Symbol', { from: owner })
+    pool2 = await Pool.new(dai.address, fyDai2.address, 'Name', 'Symbol', { from: owner })
 
     // Allow owner to mint fyDai the sneaky way, without recording a debt in controller
     await fyDai0.orchestrate(owner, keccak256(toUtf8Bytes('mint(address,uint256)')), { from: owner })
     await fyDai1.orchestrate(owner, keccak256(toUtf8Bytes('mint(address,uint256)')), { from: owner })
+    await fyDai2.orchestrate(owner, keccak256(toUtf8Bytes('mint(address,uint256)')), { from: owner })
 
     // Setup PoolProxy
     proxy = await PoolProxy.new(controller.address)
+
+    // Onboard user1
+    await env.maker.chai.approve(proxy.address, MAX, { from: user1 })
+    await dai.approve(proxy.address, MAX, { from: user1 })
+    await dai.approve(pool0.address, MAX, { from: user1 })
+    await controller.addDelegate(proxy.address, { from: user1 })
+
+    // Initialize pools
+    const additionalFYDaiReserves = toWad(34.4)
+
+    await env.maker.getDai(user1, initialDai, rate1)
+    await dai.approve(pool0.address, initialDai, { from: user1 })
+    await pool0.mint(user1, user1, initialDai, { from: user1 })
+    await fyDai0.mint(owner, additionalFYDaiReserves, { from: owner })
+    await fyDai0.approve(pool0.address, additionalFYDaiReserves, { from: owner })
+    await pool0.sellFYDai(owner, owner, additionalFYDaiReserves, { from: owner })
+
+    await env.maker.getDai(user1, initialDai, rate1)
+    await dai.approve(pool1.address, initialDai, { from: user1 })
+    await pool1.mint(user1, user1, initialDai, { from: user1 })
+    await fyDai1.mint(owner, additionalFYDaiReserves, { from: owner })
+    await fyDai1.approve(pool1.address, additionalFYDaiReserves, { from: owner })
+    await pool1.sellFYDai(owner, owner, additionalFYDaiReserves, { from: owner })
+
+    await env.maker.getDai(user1, initialDai, rate1)
+    await dai.approve(pool2.address, initialDai, { from: user1 })
+    await pool2.mint(user1, user1, initialDai, { from: user1 })
+    await fyDai2.mint(owner, additionalFYDaiReserves, { from: owner })
+    await fyDai2.approve(pool2.address, additionalFYDaiReserves, { from: owner })
+    await pool2.sellFYDai(owner, owner, additionalFYDaiReserves, { from: owner })
   })
 
   afterEach(async () => {
     await helper.revertToSnapshot(snapshotId)
   })
 
-  describe('with onboarding', () => {
+  it('mints liquidity tokens with dai only', async () => {
+    const oneToken = toWad(1)
+
+    const poolTokensBefore = bnify((await pool0.balanceOf(user2)).toString())
+    const maxFYDai = oneToken
+
+    const daiReserves = bnify((await dai.balanceOf(pool0.address)).toString())
+    const fyDaiReserves = bnify((await fyDai0.balanceOf(pool0.address)).toString())
+    const daiUsed = bnify(oneToken)
+    const poolSupply = bnify((await pool0.totalSupply()).toString())
+
+    // console.log('          adding liquidity...')
+    // console.log('          daiReserves: %d', daiReserves.toString())    // d_0
+    // console.log('          fyDaiReserves: %d', fyDaiReserves.toString())  // y_0
+    // console.log('          daiUsed: %d', daiUsed.toString())            // d_used
+
+    // https://www.desmos.com/calculator/bl2knrktlt
+    const expectedDaiIn = daiIn(daiReserves, fyDaiReserves, daiUsed) // d_in
+    const expectedDebt = fyDaiIn(daiReserves, fyDaiReserves, daiUsed) // y_in
+    // console.log('          expected daiIn: %d', expectedDaiIn)
+    // console.log('          expected fyDaiIn: %d', expectedDebt)
+
+    // console.log('          chi: %d', chi1)
+    const expectedPosted = postedIn(expectedDebt, chi1)
+    // console.log('          expected posted: %d', expectedPosted)         // p_chai
+
+    // https://www.desmos.com/calculator/w9qorhrjbw
+    // console.log('          Pool supply: %d', poolSupply)                 // s
+    const expectedMinted = mintedOut(poolSupply, expectedDaiIn, daiReserves) // m
+    // console.log('          expected minted: %d', expectedMinted)
+
+    await dai.mint(user2, oneToken, { from: owner })
+    await dai.approve(proxy.address, oneToken, { from: user2 })
+    await controller.addDelegate(proxy.address, { from: user2 })
+    await proxy.addLiquidityWithSignature(pool0.address, daiUsed, maxFYDai, '0x', '0x', { from: user2 })
+
+    const debt = bnify((await controller.debtFYDai(CHAI, maturity0, user2)).toString())
+    const posted = bnify((await controller.posted(CHAI, user2)).toString())
+    const minted = bnify((await pool0.balanceOf(user2)).toString()).sub(poolTokensBefore)
+
+    //asserts
+    assert.equal(
+      debt.toString(),
+      expectedDebt.toString(),
+      'User2 should have ' + expectedDebt + ' fyDai debt, instead has ' + debt.toString()
+    )
+    assert.equal(
+      posted.toString(),
+      expectedPosted.toString(),
+      'User2 should have ' + expectedPosted + ' posted chai, instead has ' + posted.toString()
+    )
+    assert.equal(
+      minted.toString(),
+      expectedMinted.toString(),
+      'User2 should have ' + expectedMinted + ' pool0 tokens, instead has ' + minted.toString()
+    )
+    // Proxy doesn't keep dai (beyond rounding)
+    expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+    // Proxy doesn't keep fyDai (beyond rounding)
+    expect(await fyDai0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+    // Proxy doesn't keep liquidity (beyond rounding)
+    expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+  })
+
+  it('checks missing approvals and signatures for adding liquidity', async () => {
+    let result = await proxy.addLiquidityCheck(pool0.address, { from: user9 })
+
+    assert.equal(result[0], false)
+    assert.equal(result[1], false)
+    assert.equal(result[2], false)
+    
+    await dai.approve(proxy.address, MAX, { from: user9 })
+    result = await proxy.addLiquidityCheck(pool0.address, { from: user9 })
+    assert.equal(result[0], false)
+    assert.equal(result[1], true)
+    assert.equal(result[2], false)
+
+    await controller.addDelegate(proxy.address, { from: user9 })
+    result = await proxy.addLiquidityCheck(pool0.address, { from: user9 })
+    assert.equal(result[0], false)
+    assert.equal(result[1], true)
+    assert.equal(result[2], true)
+
+    const oneToken = toWad(1)
+    await dai.mint(user9, oneToken, { from: owner })
+    await proxy.addLiquidityWithSignature(pool0.address, oneToken, MAX, '0x', '0x', { from: user9 })
+
+    result = await proxy.addLiquidityCheck(pool0.address, { from: user9 })
+    assert.equal(result[0], true)
+    assert.equal(result[1], true)
+    assert.equal(result[2], true)
+  })
+
+  it('does not allow borrowing more than max amount', async () => {
+    const oneToken = bnify(toWad(1))
+
+    await dai.mint(user2, oneToken, { from: owner })
+    await dai.approve(proxy.address, oneToken, { from: user2 })
+    await controller.addDelegate(proxy.address, { from: user2 })
+    await expectRevert(
+      proxy.addLiquidity(pool0.address, oneToken, 1, { from: user2 }),
+      'YieldProxy: maxFYDai exceeded'
+    )
+  })
+
+  describe('with proxied liquidity', () => {
     beforeEach(async () => {
-      await env.maker.chai.approve(proxy.address, MAX, { from: user1 })
-      await dai.approve(proxy.address, MAX, { from: user1 })
-      await dai.approve(pool0.address, MAX, { from: user1 })
-      await controller.addDelegate(proxy.address, { from: user1 })
+      const additionalFYDai = toWad(34.4)
 
-      const additionalFYDaiReserves = toWad(34.4)
+      // Add liquidity to the pool0
+      await fyDai0.mint(owner, additionalFYDai, { from: owner })
+      await fyDai0.approve(pool0.address, additionalFYDai, { from: owner })
+      await pool0.sellFYDai(owner, owner, additionalFYDai, { from: owner })
 
-      await env.maker.getDai(user1, initialDai, rate1)
-      await dai.approve(pool0.address, initialDai, { from: user1 })
-      await pool0.mint(user1, user1, initialDai, { from: user1 })
-      await fyDai0.mint(owner, additionalFYDaiReserves, { from: owner })
-      await fyDai0.approve(pool0.address, additionalFYDaiReserves, { from: owner })
-      await pool0.sellFYDai(owner, owner, additionalFYDaiReserves, { from: owner })
+      // Add liquidity to the pool1
+      await fyDai1.mint(owner, additionalFYDai, { from: owner })
+      await fyDai1.approve(pool1.address, additionalFYDai, { from: owner })
+      await pool1.sellFYDai(owner, owner, additionalFYDai, { from: owner })
 
-      await env.maker.getDai(user1, initialDai, rate1)
-      await dai.approve(pool1.address, initialDai, { from: user1 })
-      await pool1.mint(user1, user1, initialDai, { from: user1 })
-      await fyDai1.mint(owner, additionalFYDaiReserves, { from: owner })
-      await fyDai1.approve(pool1.address, additionalFYDaiReserves, { from: owner })
-      await pool1.sellFYDai(owner, owner, additionalFYDaiReserves, { from: owner })
+      const oneToken = bnify(toWad(1))
+      const maxBorrow = oneToken
+      // Give some pool0 tokens to user2
+      const users = [user2, user3, user4, user5, user6, user7, user8]
+      for (let i in users) {
+        await controller.addDelegate(proxy.address, { from: users[i] })
+
+        await dai.mint(users[i], oneToken.mul(2), { from: owner })
+        await dai.approve(proxy.address, MAX, { from: users[i] })
+        await proxy.addLiquidityWithSignature(pool0.address, oneToken, maxBorrow, '0x', '0x', { from: users[i] })
+        await proxy.addLiquidityWithSignature(pool1.address, oneToken, maxBorrow, '0x', '0x', { from: users[i] })
+      }
+
+      // Add some funds to the system to allow for rounding losses when withdrawing chai
+      await maker.getChai(owner, 1000, chi1, rate1) // getChai can't get very small amounts
+      await chai.approve(treasury.address, precision, { from: owner })
+      await controller.post(CHAI, owner, owner, precision, { from: owner })
+
+      await weth.deposit({ value: toWad(1).toString() })
+      await weth.approve(treasury.address, MAX, { from: owner })
+      await controller.post(WETH, owner, owner, toWad(1).toString(), { from: owner })
     })
 
-    it('mints liquidity tokens with dai only', async () => {
-      const oneToken = toWad(1)
+    it('removes liquidity early by selling', async () => {
+      // This scenario replicates a user with more debt that can be repaid by burning liquidity tokens.
+      // It uses the pool0 to sell the obtained Dai, so it should be used when the pool0 rate is better than 1:1.
+      // Sells once, repays once, and does nothing else so the gas cost is 178K.
 
-      const poolTokensBefore = bnify((await pool0.balanceOf(user2)).toString())
-      const maxFYDai = oneToken
+      // Create some debt, so that there is no FYDai from the burn left to sell.
+      await maker.getChai(user2, chaiTokens1, chi1, rate1)
+      await chai.approve(treasury.address, chaiTokens1, { from: user2 })
+      await controller.post(CHAI, user2, user2, chaiTokens1, { from: user2 })
+      const toBorrow = (await env.unlockedOf(CHAI, user2)).toString()
+      await controller.borrow(CHAI, maturity0, user2, user2, toBorrow, { from: user2 })
 
-      const daiReserves = bnify((await dai.balanceOf(pool0.address)).toString())
-      const fyDaiReserves = bnify((await fyDai0.balanceOf(pool0.address)).toString())
-      const daiUsed = bnify(oneToken)
-      const poolSupply = bnify((await pool0.totalSupply()).toString())
+      const poolTokens = await pool0.balanceOf(user2)
+      const debt = await controller.debtFYDai(CHAI, maturity0, user2)
+      const daiBalance = await dai.balanceOf(user2)
 
-      // console.log('          adding liquidity...')
-      // console.log('          daiReserves: %d', daiReserves.toString())    // d_0
-      // console.log('          fyDaiReserves: %d', fyDaiReserves.toString())  // y_0
-      // console.log('          daiUsed: %d', daiUsed.toString())            // d_used
+      // Has pool0 tokens
+      expect(poolTokens).to.be.bignumber.gt(ZERO)
+      // Has fyDai debt
+      expect(debt).to.be.bignumber.gt(ZERO)
+      // Doesn't have dai
+      expect(daiBalance).to.be.bignumber.eq(ZERO)
+      // Has fyDai
+      expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(toBorrow)
 
-      // https://www.desmos.com/calculator/bl2knrktlt
-      const expectedDaiIn = daiIn(daiReserves, fyDaiReserves, daiUsed) // d_in
-      const expectedDebt = fyDaiIn(daiReserves, fyDaiReserves, daiUsed) // y_in
-      // console.log('          expected daiIn: %d', expectedDaiIn)
-      // console.log('          expected fyDaiIn: %d', expectedDebt)
+      // the proxy must be a delegate in the pool0 because in order to remove
+      // liquidity via the proxy we must authorize the proxy to burn from our balance
+      await pool0.addDelegate(proxy.address, { from: user2 })
+      await proxy.removeLiquidityEarlyDaiPool(pool0.address, poolTokens, '0', '0', { from: user2 }) // TODO: Test limits
 
-      // console.log('          chi: %d', chi1)
-      const expectedPosted = postedIn(expectedDebt, chi1)
-      // console.log('          expected posted: %d', expectedPosted)         // p_chai
-
-      // https://www.desmos.com/calculator/w9qorhrjbw
-      // console.log('          Pool supply: %d', poolSupply)                 // s
-      const expectedMinted = mintedOut(poolSupply, expectedDaiIn, daiReserves) // m
-      // console.log('          expected minted: %d', expectedMinted)
-
-      await dai.mint(user2, oneToken, { from: owner })
-      await dai.approve(proxy.address, oneToken, { from: user2 })
-      await controller.addDelegate(proxy.address, { from: user2 })
-      await proxy.addLiquidityWithSignature(pool0.address, daiUsed, maxFYDai, '0x', '0x', { from: user2 })
-
-      const debt = bnify((await controller.debtFYDai(CHAI, maturity0, user2)).toString())
-      const posted = bnify((await controller.posted(CHAI, user2)).toString())
-      const minted = bnify((await pool0.balanceOf(user2)).toString()).sub(poolTokensBefore)
-
-      //asserts
-      assert.equal(
-        debt.toString(),
-        expectedDebt.toString(),
-        'User2 should have ' + expectedDebt + ' fyDai debt, instead has ' + debt.toString()
-      )
-      assert.equal(
-        posted.toString(),
-        expectedPosted.toString(),
-        'User2 should have ' + expectedPosted + ' posted chai, instead has ' + posted.toString()
-      )
-      assert.equal(
-        minted.toString(),
-        expectedMinted.toString(),
-        'User2 should have ' + expectedMinted + ' pool0 tokens, instead has ' + minted.toString()
-      )
+      // Doesn't have pool0 tokens
+      expect(await pool0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
+      // Has less fyDai debt
+      expect(await controller.debtFYDai(CHAI, maturity0, user2)).to.be.bignumber.lt(debt)
+      // Got some dai
+      expect(await dai.balanceOf(user2)).to.be.bignumber.gt(ZERO)
+      // Has the same fyDai
+      expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(toBorrow)
       // Proxy doesn't keep dai (beyond rounding)
       expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
       // Proxy doesn't keep fyDai (beyond rounding)
@@ -191,143 +328,407 @@ contract('PoolProxy', async (accounts) => {
       expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
     })
 
-    it('does not allow borrowing more than max amount', async () => {
-      const oneToken = bnify(toWad(1))
+    it('checks missing approvals and signatures for removing liquidity by selling', async () => {
+      let result = await proxy.removeLiquidityEarlyDaiPoolCheck(pool2.address, { from: user9 })
 
-      await dai.mint(user2, oneToken, { from: owner })
-      await dai.approve(proxy.address, oneToken, { from: user2 })
-      await controller.addDelegate(proxy.address, { from: user2 })
+      assert.equal(result[0], false)
+      assert.equal(result[1], false)
+      assert.equal(result[2], false)
+      
+      await controller.addDelegate(proxy.address, { from: user9 })
+      result = await proxy.removeLiquidityEarlyDaiPoolCheck(pool2.address, { from: user9 })
+      assert.equal(result[0], false)
+      assert.equal(result[1], true)
+      assert.equal(result[2], false)
+
+      await pool2.addDelegate(proxy.address, { from: user9 })
+      result = await proxy.removeLiquidityEarlyDaiPoolCheck(pool2.address, { from: user9 })
+      assert.equal(result[0], false)
+      assert.equal(result[1], true)
+      assert.equal(result[2], true)
+
+      // Calling `addLiquidityWithSignature` also sets the right approvals
+      await pool0.addDelegate(proxy.address, { from: user1 })
+      result = await proxy.removeLiquidityEarlyDaiPoolCheck(pool0.address, { from: user1 })
+      assert.equal(result[0], true)
+      assert.equal(result[1], true)
+      assert.equal(result[2], true)
+    })
+
+    it('everyone can remove liquidity early by selling', async () => {
+      const users = [user2, user3, user4, user5, user6, user7, user8]
+      for (let i in users) {
+        const poolTokens = await pool0.balanceOf(users[i])
+        const debt = await controller.debtFYDai(CHAI, maturity0, users[i])
+        const daiBalance = await dai.balanceOf(users[i])
+
+        // Has pool0 tokens
+        expect(poolTokens).to.be.bignumber.gt(ZERO)
+        // Has fyDai debt
+        expect(debt).to.be.bignumber.gt(ZERO)
+        // Doesn't have dai
+        expect(daiBalance).to.be.bignumber.eq(ZERO)
+
+        // the proxy must be a delegate in the pool0 because in order to remove
+        // liquidity via the proxy we must authorize the proxy to burn from our balance
+        await pool0.addDelegate(proxy.address, { from: users[i] })
+        await proxy.removeLiquidityEarlyDaiPool(pool0.address, poolTokens, '0', '0', { from: users[i] }) // TODO: Test limits
+
+        // Doesn't have pool0 tokens
+        expect(await pool0.balanceOf(users[i])).to.be.bignumber.eq(ZERO)
+        // Has less fyDai debt
+        expect(await controller.debtFYDai(CHAI, maturity0, users[i])).to.be.bignumber.lt(debt)
+        // Got some dai
+        expect(await dai.balanceOf(users[i])).to.be.bignumber.gt(ZERO)
+        // Proxy doesn't keep dai (beyond rounding)
+        expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+        // Proxy doesn't keep fyDai (beyond rounding)
+        expect(await fyDai0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+        // Proxy doesn't keep liquidity (beyond rounding)
+        expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+      }
+    })
+
+    it('removes liquidity early by selling, with some fyDai being sold in the pool0', async () => {
+      // This scenario replicates a user with debt that can be repaid by burning liquidity tokens.
+      // It uses the pool0 to sell the obtained Dai, so it should be used when the pool0 rate is better than 1:1.
+      // Sells twice, repays once, and and withdraws, so the gas cost is about 400K.
+
+      const poolTokens = await pool0.balanceOf(user2)
+      const debt = await controller.debtFYDai(CHAI, maturity0, user2)
+      const daiBalance = await dai.balanceOf(user2)
+
+      // Has pool0 tokens
+      expect(poolTokens).to.be.bignumber.gt(ZERO)
+      // Has fyDai debt
+      expect(debt).to.be.bignumber.gt(ZERO)
+      // Doesn't have dai
+      expect(daiBalance).to.be.bignumber.eq(ZERO)
+      // Doesn't have fyDai
+      expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
+
+      // the proxy must be a delegate in the pool0 because in order to remove
+      // liquidity via the proxy we must authorize the proxy to burn from our balance
+      await pool0.addDelegate(proxy.address, { from: user2 })
+      await proxy.removeLiquidityEarlyDaiPool(pool0.address, poolTokens, '0', '0', { from: user2 }) // TODO: Test limits
+
+      // Doesn't have pool0 tokens
+      expect(await pool0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
+      // Has less fyDai debt
+      expect(await controller.debtFYDai(CHAI, maturity0, user2)).to.be.bignumber.lt(debt)
+      // Has more dai
+      expect(await dai.balanceOf(user2)).to.be.bignumber.gt(daiBalance)
+      // Doesn't have fyDai
+      expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
+      // Proxy doesn't keep dai (beyond rounding)
+      expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+      // Proxy doesn't keep fyDai (beyond rounding)
+      expect(await fyDai0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+      // Proxy doesn't keep liquidity (beyond rounding)
+      expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+    })
+
+    it('checks missing approvals and signatures for removing liquidity by repaying', async () => {
+      let result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool2.address, { from: user9 })
+
+      assert.equal(result[0], false)
+      assert.equal(result[1], false)
+      assert.equal(result[2], false)
+      
+      await controller.addDelegate(proxy.address, { from: user9 })
+      result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool2.address, { from: user9 })
+      assert.equal(result[0], false)
+      assert.equal(result[1], true)
+      assert.equal(result[2], false)
+
+      await pool2.addDelegate(proxy.address, { from: user9 })
+      result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool2.address, { from: user9 })
+      assert.equal(result[0], false)
+      assert.equal(result[1], true)
+      assert.equal(result[2], true)
+
+      // Calling `addLiquidityWithSignature` also sets the right approvals
+      await pool0.addDelegate(proxy.address, { from: user1 })
+      result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool0.address, { from: user1 })
+      assert.equal(result[0], true)
+      assert.equal(result[1], true)
+      assert.equal(result[2], true)
+    })
+
+    it('removes liquidity early by repaying, and uses all in paying debt', async () => {
+      // This scenario replicates a user with more debt that can be repaid with fyDai and Dai obtained by burning liquidity tokens.
+      // It repays with Dai at the Controller, so it should be used when the pool0 rate is worse than 1:1.
+      // Repays fyDai and Dai, sells or withdraws withdraws nothing so the gas cost is 300K.
+
+      // Create some debt, so that there is no FYDai from the burn left to sell.
+      await maker.getChai(user2, chaiTokens1, chi1, rate1)
+      await chai.approve(treasury.address, chaiTokens1, { from: user2 })
+      await controller.post(CHAI, user2, user2, chaiTokens1, { from: user2 })
+      const toBorrow = (await env.unlockedOf(CHAI, user2)).toString()
+      await controller.borrow(CHAI, maturity0, user2, user2, toBorrow, { from: user2 })
+
+      const poolTokens = await pool0.balanceOf(user2)
+      const debt = await controller.debtFYDai(CHAI, maturity0, user2)
+      const daiBalance = await dai.balanceOf(user2)
+
+      // Has pool0 tokens
+      expect(poolTokens).to.be.bignumber.gt(ZERO)
+      // Has fyDai debt
+      expect(debt).to.be.bignumber.gt(ZERO)
+      // Doesn't have dai
+      expect(daiBalance).to.be.bignumber.eq(ZERO)
+      // Has fyDai
+      expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(toBorrow)
+
+      // the proxy must be a delegate in the pool0 because in order to remove
+      // liquidity via the proxy we must authorize the proxy to burn from our balance
+      await pool0.addDelegate(proxy.address, { from: user2 })
+      await proxy.removeLiquidityEarlyDaiFixedWithSignature(pool0.address, poolTokens, '0', '0x', '0x', { from: user2 }) // TODO: Test limits
+
+      // Doesn't have pool0 tokens
+      expect(await pool0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
+      // Has less fyDai debt
+      expect(await controller.debtFYDai(CHAI, maturity0, user2)).to.be.bignumber.lt(debt)
+      // Doesn't have dai
+      expect(daiBalance).to.be.bignumber.eq(ZERO)
+      // Has the same fyDai
+      expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(toBorrow)
+      // Proxy doesn't keep dai (beyond rounding)
+      expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+      // Proxy doesn't keep fyDai (beyond rounding)
+      expect(await fyDai0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+      // Proxy doesn't keep liquidity (beyond rounding)
+      expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+    })
+
+    it('removes liquidity early by repaying, and has Dai left', async () => {
+      // This scenario replicates a user with debt that can be repaid with fyDai and Dai obtained by burning liquidity tokens.
+      // It repays with Dai at the Controller, so it should be used when the pool0 rate is worse than 1:1.
+      // Repays fyDai and Dai, withdraws Dai and Chai so the gas cost is 394K.
+
+      const poolTokens = await pool0.balanceOf(user2)
+      const debt = await controller.debtFYDai(CHAI, maturity0, user2)
+      const daiBalance = await dai.balanceOf(user2)
+
+      // Has pool0 tokens
+      expect(poolTokens).to.be.bignumber.gt(ZERO)
+      // Has fyDai debt
+      expect(debt).to.be.bignumber.gt(ZERO)
+      // Doesn't have dai
+      expect(daiBalance).to.be.bignumber.eq(ZERO)
+      // Doesn't have fyDai
+      expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
+
+      // the proxy must be a delegate in the pool0 because in order to remove
+      // liquidity via the proxy we must authorize the proxy to burn from our balance
+      await pool0.addDelegate(proxy.address, { from: user2 })
+      await proxy.removeLiquidityEarlyDaiFixedWithSignature(pool0.address, poolTokens, '0', '0x', '0x', { from: user2 }) // TODO: Test limits
+
+      // Doesn't have pool0 tokens
+      expect(await pool0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
+      // Has less fyDai debt
+      expect(await controller.debtFYDai(CHAI, maturity0, user2)).to.be.bignumber.lt(debt)
+      // Has more dai
+      expect(await dai.balanceOf(user2)).to.be.bignumber.gt(daiBalance)
+      // Doesn't have fyDai
+      expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
+      // Proxy doesn't keep dai (beyond rounding)
+      expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+      // Proxy doesn't keep fyDai (beyond rounding)
+      expect(await fyDai0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+      // Proxy doesn't keep liquidity (beyond rounding)
+      expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+    })
+
+    it('everyone can remove liquidity early by repaying', async () => {
+      const users = [user2, user3, user4, user5, user6, user7, user8]
+      for (let i in users) {
+        const poolTokens = await pool0.balanceOf(users[i])
+        const debt = await controller.debtFYDai(CHAI, maturity0, users[i])
+        const daiBalance = await dai.balanceOf(users[i])
+
+        // Has pool0 tokens
+        expect(poolTokens).to.be.bignumber.gt(ZERO)
+        // Has fyDai debt
+        expect(debt).to.be.bignumber.gt(ZERO)
+        // Doesn't have dai
+        expect(daiBalance).to.be.bignumber.eq(ZERO)
+        // Doesn't have fyDai
+        expect(await fyDai0.balanceOf(users[i])).to.be.bignumber.eq(ZERO)
+
+        // the proxy must be a delegate in the pool0 because in order to remove
+        // liquidity via the proxy we must authorize the proxy to burn from our balance
+        await pool0.addDelegate(proxy.address, { from: users[i] })
+        await proxy.removeLiquidityEarlyDaiFixedWithSignature(pool0.address, poolTokens, '0', '0x', '0x', { from: users[i] }) // TODO: Test limits
+
+        // Doesn't have pool0 tokens
+        expect(await pool0.balanceOf(users[i])).to.be.bignumber.eq(ZERO)
+        // Has less fyDai debt
+        expect(await controller.debtFYDai(CHAI, maturity0, users[i])).to.be.bignumber.lt(debt)
+        // Has more dai
+        expect(await dai.balanceOf(users[i])).to.be.bignumber.gt(daiBalance)
+        // Doesn't have fyDai
+        expect(await fyDai0.balanceOf(users[i])).to.be.bignumber.eq(ZERO)
+        // Proxy doesn't keep dai (beyond rounding)
+        expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+        // Proxy doesn't keep fyDai (beyond rounding)
+        expect(await fyDai0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+        // Proxy doesn't keep liquidity (beyond rounding)
+        expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+      }
+    })
+
+    it('removes liquidity early by repaying, and has Dai and fyDai left', async () => {
+      // This scenario replicates a user with debt that can be repaid with fyDai and Dai obtained by burning liquidity tokens.
+      // It repays with Dai at the Controller, so it should be used when the pool0 rate is worse than 1:1.
+      // Repays fyDai, sells fyDai, withdraws Dai and Chai so the gas cost is 333K.
+
+      const poolTokens = await pool0.balanceOf(user2)
+      const debt = await controller.debtFYDai(CHAI, maturity0, user2)
+      const daiBalance = await dai.balanceOf(user2)
+
+      // Has pool0 tokens
+      expect(poolTokens).to.be.bignumber.gt(ZERO)
+      // Has fyDai debt
+      expect(debt).to.be.bignumber.gt(ZERO)
+      // Doesn't have dai
+      expect(daiBalance).to.be.bignumber.eq(ZERO)
+      // Doesn't have fyDai
+      expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
+
+      // Pay some debt, so that there is FYDai from the burn left to sell.
+      await fyDai0.mint(user2, debt.div(new BN('2')), { from: owner })
+      await controller.repayFYDai(CHAI, maturity0, user2, user2, debt.div(new BN('2')), { from: user2 })
+
+      // the proxy must be a delegate in the pool0 because in order to remove
+      // liquidity via the proxy we must authorize the proxy to burn from our balance
+      await pool0.addDelegate(proxy.address, { from: user2 })
+      await proxy.removeLiquidityEarlyDaiFixedWithSignature(pool0.address, poolTokens, '0', '0x', '0x', { from: user2 }) // TODO: Test limits
+
+      // Doesn't have pool0 tokens
+      expect(await pool0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
+      // Has less fyDai debt
+      expect(await controller.debtFYDai(CHAI, maturity0, user2)).to.be.bignumber.lt(debt)
+      // Has more dai
+      expect(await dai.balanceOf(user2)).to.be.bignumber.gt(daiBalance)
+      // Doesn't have fyDai
+      expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
+      // Proxy doesn't keep dai (beyond rounding)
+      expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+      // Proxy doesn't keep fyDai (beyond rounding)
+      expect(await fyDai0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+      // Proxy doesn't keep liquidity (beyond rounding)
+      expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+    })
+
+    it("doesn't remove liquidity if minimum prices not achieved", async () => {
+      const poolTokens = await pool0.balanceOf(user2)
+      const debt = await controller.debtFYDai(CHAI, maturity0, user2)
+      const daiBalance = await dai.balanceOf(user2)
+
+      // Has pool0 tokens
+      expect(poolTokens).to.be.bignumber.gt(ZERO)
+      // Has fyDai debt
+      expect(debt).to.be.bignumber.gt(ZERO)
+      // Doesn't have dai
+      expect(daiBalance).to.be.bignumber.eq(ZERO)
+      // Doesn't have fyDai
+      expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
+
+      // the proxy must be a delegate in the pool0 because in order to remove
+      // liquidity via the proxy we must authorize the proxy to burn from our balance
+      await pool0.addDelegate(proxy.address, { from: user2 })
       await expectRevert(
-        proxy.addLiquidity(pool0.address, oneToken, 1, { from: user2 }),
-        'YieldProxy: maxFYDai exceeded'
+        proxy.removeLiquidityEarlyDaiPool(pool0.address, poolTokens, toRay(2), '0', { from: user2 }),
+        'YieldProxy: minimumDaiPrice not reached'
+      )
+      await expectRevert(
+        proxy.removeLiquidityEarlyDaiPool(pool0.address, poolTokens, '0', toRay(2), { from: user2 }),
+        'YieldProxy: minimumFYDaiPrice not reached'
       )
     })
 
-    describe('with proxied liquidity', () => {
-      beforeEach(async () => {
-        const additionalFYDai = toWad(34.4)
+    it('checks missing approvals and signatures for removing mature liquidity', async () => {
+      await helper.advanceTime(31556952)
+      await helper.advanceBlock()
+      await fyDai0.mature()
 
-        // Add liquidity to the pool0
-        await fyDai0.mint(owner, additionalFYDai, { from: owner })
-        await fyDai0.approve(pool0.address, additionalFYDai, { from: owner })
-        await pool0.sellFYDai(owner, owner, additionalFYDai, { from: owner })
+      let result = await proxy.removeLiquidityMatureCheck(pool2.address, { from: user9 })
 
-        // Add liquidity to the pool1
-        await fyDai1.mint(owner, additionalFYDai, { from: owner })
-        await fyDai1.approve(pool1.address, additionalFYDai, { from: owner })
-        await pool1.sellFYDai(owner, owner, additionalFYDai, { from: owner })
+      assert.equal(result[0], false)
+      assert.equal(result[1], false)
+      assert.equal(result[2], false)
+      
+      await controller.addDelegate(proxy.address, { from: user9 })
+      result = await proxy.removeLiquidityMatureCheck(pool2.address, { from: user9 })
+      assert.equal(result[0], false)
+      assert.equal(result[1], true)
+      assert.equal(result[2], false)
 
-        const oneToken = bnify(toWad(1))
-        const maxBorrow = oneToken
-        // Give some pool0 tokens to user2
-        const users = [user2, user3, user4, user5, user6, user7, user8, user9]
-        for (let i in users) {
-          await controller.addDelegate(proxy.address, { from: users[i] })
+      await pool2.addDelegate(proxy.address, { from: user9 })
+      result = await proxy.removeLiquidityMatureCheck(pool2.address, { from: user9 })
+      assert.equal(result[0], false)
+      assert.equal(result[1], true)
+      assert.equal(result[2], true)
 
-          await dai.mint(users[i], oneToken.mul(2), { from: owner })
-          await dai.approve(proxy.address, MAX, { from: users[i] })
-          await proxy.addLiquidityWithSignature(pool0.address, oneToken, maxBorrow, '0x', '0x', { from: users[i] })
-          await proxy.addLiquidityWithSignature(pool1.address, oneToken, maxBorrow, '0x', '0x', { from: users[i] })
-        }
+      const poolTokens = await pool0.balanceOf(user2)
+      await pool0.addDelegate(proxy.address, { from: user2 })
+      await proxy.removeLiquidityMatureWithSignature(pool0.address, poolTokens, '0x', '0x', { from: user2 })
 
-        // Add some funds to the system to allow for rounding losses when withdrawing chai
-        await maker.getChai(owner, 1000, chi1, rate1) // getChai can't get very small amounts
-        await chai.approve(treasury.address, precision, { from: owner })
-        await controller.post(CHAI, owner, owner, precision, { from: owner })
+      result = await proxy.removeLiquidityMatureCheck(pool0.address, { from: user2 })
+      assert.equal(result[0], true)
+      assert.equal(result[1], true)
+      assert.equal(result[2], true)
+    })
 
-        await weth.deposit({ value: toWad(1).toString() })
-        await weth.approve(treasury.address, MAX, { from: owner })
-        await controller.post(WETH, owner, owner, toWad(1).toString(), { from: owner })
-      })
+    it('removes liquidity after maturity by redeeming', async () => {
+      await helper.advanceTime(31556952)
+      await helper.advanceBlock()
+      await fyDai0.mature()
 
-      it('removes liquidity early by selling', async () => {
-        // This scenario replicates a user with more debt that can be repaid by burning liquidity tokens.
-        // It uses the pool0 to sell the obtained Dai, so it should be used when the pool0 rate is better than 1:1.
-        // Sells once, repays once, and does nothing else so the gas cost is 178K.
+      const poolTokens = await pool0.balanceOf(user2)
+      const debt = await controller.debtFYDai(CHAI, maturity0, user2)
+      const daiBalance = await dai.balanceOf(user2)
 
-        // Create some debt, so that there is no FYDai from the burn left to sell.
-        await maker.getChai(user2, chaiTokens1, chi1, rate1)
-        await chai.approve(treasury.address, chaiTokens1, { from: user2 })
-        await controller.post(CHAI, user2, user2, chaiTokens1, { from: user2 })
-        const toBorrow = (await env.unlockedOf(CHAI, user2)).toString()
-        await controller.borrow(CHAI, maturity0, user2, user2, toBorrow, { from: user2 })
+      // Has pool0 tokens
+      expect(poolTokens).to.be.bignumber.gt(ZERO)
+      // Has fyDai debt
+      expect(debt).to.be.bignumber.gt(ZERO)
+      // Doesn't have dai
+      expect(daiBalance).to.be.bignumber.eq(ZERO)
+      // Doesn't have fyDai
+      expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
 
-        const poolTokens = await pool0.balanceOf(user2)
-        const debt = await controller.debtFYDai(CHAI, maturity0, user2)
-        const daiBalance = await dai.balanceOf(user2)
+      await pool0.addDelegate(proxy.address, { from: user2 })
 
-        // Has pool0 tokens
-        expect(poolTokens).to.be.bignumber.gt(ZERO)
-        // Has fyDai debt
-        expect(debt).to.be.bignumber.gt(ZERO)
-        // Doesn't have dai
-        expect(daiBalance).to.be.bignumber.eq(ZERO)
-        // Has fyDai
-        expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(toBorrow)
+      await proxy.removeLiquidityMatureWithSignature(pool0.address, poolTokens, '0x', '0x', { from: user2 })
 
-        // the proxy must be a delegate in the pool0 because in order to remove
-        // liquidity via the proxy we must authorize the proxy to burn from our balance
-        await pool0.addDelegate(proxy.address, { from: user2 })
-        await proxy.removeLiquidityEarlyDaiPool(pool0.address, poolTokens, '0', '0', { from: user2 }) // TODO: Test limits
+      // Doesn't have pool0 tokens
+      expect(await pool0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
+      // Has less fyDai debt
+      expect(await controller.debtFYDai(CHAI, maturity0, user2)).to.be.bignumber.lt(debt)
+      // Has more dai
+      expect(await dai.balanceOf(user2)).to.be.bignumber.gt(daiBalance)
+      // Doesn't have fyDai
+      expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
+      // Proxy doesn't keep dai (beyond rounding)
+      expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+      // Proxy doesn't keep fyDai (beyond rounding)
+      expect(await fyDai0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+      // Proxy doesn't keep liquidity (beyond rounding)
+      expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
+    })
 
-        // Doesn't have pool0 tokens
-        expect(await pool0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
-        // Has less fyDai debt
-        expect(await controller.debtFYDai(CHAI, maturity0, user2)).to.be.bignumber.lt(debt)
-        // Got some dai
-        expect(await dai.balanceOf(user2)).to.be.bignumber.gt(ZERO)
-        // Has the same fyDai
-        expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(toBorrow)
-        // Proxy doesn't keep dai (beyond rounding)
-        expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-        // Proxy doesn't keep fyDai (beyond rounding)
-        expect(await fyDai0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-        // Proxy doesn't keep liquidity (beyond rounding)
-        expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-      })
+    it('everyone can remove liquidity after maturity by redeeming', async () => {
+      await helper.advanceTime(31556952)
+      await helper.advanceBlock()
+      await fyDai0.mature()
 
-      it('everyone can remove liquidity early by selling', async () => {
-        const users = [user2, user3, user4, user5, user6, user7, user8, user9]
-        for (let i in users) {
-          const poolTokens = await pool0.balanceOf(users[i])
-          const debt = await controller.debtFYDai(CHAI, maturity0, users[i])
-          const daiBalance = await dai.balanceOf(users[i])
-
-          // Has pool0 tokens
-          expect(poolTokens).to.be.bignumber.gt(ZERO)
-          // Has fyDai debt
-          expect(debt).to.be.bignumber.gt(ZERO)
-          // Doesn't have dai
-          expect(daiBalance).to.be.bignumber.eq(ZERO)
-
-          // the proxy must be a delegate in the pool0 because in order to remove
-          // liquidity via the proxy we must authorize the proxy to burn from our balance
-          await pool0.addDelegate(proxy.address, { from: users[i] })
-          await proxy.removeLiquidityEarlyDaiPool(pool0.address, poolTokens, '0', '0', { from: users[i] }) // TODO: Test limits
-
-          // Doesn't have pool0 tokens
-          expect(await pool0.balanceOf(users[i])).to.be.bignumber.eq(ZERO)
-          // Has less fyDai debt
-          expect(await controller.debtFYDai(CHAI, maturity0, users[i])).to.be.bignumber.lt(debt)
-          // Got some dai
-          expect(await dai.balanceOf(users[i])).to.be.bignumber.gt(ZERO)
-          // Proxy doesn't keep dai (beyond rounding)
-          expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-          // Proxy doesn't keep fyDai (beyond rounding)
-          expect(await fyDai0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-          // Proxy doesn't keep liquidity (beyond rounding)
-          expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-        }
-      })
-
-      it('removes liquidity early by selling, with some fyDai being sold in the pool0', async () => {
-        // This scenario replicates a user with debt that can be repaid by burning liquidity tokens.
-        // It uses the pool0 to sell the obtained Dai, so it should be used when the pool0 rate is better than 1:1.
-        // Sells twice, repays once, and and withdraws, so the gas cost is about 400K.
-
-        const poolTokens = await pool0.balanceOf(user2)
-        const debt = await controller.debtFYDai(CHAI, maturity0, user2)
-        const daiBalance = await dai.balanceOf(user2)
+      const users = [user2, user3, user4, user5, user6, user7, user8]
+      for (let i in users) {
+        const poolTokens = await pool0.balanceOf(users[i])
+        const debt = await controller.debtFYDai(CHAI, maturity0, users[i])
+        const daiBalance = await dai.balanceOf(users[i])
 
         // Has pool0 tokens
         expect(poolTokens).to.be.bignumber.gt(ZERO)
@@ -340,310 +741,37 @@ contract('PoolProxy', async (accounts) => {
 
         // the proxy must be a delegate in the pool0 because in order to remove
         // liquidity via the proxy we must authorize the proxy to burn from our balance
-        await pool0.addDelegate(proxy.address, { from: user2 })
-        await proxy.removeLiquidityEarlyDaiPool(pool0.address, poolTokens, '0', '0', { from: user2 }) // TODO: Test limits
+        await pool0.addDelegate(proxy.address, { from: users[i] })
+        await proxy.removeLiquidityMatureWithSignature(pool0.address, poolTokens, '0x', '0x', { from: users[i] })
 
         // Doesn't have pool0 tokens
-        expect(await pool0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
+        expect(await pool0.balanceOf(users[i])).to.be.bignumber.eq(ZERO)
         // Has less fyDai debt
-        expect(await controller.debtFYDai(CHAI, maturity0, user2)).to.be.bignumber.lt(debt)
+        expect(await controller.debtFYDai(CHAI, maturity0, users[i])).to.be.bignumber.lt(debt)
         // Has more dai
         expect(await dai.balanceOf(user2)).to.be.bignumber.gt(daiBalance)
-        // Doesn't have fyDai
-        expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
         // Proxy doesn't keep dai (beyond rounding)
         expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
         // Proxy doesn't keep fyDai (beyond rounding)
         expect(await fyDai0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
         // Proxy doesn't keep liquidity (beyond rounding)
         expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-      })
+      }
+    })
 
-      it('removes liquidity early by repaying, and uses all in paying debt', async () => {
-        // This scenario replicates a user with more debt that can be repaid with fyDai and Dai obtained by burning liquidity tokens.
-        // It repays with Dai at the Controller, so it should be used when the pool0 rate is worse than 1:1.
-        // Repays fyDai and Dai, sells or withdraws withdraws nothing so the gas cost is 300K.
+    it('and I mean everyone', async () => {
+      await helper.advanceTime(31556952)
+      await helper.advanceBlock()
+      await fyDai0.mature()
 
-        // Create some debt, so that there is no FYDai from the burn left to sell.
-        await maker.getChai(user2, chaiTokens1, chi1, rate1)
-        await chai.approve(treasury.address, chaiTokens1, { from: user2 })
-        await controller.post(CHAI, user2, user2, chaiTokens1, { from: user2 })
-        const toBorrow = (await env.unlockedOf(CHAI, user2)).toString()
-        await controller.borrow(CHAI, maturity0, user2, user2, toBorrow, { from: user2 })
-
-        const poolTokens = await pool0.balanceOf(user2)
-        const debt = await controller.debtFYDai(CHAI, maturity0, user2)
-        const daiBalance = await dai.balanceOf(user2)
-
-        // Has pool0 tokens
-        expect(poolTokens).to.be.bignumber.gt(ZERO)
-        // Has fyDai debt
-        expect(debt).to.be.bignumber.gt(ZERO)
-        // Doesn't have dai
-        expect(daiBalance).to.be.bignumber.eq(ZERO)
-        // Has fyDai
-        expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(toBorrow)
-
-        // the proxy must be a delegate in the pool0 because in order to remove
-        // liquidity via the proxy we must authorize the proxy to burn from our balance
-        await pool0.addDelegate(proxy.address, { from: user2 })
-        await proxy.removeLiquidityEarlyDaiFixedWithSignature(pool0.address, poolTokens, '0', '0x', '0x', { from: user2 }) // TODO: Test limits
-
-        // Doesn't have pool0 tokens
-        expect(await pool0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
-        // Has less fyDai debt
-        expect(await controller.debtFYDai(CHAI, maturity0, user2)).to.be.bignumber.lt(debt)
-        // Doesn't have dai
-        expect(daiBalance).to.be.bignumber.eq(ZERO)
-        // Has the same fyDai
-        expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(toBorrow)
-        // Proxy doesn't keep dai (beyond rounding)
-        expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-        // Proxy doesn't keep fyDai (beyond rounding)
-        expect(await fyDai0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-        // Proxy doesn't keep liquidity (beyond rounding)
-        expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-      })
-
-      it('removes liquidity early by repaying, and has Dai left', async () => {
-        // This scenario replicates a user with debt that can be repaid with fyDai and Dai obtained by burning liquidity tokens.
-        // It repays with Dai at the Controller, so it should be used when the pool0 rate is worse than 1:1.
-        // Repays fyDai and Dai, withdraws Dai and Chai so the gas cost is 394K.
-
-        const poolTokens = await pool0.balanceOf(user2)
-        const debt = await controller.debtFYDai(CHAI, maturity0, user2)
-        const daiBalance = await dai.balanceOf(user2)
-
-        // Has pool0 tokens
-        expect(poolTokens).to.be.bignumber.gt(ZERO)
-        // Has fyDai debt
-        expect(debt).to.be.bignumber.gt(ZERO)
-        // Doesn't have dai
-        expect(daiBalance).to.be.bignumber.eq(ZERO)
-        // Doesn't have fyDai
-        expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
-
-        // the proxy must be a delegate in the pool0 because in order to remove
-        // liquidity via the proxy we must authorize the proxy to burn from our balance
-        await pool0.addDelegate(proxy.address, { from: user2 })
-        await proxy.removeLiquidityEarlyDaiFixedWithSignature(pool0.address, poolTokens, '0', '0x', '0x', { from: user2 }) // TODO: Test limits
-
-        // Doesn't have pool0 tokens
-        expect(await pool0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
-        // Has less fyDai debt
-        expect(await controller.debtFYDai(CHAI, maturity0, user2)).to.be.bignumber.lt(debt)
-        // Has more dai
-        expect(await dai.balanceOf(user2)).to.be.bignumber.gt(daiBalance)
-        // Doesn't have fyDai
-        expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
-        // Proxy doesn't keep dai (beyond rounding)
-        expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-        // Proxy doesn't keep fyDai (beyond rounding)
-        expect(await fyDai0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-        // Proxy doesn't keep liquidity (beyond rounding)
-        expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-      })
-
-      it('everyone can remove liquidity early by repaying', async () => {
-        const users = [user2, user3, user4, user5, user6, user7, user8, user9]
-        for (let i in users) {
-          const poolTokens = await pool0.balanceOf(users[i])
-          const debt = await controller.debtFYDai(CHAI, maturity0, users[i])
-          const daiBalance = await dai.balanceOf(users[i])
-
-          // Has pool0 tokens
-          expect(poolTokens).to.be.bignumber.gt(ZERO)
-          // Has fyDai debt
-          expect(debt).to.be.bignumber.gt(ZERO)
-          // Doesn't have dai
-          expect(daiBalance).to.be.bignumber.eq(ZERO)
-          // Doesn't have fyDai
-          expect(await fyDai0.balanceOf(users[i])).to.be.bignumber.eq(ZERO)
-
-          // the proxy must be a delegate in the pool0 because in order to remove
-          // liquidity via the proxy we must authorize the proxy to burn from our balance
-          await pool0.addDelegate(proxy.address, { from: users[i] })
-          await proxy.removeLiquidityEarlyDaiFixedWithSignature(pool0.address, poolTokens, '0', '0x', '0x', { from: users[i] }) // TODO: Test limits
-
-          // Doesn't have pool0 tokens
-          expect(await pool0.balanceOf(users[i])).to.be.bignumber.eq(ZERO)
-          // Has less fyDai debt
-          expect(await controller.debtFYDai(CHAI, maturity0, users[i])).to.be.bignumber.lt(debt)
-          // Has more dai
-          expect(await dai.balanceOf(users[i])).to.be.bignumber.gt(daiBalance)
-          // Doesn't have fyDai
-          expect(await fyDai0.balanceOf(users[i])).to.be.bignumber.eq(ZERO)
-          // Proxy doesn't keep dai (beyond rounding)
-          expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-          // Proxy doesn't keep fyDai (beyond rounding)
-          expect(await fyDai0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-          // Proxy doesn't keep liquidity (beyond rounding)
-          expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-        }
-      })
-
-      it('removes liquidity early by repaying, and has Dai and fyDai left', async () => {
-        // This scenario replicates a user with debt that can be repaid with fyDai and Dai obtained by burning liquidity tokens.
-        // It repays with Dai at the Controller, so it should be used when the pool0 rate is worse than 1:1.
-        // Repays fyDai, sells fyDai, withdraws Dai and Chai so the gas cost is 333K.
-
-        const poolTokens = await pool0.balanceOf(user2)
-        const debt = await controller.debtFYDai(CHAI, maturity0, user2)
-        const daiBalance = await dai.balanceOf(user2)
-
-        // Has pool0 tokens
-        expect(poolTokens).to.be.bignumber.gt(ZERO)
-        // Has fyDai debt
-        expect(debt).to.be.bignumber.gt(ZERO)
-        // Doesn't have dai
-        expect(daiBalance).to.be.bignumber.eq(ZERO)
-        // Doesn't have fyDai
-        expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
-
-        // Pay some debt, so that there is FYDai from the burn left to sell.
-        await fyDai0.mint(user2, debt.div(new BN('2')), { from: owner })
-        await controller.repayFYDai(CHAI, maturity0, user2, user2, debt.div(new BN('2')), { from: user2 })
-
-        // the proxy must be a delegate in the pool0 because in order to remove
-        // liquidity via the proxy we must authorize the proxy to burn from our balance
-        await pool0.addDelegate(proxy.address, { from: user2 })
-        await proxy.removeLiquidityEarlyDaiFixedWithSignature(pool0.address, poolTokens, '0', '0x', '0x', { from: user2 }) // TODO: Test limits
-
-        // Doesn't have pool0 tokens
-        expect(await pool0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
-        // Has less fyDai debt
-        expect(await controller.debtFYDai(CHAI, maturity0, user2)).to.be.bignumber.lt(debt)
-        // Has more dai
-        expect(await dai.balanceOf(user2)).to.be.bignumber.gt(daiBalance)
-        // Doesn't have fyDai
-        expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
-        // Proxy doesn't keep dai (beyond rounding)
-        expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-        // Proxy doesn't keep fyDai (beyond rounding)
-        expect(await fyDai0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-        // Proxy doesn't keep liquidity (beyond rounding)
-        expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-      })
-
-      it("doesn't remove liquidity if minimum prices not achieved", async () => {
-        const poolTokens = await pool0.balanceOf(user2)
-        const debt = await controller.debtFYDai(CHAI, maturity0, user2)
-        const daiBalance = await dai.balanceOf(user2)
-
-        // Has pool0 tokens
-        expect(poolTokens).to.be.bignumber.gt(ZERO)
-        // Has fyDai debt
-        expect(debt).to.be.bignumber.gt(ZERO)
-        // Doesn't have dai
-        expect(daiBalance).to.be.bignumber.eq(ZERO)
-        // Doesn't have fyDai
-        expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
-
-        // the proxy must be a delegate in the pool0 because in order to remove
-        // liquidity via the proxy we must authorize the proxy to burn from our balance
-        await pool0.addDelegate(proxy.address, { from: user2 })
-        await expectRevert(
-          proxy.removeLiquidityEarlyDaiPool(pool0.address, poolTokens, toRay(2), '0', { from: user2 }),
-          'YieldProxy: minimumDaiPrice not reached'
-        )
-        await expectRevert(
-          proxy.removeLiquidityEarlyDaiPool(pool0.address, poolTokens, '0', toRay(2), { from: user2 }),
-          'YieldProxy: minimumFYDaiPrice not reached'
-        )
-      })
-
-      it('removes liquidity after maturity by redeeming', async () => {
-        await helper.advanceTime(31556952)
-        await helper.advanceBlock()
-        await fyDai0.mature()
-
-        const poolTokens = await pool0.balanceOf(user2)
-        const debt = await controller.debtFYDai(CHAI, maturity0, user2)
-        const daiBalance = await dai.balanceOf(user2)
-
-        // Has pool0 tokens
-        expect(poolTokens).to.be.bignumber.gt(ZERO)
-        // Has fyDai debt
-        expect(debt).to.be.bignumber.gt(ZERO)
-        // Doesn't have dai
-        expect(daiBalance).to.be.bignumber.eq(ZERO)
-        // Doesn't have fyDai
-        expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
-
-        await pool0.addDelegate(proxy.address, { from: user2 })
-
-        await proxy.removeLiquidityMatureWithSignature(pool0.address, poolTokens, '0x', '0x', { from: user2 })
-
-        // Doesn't have pool0 tokens
-        expect(await pool0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
-        // Has less fyDai debt
-        expect(await controller.debtFYDai(CHAI, maturity0, user2)).to.be.bignumber.lt(debt)
-        // Has more dai
-        expect(await dai.balanceOf(user2)).to.be.bignumber.gt(daiBalance)
-        // Doesn't have fyDai
-        expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
-        // Proxy doesn't keep dai (beyond rounding)
-        expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-        // Proxy doesn't keep fyDai (beyond rounding)
-        expect(await fyDai0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-        // Proxy doesn't keep liquidity (beyond rounding)
-        expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-      })
-
-      it('everyone can remove liquidity after maturity by redeeming', async () => {
-        await helper.advanceTime(31556952)
-        await helper.advanceBlock()
-        await fyDai0.mature()
-
-        const users = [user2, user3, user4, user5, user6, user7, user8, user9]
-        for (let i in users) {
-          const poolTokens = await pool0.balanceOf(users[i])
-          const debt = await controller.debtFYDai(CHAI, maturity0, users[i])
-          const daiBalance = await dai.balanceOf(users[i])
-
-          // Has pool0 tokens
-          expect(poolTokens).to.be.bignumber.gt(ZERO)
-          // Has fyDai debt
-          expect(debt).to.be.bignumber.gt(ZERO)
-          // Doesn't have dai
-          expect(daiBalance).to.be.bignumber.eq(ZERO)
-          // Doesn't have fyDai
-          expect(await fyDai0.balanceOf(user2)).to.be.bignumber.eq(ZERO)
-
-          // the proxy must be a delegate in the pool0 because in order to remove
-          // liquidity via the proxy we must authorize the proxy to burn from our balance
-          await pool0.addDelegate(proxy.address, { from: users[i] })
-          await proxy.removeLiquidityMatureWithSignature(pool0.address, poolTokens, '0x', '0x', { from: users[i] })
-
-          // Doesn't have pool0 tokens
-          expect(await pool0.balanceOf(users[i])).to.be.bignumber.eq(ZERO)
-          // Has less fyDai debt
-          expect(await controller.debtFYDai(CHAI, maturity0, users[i])).to.be.bignumber.lt(debt)
-          // Has more dai
-          expect(await dai.balanceOf(user2)).to.be.bignumber.gt(daiBalance)
-          // Proxy doesn't keep dai (beyond rounding)
-          expect(await dai.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-          // Proxy doesn't keep fyDai (beyond rounding)
-          expect(await fyDai0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-          // Proxy doesn't keep liquidity (beyond rounding)
-          expect(await pool0.balanceOf(proxy.address)).to.be.bignumber.lt(roundingProfit)
-        }
-      })
-
-      it('and I mean everyone', async () => {
-        await helper.advanceTime(31556952)
-        await helper.advanceBlock()
-        await fyDai0.mature()
-
-        const users = [user1, user2, user3, user4, user5, user6, user7, user8, user9]
-        for (let i in users) {
-          const poolTokens = await pool0.balanceOf(users[i])
-          await pool0.addDelegate(proxy.address, { from: users[i] })
-          await proxy.removeLiquidityMatureWithSignature(pool0.address, poolTokens, '0x', '0x', { from: users[i] })
-        }
-        console.log(`           Remaining Dai:   ${(await pool0.getDaiReserves()).toString()}`)
-        console.log(`           Remaining fyDai: ${(await pool0.getFYDaiReserves()).toString()}`)
-      })
+      const users = [user1, user2, user3, user4, user5, user6, user7, user8]
+      for (let i in users) {
+        const poolTokens = await pool0.balanceOf(users[i])
+        await pool0.addDelegate(proxy.address, { from: users[i] })
+        await proxy.removeLiquidityMatureWithSignature(pool0.address, poolTokens, '0x', '0x', { from: users[i] })
+      }
+      console.log(`           Remaining Dai:   ${(await pool0.getDaiReserves()).toString()}`)
+      console.log(`           Remaining fyDai: ${(await pool0.getFYDaiReserves()).toString()}`)
     })
   })
 })

--- a/test/peripheral/532_poolProxy_signatures.ts
+++ b/test/peripheral/532_poolProxy_signatures.ts
@@ -59,7 +59,7 @@ contract('PoolProxy - Signatures', async (accounts) => {
     await fyDai1.orchestrate(owner, keccak256(toUtf8Bytes('mint(address,uint256)')), { from: owner })
 
     // Setup PoolProxy
-    proxy = await PoolProxy.new(dai.address, chai.address, treasury.address, controller.address)
+    proxy = await PoolProxy.new(controller.address)
   })
 
   afterEach(async () => {

--- a/test/peripheral/532_poolProxy_signatures.ts
+++ b/test/peripheral/532_poolProxy_signatures.ts
@@ -177,11 +177,11 @@ contract('PoolProxy - Signatures', async (accounts) => {
         const maxBorrow = oneToken
         // Give some pool0 tokens to user2
         await dai.mint(user2, oneToken, { from: owner })
-        await proxy.addLiquidity(pool0.address, oneToken, maxBorrow, { from: user2 })
+        await proxy.addLiquidityWithSignature(pool0.address, oneToken, maxBorrow, '0x', '0x', { from: user2 })
 
         // Give some pool1 tokens to user2
         await dai.mint(user2, oneToken, { from: owner })
-        await proxy.addLiquidity(pool1.address, oneToken, maxBorrow, { from: user2 })
+        await proxy.addLiquidityWithSignature(pool1.address, oneToken, maxBorrow, '0x', '0x', { from: user2 })
 
         // Authorize the proxy for the pool
         const poolDigest = getSignatureDigest(

--- a/test/peripheral/533_poolProxy_dsproxy.ts
+++ b/test/peripheral/533_poolProxy_dsproxy.ts
@@ -179,11 +179,11 @@ contract('PoolProxy - DSProxy', async (accounts) => {
         const maxBorrow = oneToken
         // Give some pool0 tokens to user2
         await dai.mint(user2, oneToken, { from: owner })
-        await poolProxy.addLiquidity(pool0.address, oneToken, maxBorrow, { from: user2 })
+        await poolProxy.addLiquidityWithSignature(pool0.address, oneToken, maxBorrow, '0x', '0x', { from: user2 })
 
         // Give some pool1 tokens to user2
         await dai.mint(user2, oneToken, { from: owner })
-        await poolProxy.addLiquidity(pool1.address, oneToken, maxBorrow, { from: user2 })
+        await poolProxy.addLiquidityWithSignature(pool1.address, oneToken, maxBorrow, '0x', '0x', { from: user2 })
 
         // Authorize the proxy for the pool
         const poolDigest = getSignatureDigest(

--- a/test/peripheral/533_poolProxy_dsproxy.ts
+++ b/test/peripheral/533_poolProxy_dsproxy.ts
@@ -66,7 +66,7 @@ contract('PoolProxy - DSProxy', async (accounts) => {
     await fyDai1.orchestrate(owner, keccak256(toUtf8Bytes('mint(address,uint256)')), { from: owner })
 
     // Setup PoolProxy
-    poolProxy = await PoolProxy.new(dai.address, chai.address, treasury.address, controller.address)
+    poolProxy = await PoolProxy.new(controller.address)
 
     // Setup DSProxyFactory and DSProxyCache
     proxyFactory = await DSProxyFactory.new({ from: owner })


### PR DESCRIPTION
Implements `check` functions for proxy methods.
Moves approvals to the `WithSignature` functions.

The flow should be that before calling a proxy function the `*Check` function should be called first.
If a tuple of `true` is returned, then the plain `*` function should be called, skipping proxy approvals and saving gas for users.
If the return contains any `false` then the `*WithSignature` function should be called.

In any return tuple of a `*Check` function the first value reveals if proxy approvals (not signatures!) are missing, calling `*WithSignature` fixes this (regardless of signatures passed as parameters).
In any return tuple the second and subsequent values reveal if needed signatures are present, in the same order as they would be passed on to `*WithSignature`.