### PR TITLE
chore(formatting): Adds prettier-solidity plugin and formats contracts

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -1,7 +1,8 @@
 {
     "extends": "solhint:recommended",
-    "plugins": [],
+    "plugins": ["prettier"],
     "rules": {
+        "prettier/prettier": "warn",
         "avoid-throw": "off",
         "avoid-suicide": "error",
         "avoid-sha3": "warn",

--- a/contracts/FYDai.sol
+++ b/contracts/FYDai.sol
@@ -1,18 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-import "@openzeppelin/contracts/math/Math.sol";
-import "./interfaces/IVat.sol";
-import "./interfaces/IPot.sol";
-import "./interfaces/ITreasury.sol";
-import "./interfaces/IFYDai.sol";
-import "./interfaces/IFlashMinter.sol";
-import "./helpers/Delegable.sol";
-import "./helpers/DecimalMath.sol";
-import "./helpers/Orchestrated.sol";
-import "./helpers/ERC20Permit.sol";
-
-
+import '@openzeppelin/contracts/math/Math.sol';
+import './interfaces/IVat.sol';
+import './interfaces/IPot.sol';
+import './interfaces/ITreasury.sol';
+import './interfaces/IFYDai.sol';
+import './interfaces/IFlashMinter.sol';
+import './helpers/Delegable.sol';
+import './helpers/DecimalMath.sol';
+import './helpers/Orchestrated.sol';
+import './helpers/ERC20Permit.sol';
 
 /**
  * @dev fyDai is an fyToken targeting Chai.
@@ -23,14 +21,13 @@ import "./helpers/ERC20Permit.sol";
  * Minting and burning of fyDai is restricted to orchestrated contracts. Redeeming and flash-minting is allowed to anyone.
  */
 
-contract FYDai is IFYDai, Orchestrated(), Delegable(), DecimalMath, ERC20Permit  {
-
+contract FYDai is IFYDai, Orchestrated, Delegable, DecimalMath, ERC20Permit {
     event Redeemed(address indexed from, address indexed to, uint256 fyDaiIn, uint256 daiOut);
     event Matured(uint256 rate, uint256 chi);
 
-    bytes32 public constant WETH = "ETH-A";
+    bytes32 public constant WETH = 'ETH-A';
 
-    uint256 constant internal MAX_TIME_TO_MATURITY = 126144000; // seconds in four years
+    uint256 internal constant MAX_TIME_TO_MATURITY = 126144000; // seconds in four years
 
     IVat public vat;
     IPot public pot;
@@ -38,17 +35,17 @@ contract FYDai is IFYDai, Orchestrated(), Delegable(), DecimalMath, ERC20Permit 
 
     bool public override isMature;
     uint256 public override maturity;
-    uint256 public override chi0;      // Chi at maturity
-    uint256 public override rate0;     // Rate at maturity
+    uint256 public override chi0; // Chi at maturity
+    uint256 public override rate0; // Rate at maturity
 
-    uint public override unlocked = 1;
+    uint256 public override unlocked = 1;
     modifier lock() {
         require(unlocked == 1, 'FYDai: Locked');
         unlocked = 0;
         _;
         unlocked = 1;
     }
-    
+
     /// @dev The constructor:
     /// Sets the name and symbol for the fyDai token.
     /// Connects to Vat, Jug, Pot and Treasury.
@@ -61,7 +58,7 @@ contract FYDai is IFYDai, Orchestrated(), Delegable(), DecimalMath, ERC20Permit 
         string memory symbol
     ) public ERC20Permit(name, symbol) {
         // solium-disable-next-line security/no-block-members
-        require(maturity_ > now && maturity_ < now + MAX_TIME_TO_MATURITY, "FYDai: Invalid maturity");
+        require(maturity_ > now && maturity_ < now + MAX_TIME_TO_MATURITY, 'FYDai: Invalid maturity');
         treasury = ITreasury(treasury_);
         vat = treasury.vat();
         pot = treasury.pot();
@@ -77,7 +74,7 @@ contract FYDai is IFYDai, Orchestrated(), Delegable(), DecimalMath, ERC20Permit 
     // chi() = ---------
     //          chi_mat
     //
-    function chiGrowth() public view override returns(uint256){
+    function chiGrowth() public view override returns (uint256) {
         if (isMature != true) return chi0;
         return Math.min(rateGrowth(), divd(pot.chi(), chi0)); // Rounding in favour of the protocol
     }
@@ -89,9 +86,9 @@ contract FYDai is IFYDai, Orchestrated(), Delegable(), DecimalMath, ERC20Permit 
     // rateGrowth() = ----------
     //                 rate_mat
     //
-    function rateGrowth() public view override returns(uint256){
+    function rateGrowth() public view override returns (uint256) {
         if (isMature != true) return rate0;
-        (, uint256 rate,,,) = vat.ilks(WETH);
+        (, uint256 rate, , , ) = vat.ilks(WETH);
         return Math.max(UNIT, divdrup(rate, rate0)); // Rounding in favour of the protocol
     }
 
@@ -100,13 +97,10 @@ contract FYDai is IFYDai, Orchestrated(), Delegable(), DecimalMath, ERC20Permit 
         require(
             // solium-disable-next-line security/no-block-members
             now > maturity,
-            "FYDai: Too early to mature"
+            'FYDai: Too early to mature'
         );
-        require(
-            isMature != true,
-            "FYDai: Already matured"
-        );
-        (, rate0,,,) = vat.ilks(WETH); // Retrieve the MakerDAO Vat
+        require(isMature != true, 'FYDai: Already matured');
+        (, rate0, , , ) = vat.ilks(WETH); // Retrieve the MakerDAO Vat
         rate0 = Math.max(rate0, UNIT); // Floor it at 1.0
         chi0 = pot.chi();
         isMature = true;
@@ -123,17 +117,15 @@ contract FYDai is IFYDai, Orchestrated(), Delegable(), DecimalMath, ERC20Permit 
     /// @param fyDaiAmount Amount of fyDai to burn.
     // from --- fyDai ---> us
     // us   --- Dai  ---> to
-    function redeem(address from, address to, uint256 fyDaiAmount)
-        public onlyHolderOrDelegate(from, "FYDai: Only Holder Or Delegate") lock override 
-        returns (uint256)
-    {
-        require(
-            isMature == true,
-            "FYDai: fyDai is not mature"
-        );
-        _burn(from, fyDaiAmount);                              // Burn fyDai from `from`
-        uint256 daiAmount = muld(fyDaiAmount, chiGrowth());    // User gets interest for holding after maturity
-        treasury.pullDai(to, daiAmount);                     // Give dai to `to`, from Treasury
+    function redeem(
+        address from,
+        address to,
+        uint256 fyDaiAmount
+    ) public override onlyHolderOrDelegate(from, 'FYDai: Only Holder Or Delegate') lock returns (uint256) {
+        require(isMature == true, 'FYDai: fyDai is not mature');
+        _burn(from, fyDaiAmount); // Burn fyDai from `from`
+        uint256 daiAmount = muld(fyDaiAmount, chiGrowth()); // User gets interest for holding after maturity
+        treasury.pullDai(to, daiAmount); // Give dai to `to`, from Treasury
         emit Redeemed(from, to, fyDaiAmount, daiAmount);
         return daiAmount;
     }
@@ -141,7 +133,7 @@ contract FYDai is IFYDai, Orchestrated(), Delegable(), DecimalMath, ERC20Permit 
     /// @dev Flash-mint fyDai. Calls back on `IFlashMinter.executeOnFlashMint()`
     /// @param fyDaiAmount Amount of fyDai to mint.
     /// @param data User-defined data to pass on to `executeOnFlashMint()`
-    function flashMint(uint256 fyDaiAmount, bytes calldata data) external lock override {
+    function flashMint(uint256 fyDaiAmount, bytes calldata data) external override lock {
         _mint(msg.sender, fyDaiAmount);
         IFlashMinter(msg.sender).executeOnFlashMint(fyDaiAmount, data);
         _burn(msg.sender, fyDaiAmount);
@@ -151,7 +143,7 @@ contract FYDai is IFYDai, Orchestrated(), Delegable(), DecimalMath, ERC20Permit 
     /// This function can only be called by other Yield contracts, not users directly.
     /// @param to Wallet to mint the fyDai in.
     /// @param fyDaiAmount Amount of fyDai to mint.
-    function mint(address to, uint256 fyDaiAmount) public override onlyOrchestrated("FYDai: Not Authorized") {
+    function mint(address to, uint256 fyDaiAmount) public override onlyOrchestrated('FYDai: Not Authorized') {
         _mint(to, fyDaiAmount);
     }
 
@@ -159,7 +151,7 @@ contract FYDai is IFYDai, Orchestrated(), Delegable(), DecimalMath, ERC20Permit 
     /// This function can only be called by other Yield contracts, not users directly.
     /// @param from Wallet to burn the fyDai from.
     /// @param fyDaiAmount Amount of fyDai to burn.
-    function burn(address from, uint256 fyDaiAmount) public override onlyOrchestrated("FYDai: Not Authorized") {
+    function burn(address from, uint256 fyDaiAmount) public override onlyOrchestrated('FYDai: Not Authorized') {
         _burn(from, fyDaiAmount);
     }
 
@@ -168,6 +160,6 @@ contract FYDai is IFYDai, Orchestrated(), Delegable(), DecimalMath, ERC20Permit 
     /// @param fyDaiAmount Amount of fyDai to mint.
     function _mint(address to, uint256 fyDaiAmount) internal override {
         super._mint(to, fyDaiAmount);
-        require(totalSupply() <= 5192296858534827628530496329220096, "FYDai: Total supply limit exceeded"); // 2**112
+        require(totalSupply() <= 5192296858534827628530496329220096, 'FYDai: Total supply limit exceeded'); // 2**112
     }
 }

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.0;
-import "@openzeppelin/contracts/access/Ownable.sol";
+import '@openzeppelin/contracts/access/Ownable.sol';
 
 /**
  * @dev The Migrations contract is a standard truffle contract that keeps track of which migrations were done on the current network.
  * For fyDai, we have updated it and added functionality that enables it as well to work as a deployed contract registry.
  */
-contract Migrations is Ownable() {
+contract Migrations is Ownable {
     event Registered(bytes32 name, address addr);
-    uint public lastCompletedMigration;
+    uint256 public lastCompletedMigration;
     string public version;
 
     /// @dev Deployed contract to deployment address
@@ -17,24 +17,24 @@ contract Migrations is Ownable() {
     /// @dev Contract name iterator
     bytes32[] public names;
 
-    constructor (string memory version_) public {
+    constructor(string memory version_) public {
         version = version_;
     }
 
     /// @dev Amount of registered contracts
-    function length() external view returns (uint) {
+    function length() external view returns (uint256) {
         return names.length;
     }
 
     /// @dev Register a contract name and address
-    function register(bytes32 name, address addr ) external onlyOwner {
+    function register(bytes32 name, address addr) external onlyOwner {
         contracts[name] = addr;
         names.push(name);
         emit Registered(name, addr);
     }
 
     /// @dev Register the index of the last completed migration
-    function setCompleted(uint completed) public onlyOwner {
+    function setCompleted(uint256 completed) public onlyOwner {
         lastCompletedMigration = completed;
     }
 

--- a/contracts/Unwind.sol
+++ b/contracts/Unwind.sol
@@ -1,23 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/math/Math.sol";
-import "@openzeppelin/contracts/math/SafeMath.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "./interfaces/IVat.sol";
-import "./interfaces/IWeth.sol";
-import "./interfaces/IGemJoin.sol";
-import "./interfaces/IDaiJoin.sol";
-import "./interfaces/IPot.sol";
-import "./interfaces/IEnd.sol";
-import "./interfaces/IChai.sol";
-import "./interfaces/ITreasury.sol";
-import "./interfaces/IController.sol";
-import "./interfaces/IFYDai.sol";
-import "./interfaces/ILiquidations.sol";
-import "./helpers/DecimalMath.sol";
-
+import '@openzeppelin/contracts/access/Ownable.sol';
+import '@openzeppelin/contracts/math/Math.sol';
+import '@openzeppelin/contracts/math/SafeMath.sol';
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import './interfaces/IVat.sol';
+import './interfaces/IWeth.sol';
+import './interfaces/IGemJoin.sol';
+import './interfaces/IDaiJoin.sol';
+import './interfaces/IPot.sol';
+import './interfaces/IEnd.sol';
+import './interfaces/IChai.sol';
+import './interfaces/ITreasury.sol';
+import './interfaces/IController.sol';
+import './interfaces/IFYDai.sol';
+import './interfaces/ILiquidations.sol';
+import './helpers/DecimalMath.sol';
 
 /**
  * @dev Unwind allows everyone to recover their assets from the Yield protocol in the event of a MakerDAO shutdown.
@@ -26,11 +25,11 @@ import "./helpers/DecimalMath.sol";
  * At this point, users can settle their positions using `settle`. The MakerDAO rates will be used to convert all debt and collateral to a Weth payout.
  * Users can also redeem here their fyDai for a Weth payout, using `redeem`.
  */
-contract Unwind is Ownable(), DecimalMath {
+contract Unwind is Ownable, DecimalMath {
     using SafeMath for uint256;
 
-    bytes32 public constant CHAI = "CHAI";
-    bytes32 public constant WETH = "ETH-A";
+    bytes32 public constant CHAI = 'CHAI';
+    bytes32 public constant WETH = 'ETH-A';
 
     IVat public vat;
     IERC20 public dai;
@@ -56,10 +55,7 @@ contract Unwind is Ownable(), DecimalMath {
     /// @dev The constructor links to vat, daiJoin, weth, wethJoin, jug, pot, end, chai, treasury, controller and liquidations.
     /// Liquidations should have privileged access to controller and liquidations using orchestration.
     /// The constructor gives treasury and end permission on unwind's MakerDAO vaults.
-    constructor (
-        address end_,
-        address liquidations_
-    ) public {
+    constructor(address end_, address liquidations_) public {
         end = IEnd(end_);
         liquidations = ILiquidations(liquidations_);
         controller = liquidations.controller();
@@ -78,26 +74,20 @@ contract Unwind is Ownable(), DecimalMath {
     }
 
     /// @dev max(0, x - y)
-    function subFloorZero(uint256 x, uint256 y) public pure returns(uint256) {
+    function subFloorZero(uint256 x, uint256 y) public pure returns (uint256) {
         if (y >= x) return 0;
         else return x - y;
     }
 
     /// @dev Safe casting from uint256 to int256
-    function toInt(uint256 x) internal pure returns(int256) {
-        require(
-            x <= uint256(type(int256).max),
-            "Treasury: Cast overflow"
-        );
+    function toInt(uint256 x) internal pure returns (int256) {
+        require(x <= uint256(type(int256).max), 'Treasury: Cast overflow');
         return int256(x);
     }
 
     /// @dev Disables treasury, controller and liquidations.
     function unwind() public {
-        require(
-            end.tag(WETH) != 0,
-            "Unwind: MakerDAO not shutting down"
-        );
+        require(end.tag(WETH) != 0, 'Unwind: MakerDAO not shutting down');
         live = false;
         treasury.shutdown();
         controller.shutdown();
@@ -107,62 +97,47 @@ contract Unwind is Ownable(), DecimalMath {
     /// @dev Return the Dai equivalent value to a Chai amount.
     /// @param chaiAmount The Chai value to convert.
     /// @param chi The `chi` value from `Pot`.
-    function chaiToDai(uint256 chaiAmount, uint256 chi) public pure returns(uint256) {
+    function chaiToDai(uint256 chaiAmount, uint256 chi) public pure returns (uint256) {
         return muld(chaiAmount, chi);
     }
 
     /// @dev Return the Weth equivalent value to a Dai amount, during Dss Shutdown
     /// @param daiAmount The Dai value to convert.
     /// @param fix The `fix` value from `End`.
-    function daiToFixWeth(uint256 daiAmount, uint256 fix) public pure returns(uint256) {
+    function daiToFixWeth(uint256 daiAmount, uint256 fix) public pure returns (uint256) {
         return muld(daiAmount, fix);
     }
 
     /// @dev Settle system debt in MakerDAO and free remaining collateral.
     function settleTreasury() public {
-        require(
-            live == false,
-            "Unwind: Unwind first"
-        );
+        require(live == false, 'Unwind: Unwind first');
         (uint256 ink, uint256 art) = vat.urns(WETH, address(treasury));
-        require(ink > 0, "Unwind: Nothing to settle");
+        require(ink > 0, 'Unwind: Nothing to settle');
 
-        _treasuryWeth = ink;                            // We will need this to skim profits
-        vat.fork(                                      // Take the treasury vault
-            WETH,
-            address(treasury),
-            address(this),
-            toInt(ink),
-            toInt(art)
-        );
-        end.skim(WETH, address(this));                // Settle debts
-        end.free(WETH);                               // Free collateral
-        uint256 gem = vat.gem(WETH, address(this));   // Find out how much collateral we have now
-        wethJoin.exit(address(this), gem);            // Take collateral out
+        _treasuryWeth = ink; // We will need this to skim profits
+        vat.fork(WETH, address(treasury), address(this), toInt(ink), toInt(art)); // Take the treasury vault
+        end.skim(WETH, address(this)); // Settle debts
+        end.free(WETH); // Free collateral
+        uint256 gem = vat.gem(WETH, address(this)); // Find out how much collateral we have now
+        wethJoin.exit(address(this), gem); // Take collateral out
         settled = true;
     }
 
     /// @dev Put all chai savings in MakerDAO and exchange them for weth
     function cashSavings() public {
-        require(
-            end.tag(WETH) != 0,
-            "Unwind: End.sol not caged"
-        );
-        require(
-            end.fix(WETH) != 0,
-            "Unwind: End.sol not ready"
-        );
-        
-        uint256 chaiTokens = chai.balanceOf(address(treasury));
-        require(chaiTokens > 0, "Unwind: Nothing to cash");
-        chai.exit(address(treasury), chaiTokens);           // Get the chai as dai
+        require(end.tag(WETH) != 0, 'Unwind: End.sol not caged');
+        require(end.fix(WETH) != 0, 'Unwind: End.sol not ready');
 
-        uint256 daiTokens = dai.balanceOf(address(this));   // Find out how much is the chai worth
-        daiJoin.join(address(this), daiTokens);             // Put the dai into MakerDAO
-        end.pack(daiTokens);                                // Into End.sol, more exactly
-        end.cash(WETH, daiTokens);                          // Exchange the dai for weth
-        uint256 gem = vat.gem(WETH, address(this));         // Find out how much collateral we have now
-        wethJoin.exit(address(this), gem);                  // Take collateral out
+        uint256 chaiTokens = chai.balanceOf(address(treasury));
+        require(chaiTokens > 0, 'Unwind: Nothing to cash');
+        chai.exit(address(treasury), chaiTokens); // Get the chai as dai
+
+        uint256 daiTokens = dai.balanceOf(address(this)); // Find out how much is the chai worth
+        daiJoin.join(address(this), daiTokens); // Put the dai into MakerDAO
+        end.pack(daiTokens); // Into End.sol, more exactly
+        end.cash(WETH, daiTokens); // Exchange the dai for weth
+        uint256 gem = vat.gem(WETH, address(this)); // Find out how much collateral we have now
+        wethJoin.exit(address(this), gem); // Take collateral out
         cashedOut = true;
 
         _fix = end.fix(WETH);
@@ -174,7 +149,7 @@ contract Unwind is Ownable(), DecimalMath {
     /// @param user User vault to settle, and wallet to receive the corresponding weth.
     function settle(bytes32 collateral, address user) public {
         (uint256 tokens, uint256 debt) = controller.erase(collateral, user);
-        require(tokens > 0, "Unwind: Nothing to settle");
+        require(tokens > 0, 'Unwind: Nothing to settle');
 
         uint256 remainder;
         if (collateral == WETH) {
@@ -189,7 +164,7 @@ contract Unwind is Ownable(), DecimalMath {
     /// @param user User vault to settle, and wallet to receive the corresponding weth.
     function settleLiquidations(address user) public {
         (uint256 wethAmount, uint256 debt) = liquidations.erase(user);
-        require(wethAmount > 0, "Unwind: Nothing to settle");
+        require(wethAmount > 0, 'Unwind: Nothing to settle');
 
         uint256 remainder = subFloorZero(wethAmount, daiToFixWeth(debt, _fix));
 
@@ -201,16 +176,11 @@ contract Unwind is Ownable(), DecimalMath {
     /// @param user Wallet containing the fyDai to burn.
     function redeem(uint256 maturity, address user) public {
         IFYDai fyDai = controller.series(maturity);
-        require(fyDai.unlocked() == 1, "fyDai is still locked");
+        require(fyDai.unlocked() == 1, 'fyDai is still locked');
         uint256 fyDaiAmount = fyDai.balanceOf(user);
-        require(fyDaiAmount > 0, "Unwind: Nothing to redeem");
+        require(fyDaiAmount > 0, 'Unwind: Nothing to redeem');
 
         fyDai.burn(user, fyDaiAmount);
-        require(
-            weth.transfer(
-                user,
-                daiToFixWeth(muld(fyDaiAmount, fyDai.chiGrowth()), _fix)
-            )
-        );
+        require(weth.transfer(user, daiToFixWeth(muld(fyDaiAmount, fyDai.chiGrowth()), _fix)));
     }
 }

--- a/contracts/external/chai/chai.sol
+++ b/contracts/external/chai/chai.sol
@@ -23,63 +23,79 @@ interface VatLike {
 
 interface PotLike {
     function chi() external returns (uint256);
+
     function rho() external returns (uint256);
+
     function drip() external returns (uint256);
+
     function join(uint256) external;
+
     function exit(uint256) external;
 }
 
 interface JoinLike {
-    function join(address, uint) external;
-    function exit(address, uint) external;
+    function join(address, uint256) external;
+
+    function exit(address, uint256) external;
 }
 
 interface GemLike {
-    function transferFrom(address,address,uint) external returns (bool);
-    function approve(address,uint) external returns (bool);
+    function transferFrom(
+        address,
+        address,
+        uint256
+    ) external returns (bool);
+
+    function approve(address, uint256) external returns (bool);
 }
 
 contract Chai {
     // --- Data ---
-    VatLike  public vat;
-    PotLike  public pot;
+    VatLike public vat;
+    PotLike public pot;
     JoinLike public daiJoin;
-    GemLike  public daiToken;
+    GemLike public daiToken;
 
     // --- ERC20 Data ---
-    string  public constant name     = "Chai";
-    string  public constant symbol   = "CHAI";
-    string  public constant version  = "1";
-    uint8   public constant decimals = 18;
+    string public constant name = 'Chai';
+    string public constant symbol = 'CHAI';
+    string public constant version = '1';
+    uint8 public constant decimals = 18;
     uint256 public totalSupply;
 
-    mapping (address => uint)                      public balanceOf;
-    mapping (address => mapping (address => uint)) public allowance;
-    mapping (address => uint)                      public nonces;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+    mapping(address => uint256) public nonces;
 
-    event Approval(address indexed src, address indexed guy, uint wad);
-    event Transfer(address indexed src, address indexed dst, uint wad);
+    event Approval(address indexed src, address indexed guy, uint256 wad);
+    event Transfer(address indexed src, address indexed dst, uint256 wad);
 
     // --- Math ---
-    uint constant RAY = 10 ** 27;
-    function add(uint x, uint y) internal pure returns (uint z) {
+    uint256 constant RAY = 10**27;
+
+    function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x + y) >= x);
     }
-    function sub(uint x, uint y) internal pure returns (uint z) {
+
+    function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x - y) <= x);
     }
-    function mul(uint x, uint y) internal pure returns (uint z) {
+
+    function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require(y == 0 || (z = x * y) / y == x);
     }
-    function rmul(uint x, uint y) internal pure returns (uint z) {
+
+    function rmul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         // always rounds down
         z = mul(x, y) / RAY;
     }
-    function rdiv(uint x, uint y) internal pure returns (uint z) {
+
+    function rdiv(uint256 x, uint256 y) internal pure returns (uint256 z) {
         // always rounds down
         z = mul(x, RAY) / y;
     }
-    function rdivup(uint x, uint y) internal pure returns (uint z) {
+
+    function rdivup(uint256 x, uint256 y) internal pure returns (uint256 z) {
         // always rounds up
         z = add(mul(x, RAY), sub(y, 1)) / y;
     }
@@ -87,9 +103,14 @@ contract Chai {
     // --- EIP712 niceties ---
     bytes32 public constant DOMAIN_SEPARATOR = 0x0b50407de9fa158c2cba01a99633329490dfd22989a150c20e8c7b4c1fb0fcc3;
     // keccak256("Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)"));
-    bytes32 public constant PERMIT_TYPEHASH  = 0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb;
+    bytes32 public constant PERMIT_TYPEHASH = 0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb;
 
-    constructor(address vat_, address pot_, address daiJoin_, address weth_) public {
+    constructor(
+        address vat_,
+        address pot_,
+        address daiJoin_,
+        address weth_
+    ) public {
         /* assert (DOMAIN_SEPARATOR ==
           keccak256(abi.encode(
             keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
@@ -104,25 +125,33 @@ contract Chai {
         vat.hope(address(daiJoin));
         vat.hope(address(pot));
 
-        daiToken.approve(address(daiJoin), uint(-1));
+        daiToken.approve(address(daiJoin), uint256(-1));
     }
 
     // --- Token ---
-    function transfer(address dst, uint wad) external returns (bool) {
+    function transfer(address dst, uint256 wad) external returns (bool) {
         return transferFrom(msg.sender, dst, wad);
     }
+
     // like transferFrom but dai-denominated
-    function move(address src, address dst, uint wad) external returns (bool) {
-        uint chi = (now > pot.rho()) ? pot.drip() : pot.chi();
+    function move(
+        address src,
+        address dst,
+        uint256 wad
+    ) external returns (bool) {
+        uint256 chi = (now > pot.rho()) ? pot.drip() : pot.chi();
         // rounding up ensures dst gets at least wad dai
         return transferFrom(src, dst, rdivup(wad, chi));
     }
-    function transferFrom(address src, address dst, uint wad)
-        public returns (bool)
-    {
-        require(balanceOf[src] >= wad, "chai/insufficient-balance");
-        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
-            require(allowance[src][msg.sender] >= wad, "chai/insufficient-allowance");
+
+    function transferFrom(
+        address src,
+        address dst,
+        uint256 wad
+    ) public returns (bool) {
+        require(balanceOf[src] >= wad, 'chai/insufficient-balance');
+        if (src != msg.sender && allowance[src][msg.sender] != uint256(-1)) {
+            require(allowance[src][msg.sender] >= wad, 'chai/insufficient-allowance');
             allowance[src][msg.sender] = sub(allowance[src][msg.sender], wad);
         }
         balanceOf[src] = sub(balanceOf[src], wad);
@@ -130,44 +159,53 @@ contract Chai {
         emit Transfer(src, dst, wad);
         return true;
     }
-    function approve(address usr, uint wad) external returns (bool) {
+
+    function approve(address usr, uint256 wad) external returns (bool) {
         allowance[msg.sender][usr] = wad;
         emit Approval(msg.sender, usr, wad);
         return true;
     }
 
     // --- Approve by signature ---
-    function permit(address holder, address spender, uint256 nonce, uint256 expiry, bool allowed, uint8 v, bytes32 r, bytes32 s) external
-    {
-        bytes32 digest = keccak256(abi.encodePacked(
-            "\x19\x01",
-            DOMAIN_SEPARATOR,
-            keccak256(abi.encode(PERMIT_TYPEHASH,
-                                 holder,
-                                 spender,
-                                 nonce,
-                                 expiry,
-                                 allowed))));
-        require(holder != address(0), "chai/invalid holder");
-        require(holder == ecrecover(digest, v, r, s), "chai/invalid-permit");
-        require(expiry == 0 || now <= expiry, "chai/permit-expired");
-        require(nonce == nonces[holder]++, "chai/invalid-nonce");
+    function permit(
+        address holder,
+        address spender,
+        uint256 nonce,
+        uint256 expiry,
+        bool allowed,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        bytes32 digest =
+            keccak256(
+                abi.encodePacked(
+                    '\x19\x01',
+                    DOMAIN_SEPARATOR,
+                    keccak256(abi.encode(PERMIT_TYPEHASH, holder, spender, nonce, expiry, allowed))
+                )
+            );
+        require(holder != address(0), 'chai/invalid holder');
+        require(holder == ecrecover(digest, v, r, s), 'chai/invalid-permit');
+        require(expiry == 0 || now <= expiry, 'chai/permit-expired');
+        require(nonce == nonces[holder]++, 'chai/invalid-nonce');
 
-        uint can = allowed ? uint(-1) : 0;
+        uint256 can = allowed ? uint256(-1) : 0;
         allowance[holder][spender] = can;
         emit Approval(holder, spender, can);
     }
 
-    function dai(address usr) external returns (uint wad) {
-        uint chi = (now > pot.rho()) ? pot.drip() : pot.chi();
+    function dai(address usr) external returns (uint256 wad) {
+        uint256 chi = (now > pot.rho()) ? pot.drip() : pot.chi();
         wad = rmul(chi, balanceOf[usr]);
     }
+
     // wad is denominated in dai
-    function join(address dst, uint wad) external {
-        uint chi = (now > pot.rho()) ? pot.drip() : pot.chi();
-        uint pie = rdiv(wad, chi);
+    function join(address dst, uint256 wad) external {
+        uint256 chi = (now > pot.rho()) ? pot.drip() : pot.chi();
+        uint256 pie = rdiv(wad, chi);
         balanceOf[dst] = add(balanceOf[dst], pie);
-        totalSupply    = add(totalSupply, pie);
+        totalSupply = add(totalSupply, pie);
 
         daiToken.transferFrom(msg.sender, address(this), wad);
         daiJoin.join(address(this), wad);
@@ -176,24 +214,24 @@ contract Chai {
     }
 
     // wad is denominated in (1/chi) * dai
-    function exit(address src, uint wad) public {
-        require(balanceOf[src] >= wad, "chai/insufficient-balance");
-        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
-            require(allowance[src][msg.sender] >= wad, "chai/insufficient-allowance");
+    function exit(address src, uint256 wad) public {
+        require(balanceOf[src] >= wad, 'chai/insufficient-balance');
+        if (src != msg.sender && allowance[src][msg.sender] != uint256(-1)) {
+            require(allowance[src][msg.sender] >= wad, 'chai/insufficient-allowance');
             allowance[src][msg.sender] = sub(allowance[src][msg.sender], wad);
         }
         balanceOf[src] = sub(balanceOf[src], wad);
-        totalSupply    = sub(totalSupply, wad);
+        totalSupply = sub(totalSupply, wad);
 
-        uint chi = (now > pot.rho()) ? pot.drip() : pot.chi();
+        uint256 chi = (now > pot.rho()) ? pot.drip() : pot.chi();
         pot.exit(wad);
         daiJoin.exit(msg.sender, rmul(chi, wad));
         emit Transfer(src, address(0), wad);
     }
 
     // wad is denominated in dai
-    function draw(address src, uint wad) external {
-        uint chi = (now > pot.rho()) ? pot.drip() : pot.chi();
+    function draw(address src, uint256 wad) external {
+        uint256 chi = (now > pot.rho()) ? pot.drip() : pot.chi();
         // rounding up ensures usr gets at least wad dai
         exit(src, rdivup(wad, chi));
     }

--- a/contracts/external/maker/ProxyRegistry.sol
+++ b/contracts/external/maker/ProxyRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.0;
 
-import "./dsproxy.sol";
+import './dsproxy.sol';
 
 // This Registry deploys new proxy instances through DSProxyFactory.build(address) and keeps a registry of owner => proxy
 contract ProxyRegistry {

--- a/contracts/external/maker/auth.sol
+++ b/contracts/external/maker/auth.sol
@@ -16,42 +16,38 @@ pragma solidity >=0.4.23;
 
 interface DSAuthority {
     function canCall(
-        address src, address dst, bytes4 sig
+        address src,
+        address dst,
+        bytes4 sig
     ) external view returns (bool);
 }
 
 contract DSAuthEvents {
-    event LogSetAuthority (address indexed authority);
-    event LogSetOwner     (address indexed owner);
+    event LogSetAuthority(address indexed authority);
+    event LogSetOwner(address indexed owner);
 }
 
 contract DSAuth is DSAuthEvents {
-    DSAuthority  public  authority;
-    address      public  owner;
+    DSAuthority public authority;
+    address public owner;
 
     constructor() public {
         owner = msg.sender;
         emit LogSetOwner(msg.sender);
     }
 
-    function setOwner(address owner_)
-        public
-        auth
-    {
+    function setOwner(address owner_) public auth {
         owner = owner_;
         emit LogSetOwner(owner);
     }
 
-    function setAuthority(DSAuthority authority_)
-        public
-        auth
-    {
+    function setAuthority(DSAuthority authority_) public auth {
         authority = authority_;
         emit LogSetAuthority(address(authority));
     }
 
     modifier auth {
-        require(isAuthorized(msg.sender, msg.sig), "ds-auth-unauthorized");
+        require(isAuthorized(msg.sender, msg.sig), 'ds-auth-unauthorized');
         _;
     }
 

--- a/contracts/external/maker/dai.sol
+++ b/contracts/external/maker/dai.sol
@@ -16,37 +16,45 @@
 
 pragma solidity ^0.6.0;
 
-import "./lib.sol";
+import './lib.sol';
 
 contract Dai is LibNote {
     // --- Auth ---
-    mapping (address => uint) public wards;
-    function rely(address guy) external note auth { wards[guy] = 1; }
-    function deny(address guy) external note auth { wards[guy] = 0; }
+    mapping(address => uint256) public wards;
+
+    function rely(address guy) external note auth {
+        wards[guy] = 1;
+    }
+
+    function deny(address guy) external note auth {
+        wards[guy] = 0;
+    }
+
     modifier auth {
-        require(wards[msg.sender] == 1, "Dai/not-authorized");
+        require(wards[msg.sender] == 1, 'Dai/not-authorized');
         _;
     }
 
     // --- ERC20 Data ---
-    string  public constant name     = "Dai Stablecoin";
-    string  public constant symbol   = "DAI";
-    string  public constant version  = "1";
-    uint8   public constant decimals = 18;
+    string public constant name = 'Dai Stablecoin';
+    string public constant symbol = 'DAI';
+    string public constant version = '1';
+    uint8 public constant decimals = 18;
     uint256 public totalSupply;
 
-    mapping (address => uint)                      public balanceOf;
-    mapping (address => mapping (address => uint)) public allowance;
-    mapping (address => uint)                      public nonces;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+    mapping(address => uint256) public nonces;
 
-    event Approval(address indexed src, address indexed guy, uint wad);
-    event Transfer(address indexed src, address indexed dst, uint wad);
+    event Approval(address indexed src, address indexed guy, uint256 wad);
+    event Transfer(address indexed src, address indexed dst, uint256 wad);
 
     // --- Math ---
-    function add(uint x, uint y) internal pure returns (uint z) {
+    function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x + y) >= x);
     }
-    function sub(uint x, uint y) internal pure returns (uint z) {
+
+    function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x - y) <= x);
     }
 
@@ -57,25 +65,30 @@ contract Dai is LibNote {
 
     constructor(uint256 chainId_) public {
         wards[msg.sender] = 1;
-        DOMAIN_SEPARATOR = keccak256(abi.encode(
-            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
-            keccak256(bytes(name)),
-            keccak256(bytes(version)),
-            chainId_,
-            address(this)
-        ));
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                keccak256('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'),
+                keccak256(bytes(name)),
+                keccak256(bytes(version)),
+                chainId_,
+                address(this)
+            )
+        );
     }
 
     // --- Token ---
-    function transfer(address dst, uint wad) external returns (bool) {
+    function transfer(address dst, uint256 wad) external returns (bool) {
         return transferFrom(msg.sender, dst, wad);
     }
-    function transferFrom(address src, address dst, uint wad)
-        public returns (bool)
-    {
-        require(balanceOf[src] >= wad, "Dai/insufficient-balance");
-        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
-            require(allowance[src][msg.sender] >= wad, "Dai/insufficient-allowance");
+
+    function transferFrom(
+        address src,
+        address dst,
+        uint256 wad
+    ) public returns (bool) {
+        require(balanceOf[src] >= wad, 'Dai/insufficient-balance');
+        if (src != msg.sender && allowance[src][msg.sender] != uint256(-1)) {
+            require(allowance[src][msg.sender] >= wad, 'Dai/insufficient-allowance');
             allowance[src][msg.sender] = sub(allowance[src][msg.sender], wad);
         }
         balanceOf[src] = sub(balanceOf[src], wad);
@@ -83,59 +96,72 @@ contract Dai is LibNote {
         emit Transfer(src, dst, wad);
         return true;
     }
-    function mint(address usr, uint wad) external auth {
+
+    function mint(address usr, uint256 wad) external auth {
         balanceOf[usr] = add(balanceOf[usr], wad);
-        totalSupply    = add(totalSupply, wad);
+        totalSupply = add(totalSupply, wad);
         emit Transfer(address(0), usr, wad);
     }
-    function burn(address usr, uint wad) external {
-        require(balanceOf[usr] >= wad, "Dai/insufficient-balance");
-        if (usr != msg.sender && allowance[usr][msg.sender] != uint(-1)) {
-            require(allowance[usr][msg.sender] >= wad, "Dai/insufficient-allowance");
+
+    function burn(address usr, uint256 wad) external {
+        require(balanceOf[usr] >= wad, 'Dai/insufficient-balance');
+        if (usr != msg.sender && allowance[usr][msg.sender] != uint256(-1)) {
+            require(allowance[usr][msg.sender] >= wad, 'Dai/insufficient-allowance');
             allowance[usr][msg.sender] = sub(allowance[usr][msg.sender], wad);
         }
         balanceOf[usr] = sub(balanceOf[usr], wad);
-        totalSupply    = sub(totalSupply, wad);
+        totalSupply = sub(totalSupply, wad);
         emit Transfer(usr, address(0), wad);
     }
-    function approve(address usr, uint wad) external returns (bool) {
+
+    function approve(address usr, uint256 wad) external returns (bool) {
         allowance[msg.sender][usr] = wad;
         emit Approval(msg.sender, usr, wad);
         return true;
     }
 
     // --- Alias ---
-    function push(address usr, uint wad) external {
+    function push(address usr, uint256 wad) external {
         transferFrom(msg.sender, usr, wad);
     }
-    function pull(address usr, uint wad) external {
+
+    function pull(address usr, uint256 wad) external {
         transferFrom(usr, msg.sender, wad);
     }
-    function move(address src, address dst, uint wad) external {
+
+    function move(
+        address src,
+        address dst,
+        uint256 wad
+    ) external {
         transferFrom(src, dst, wad);
     }
 
     // --- Approve by signature ---
-    function permit(address holder, address spender, uint256 nonce, uint256 expiry,
-                    bool allowed, uint8 v, bytes32 r, bytes32 s) external
-    {
+    function permit(
+        address holder,
+        address spender,
+        uint256 nonce,
+        uint256 expiry,
+        bool allowed,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
         bytes32 digest =
-            keccak256(abi.encodePacked(
-                "\x19\x01",
-                DOMAIN_SEPARATOR,
-                keccak256(abi.encode(PERMIT_TYPEHASH,
-                                     holder,
-                                     spender,
-                                     nonce,
-                                     expiry,
-                                     allowed))
-        ));
+            keccak256(
+                abi.encodePacked(
+                    '\x19\x01',
+                    DOMAIN_SEPARATOR,
+                    keccak256(abi.encode(PERMIT_TYPEHASH, holder, spender, nonce, expiry, allowed))
+                )
+            );
 
-        require(holder != address(0), "Dai/invalid-address-0");
-        require(holder == ecrecover(digest, v, r, s), "Dai/invalid-permit");
-        require(expiry == 0 || now <= expiry, "Dai/permit-expired");
-        require(nonce == nonces[holder]++, "Dai/invalid-nonce");
-        uint wad = allowed ? uint(-1) : 0;
+        require(holder != address(0), 'Dai/invalid-address-0');
+        require(holder == ecrecover(digest, v, r, s), 'Dai/invalid-permit');
+        require(expiry == 0 || now <= expiry, 'Dai/permit-expired');
+        require(nonce == nonces[holder]++, 'Dai/invalid-nonce');
+        uint256 wad = allowed ? uint256(-1) : 0;
         allowance[holder][spender] = wad;
         emit Approval(holder, spender, wad);
     }

--- a/contracts/external/maker/dsproxy.sol
+++ b/contracts/external/maker/dsproxy.sol
@@ -18,8 +18,8 @@
 
 pragma solidity ^0.6.0;
 
-import "./auth.sol";
-import "./note.sol";
+import './auth.sol';
+import './note.sol';
 
 // DSProxy
 // Allows code execution using a persistant identity This can be very
@@ -27,14 +27,13 @@ import "./note.sol";
 // the proxy can be changed, this allows for dynamic ownership models
 // i.e. a multisig
 contract DSProxy is DSAuth, DSNote {
-    DSProxyCache public cache;  // global cache for contracts
+    DSProxyCache public cache; // global cache for contracts
 
     constructor(address _cacheAddr) public {
         setCache(_cacheAddr);
     }
 
-    receive() external payable {
-    }
+    receive() external payable {}
 
     // use the proxy to execute calldata _data on contract _code
     function execute(bytes memory _code, bytes memory _data)
@@ -51,14 +50,8 @@ contract DSProxy is DSAuth, DSNote {
         response = execute(target, _data);
     }
 
-    function execute(address _target, bytes memory _data)
-        public
-        auth
-        note
-        payable
-        returns (bytes memory response)
-    {
-        require(_target != address(0), "ds-proxy-target-address-required");
+    function execute(address _target, bytes memory _data) public payable auth note returns (bytes memory response) {
+        require(_target != address(0), 'ds-proxy-target-address-required');
 
         // call contract in current context
         assembly {
@@ -71,22 +64,17 @@ contract DSProxy is DSAuth, DSNote {
             returndatacopy(add(response, 0x20), 0, size)
 
             switch iszero(succeeded)
-            case 1 {
-                // throw if delegatecall failed
-                revert(add(response, 0x20), size)
-            }
+                case 1 {
+                    // throw if delegatecall failed
+                    revert(add(response, 0x20), size)
+                }
         }
     }
 
     //set new cache
-    function setCache(address _cacheAddr)
-        public
-        auth
-        note
-        returns (bool)
-    {
-        require(_cacheAddr != address(0), "ds-proxy-cache-address-required");
-        cache = DSProxyCache(_cacheAddr);  // overwrite cache
+    function setCache(address _cacheAddr) public auth note returns (bool) {
+        require(_cacheAddr != address(0), 'ds-proxy-cache-address-required');
+        cache = DSProxyCache(_cacheAddr); // overwrite cache
         return true;
     }
 }
@@ -96,7 +84,7 @@ contract DSProxy is DSAuth, DSNote {
 // Deployed proxy addresses are logged
 contract DSProxyFactory {
     event Created(address indexed sender, address indexed owner, address proxy, address cache);
-    mapping(address=>bool) public isProxy;
+    mapping(address => bool) public isProxy;
     DSProxyCache public cache;
 
     constructor() public {
@@ -140,10 +128,10 @@ contract DSProxyCache {
         assembly {
             target := create(0, add(_code, 0x20), mload(_code))
             switch iszero(extcodesize(target))
-            case 1 {
-                // throw if contract failed to deploy
-                revert(0, 0)
-            }
+                case 1 {
+                    // throw if contract failed to deploy
+                    revert(0, 0)
+                }
         }
         bytes32 hash = keccak256(_code);
         cache[hash] = target;

--- a/contracts/external/maker/end.sol
+++ b/contracts/external/maker/end.sol
@@ -19,57 +19,99 @@
 
 pragma solidity ^0.6.0;
 
-import "./lib.sol";
-
-
+import './lib.sol';
 
 interface VatLike {
     function dai(address) external view returns (uint256);
-    function ilks(bytes32 ilk) external returns (
-        uint256 Art,   // [wad]
-        uint256 rate,  // [ray]
-        uint256 spot,  // [ray]
-        uint256 line,  // [rad]
-        uint256 dust   // [rad]
-    );
-    function urns(bytes32 ilk, address urn) external returns (
-        uint256 ink,   // [wad]
-        uint256 art    // [wad]
-    );
+
+    function ilks(bytes32 ilk)
+        external
+        returns (
+            uint256 Art, // [wad]
+            uint256 rate, // [ray]
+            uint256 spot, // [ray]
+            uint256 line, // [rad]
+            uint256 dust // [rad]
+        );
+
+    function urns(bytes32 ilk, address urn)
+        external
+        returns (
+            uint256 ink, // [wad]
+            uint256 art // [wad]
+        );
+
     function debt() external returns (uint256);
-    function move(address src, address dst, uint256 rad) external;
+
+    function move(
+        address src,
+        address dst,
+        uint256 rad
+    ) external;
+
     function hope(address) external;
-    function flux(bytes32 ilk, address src, address dst, uint256 rad) external;
-    function grab(bytes32 i, address u, address v, address w, int256 dink, int256 dart) external;
-    function suck(address u, address v, uint256 rad) external;
+
+    function flux(
+        bytes32 ilk,
+        address src,
+        address dst,
+        uint256 rad
+    ) external;
+
+    function grab(
+        bytes32 i,
+        address u,
+        address v,
+        address w,
+        int256 dink,
+        int256 dart
+    ) external;
+
+    function suck(
+        address u,
+        address v,
+        uint256 rad
+    ) external;
+
     function cage() external;
 }
+
 interface CatLike {
-    function ilks(bytes32) external returns (
-        address flip,
-        uint256 chop,  // [ray]
-        uint256 lump   // [rad]
-    );
+    function ilks(bytes32)
+        external
+        returns (
+            address flip,
+            uint256 chop, // [ray]
+            uint256 lump // [rad]
+        );
+
     function cage() external;
 }
+
 interface PotLike {
     function cage() external;
 }
+
 interface VowLike {
     function cage() external;
 }
+
 interface Flippy {
-    function bids(uint id) external view returns (
-        uint256 bid,   // [rad]
-        uint256 lot,   // [wad]
-        address guy,
-        uint48  tic,   // [unix epoch time]
-        uint48  end,   // [unix epoch time]
-        address usr,
-        address gal,
-        uint256 tab    // [rad]
-    );
-    function yank(uint id) external;
+    function bids(uint256 id)
+        external
+        view
+        returns (
+            uint256 bid, // [rad]
+            uint256 lot, // [wad]
+            address guy,
+            uint48 tic, // [unix epoch time]
+            uint48 end, // [unix epoch time]
+            address usr,
+            address gal,
+            uint256 tab // [rad]
+        );
+
+    function yank(uint256 id) external;
 }
 
 interface PipLike {
@@ -78,10 +120,15 @@ interface PipLike {
 
 interface Spotty {
     function par() external view returns (uint256);
-    function ilks(bytes32) external view returns (
-        PipLike pip,
-        uint256 mat    // [ray]
-    );
+
+    function ilks(bytes32)
+        external
+        view
+        returns (
+            PipLike pip,
+            uint256 mat // [ray]
+        );
+
     function cage() external;
 }
 
@@ -162,33 +209,40 @@ interface Spotty {
 
 contract End is LibNote {
     // --- Auth ---
-    mapping (address => uint) public wards;
-    function rely(address guy) external note auth { wards[guy] = 1; }
-    function deny(address guy) external note auth { wards[guy] = 0; }
+    mapping(address => uint256) public wards;
+
+    function rely(address guy) external note auth {
+        wards[guy] = 1;
+    }
+
+    function deny(address guy) external note auth {
+        wards[guy] = 0;
+    }
+
     modifier auth {
-        require(wards[msg.sender] == 1, "End/not-authorized");
+        require(wards[msg.sender] == 1, 'End/not-authorized');
         _;
     }
 
     // --- Data ---
-    VatLike  public vat;   // CDP Engine
-    CatLike  public cat;
-    VowLike  public vow;   // Debt Engine
-    PotLike  public pot;
-    Spotty   public spot;
+    VatLike public vat; // CDP Engine
+    CatLike public cat;
+    VowLike public vow; // Debt Engine
+    PotLike public pot;
+    Spotty public spot;
 
-    uint256  public live;  // Active Flag
-    uint256  public when;  // Time of cage                   [unix epoch time]
-    uint256  public wait;  // Processing Cooldown Length             [seconds]
-    uint256  public debt;  // Total outstanding dai following processing [rad]
+    uint256 public live; // Active Flag
+    uint256 public when; // Time of cage                   [unix epoch time]
+    uint256 public wait; // Processing Cooldown Length             [seconds]
+    uint256 public debt; // Total outstanding dai following processing [rad]
 
-    mapping (bytes32 => uint256) public tag;  // Cage price              [ray]
-    mapping (bytes32 => uint256) public gap;  // Collateral shortfall    [wad]
-    mapping (bytes32 => uint256) public Art;  // Total debt per ilk      [wad]
-    mapping (bytes32 => uint256) public fix;  // Final cash price        [ray]
+    mapping(bytes32 => uint256) public tag; // Cage price              [ray]
+    mapping(bytes32 => uint256) public gap; // Collateral shortfall    [wad]
+    mapping(bytes32 => uint256) public Art; // Total debt per ilk      [wad]
+    mapping(bytes32 => uint256) public fix; // Final cash price        [ray]
 
-    mapping (address => uint256)                      public bag;  //    [wad]
-    mapping (bytes32 => mapping (address => uint256)) public out;  //    [wad]
+    mapping(address => uint256) public bag; //    [wad]
+    mapping(bytes32 => mapping(address => uint256)) public out; //    [wad]
 
     // --- Init ---
     constructor() public {
@@ -197,50 +251,58 @@ contract End is LibNote {
     }
 
     // --- Math ---
-    function add(uint x, uint y) internal pure returns (uint z) {
+    function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = x + y;
         require(z >= x);
     }
-    function sub(uint x, uint y) internal pure returns (uint z) {
+
+    function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x - y) <= x);
     }
-    function mul(uint x, uint y) internal pure returns (uint z) {
+
+    function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require(y == 0 || (z = x * y) / y == x);
     }
-    function min(uint x, uint y) internal pure returns (uint z) {
+
+    function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
         return x <= y ? x : y;
     }
-    uint constant WAD = 10 ** 18;
-    uint constant RAY = 10 ** 27;
-    function rmul(uint x, uint y) internal pure returns (uint z) {
+
+    uint256 constant WAD = 10**18;
+    uint256 constant RAY = 10**27;
+
+    function rmul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = mul(x, y) / RAY;
     }
-    function rdiv(uint x, uint y) internal pure returns (uint z) {
+
+    function rdiv(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = mul(x, RAY) / y;
     }
-    function wdiv(uint x, uint y) internal pure returns (uint z) {
+
+    function wdiv(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = mul(x, WAD) / y;
     }
 
     // --- Administration ---
     function file(bytes32 what, address data) external note auth {
-        require(live == 1, "End/not-live");
-        if (what == "vat")  vat = VatLike(data);
-        else if (what == "cat")  cat = CatLike(data);
-        else if (what == "vow")  vow = VowLike(data);
-        else if (what == "pot")  pot = PotLike(data);
-        else if (what == "spot") spot = Spotty(data);
-        else revert("End/file-unrecognized-param");
+        require(live == 1, 'End/not-live');
+        if (what == 'vat') vat = VatLike(data);
+        else if (what == 'cat') cat = CatLike(data);
+        else if (what == 'vow') vow = VowLike(data);
+        else if (what == 'pot') pot = PotLike(data);
+        else if (what == 'spot') spot = Spotty(data);
+        else revert('End/file-unrecognized-param');
     }
+
     function file(bytes32 what, uint256 data) external note auth {
-        require(live == 1, "End/not-live");
-        if (what == "wait") wait = data;
-        else revert("End/file-unrecognized-param");
+        require(live == 1, 'End/not-live');
+        if (what == 'wait') wait = data;
+        else revert('End/file-unrecognized-param');
     }
 
     // --- Settlement ---
     function cage() external note auth {
-        require(live == 1, "End/not-live");
+        require(live == 1, 'End/not-live');
         live = 0;
         when = now;
         vat.cage();
@@ -251,92 +313,93 @@ contract End is LibNote {
     }
 
     function cage(bytes32 ilk) external note {
-        require(live == 0, "End/still-live");
-        require(tag[ilk] == 0, "End/tag-ilk-already-defined");
-        (Art[ilk],,,,) = vat.ilks(ilk);
-        (PipLike pip,) = spot.ilks(ilk);
+        require(live == 0, 'End/still-live');
+        require(tag[ilk] == 0, 'End/tag-ilk-already-defined');
+        (Art[ilk], , , , ) = vat.ilks(ilk);
+        (PipLike pip, ) = spot.ilks(ilk);
         // par is a ray, pip returns a wad
-        tag[ilk] = wdiv(spot.par(), uint(pip.read())); // Tag is a RAY
+        tag[ilk] = wdiv(spot.par(), uint256(pip.read())); // Tag is a RAY
     }
 
     function skip(bytes32 ilk, uint256 id) external note {
-        require(tag[ilk] != 0, "End/tag-ilk-not-defined");
+        require(tag[ilk] != 0, 'End/tag-ilk-not-defined');
 
-        (address flipV,,) = cat.ilks(ilk);
+        (address flipV, , ) = cat.ilks(ilk);
         Flippy flip = Flippy(flipV);
-        (, uint rate,,,) = vat.ilks(ilk);
-        (uint bid, uint lot,,,, address usr,, uint tab) = flip.bids(id);
+        (, uint256 rate, , , ) = vat.ilks(ilk);
+        (uint256 bid, uint256 lot, , , , address usr, , uint256 tab) = flip.bids(id);
 
-        vat.suck(address(vow), address(vow),  tab);
+        vat.suck(address(vow), address(vow), tab);
         vat.suck(address(vow), address(this), bid);
         vat.hope(address(flip));
         flip.yank(id);
 
-        uint art = tab / rate;
+        uint256 art = tab / rate;
         Art[ilk] = add(Art[ilk], art);
-        require(int(lot) >= 0 && int(art) >= 0, "End/overflow");
-        vat.grab(ilk, usr, address(this), address(vow), int(lot), int(art));
+        require(int256(lot) >= 0 && int256(art) >= 0, 'End/overflow');
+        vat.grab(ilk, usr, address(this), address(vow), int256(lot), int256(art));
     }
 
-    function setTag(bytes32 ilk, uint tag_) external note {
+    function setTag(bytes32 ilk, uint256 tag_) external note {
         tag[ilk] = tag_;
     }
 
     function skim(bytes32 ilk, address urn) external note {
-        require(tag[ilk] != 0, "End/tag-ilk-not-defined");
-        (, uint rate,,,) = vat.ilks(ilk);
-        (uint ink, uint art) = vat.urns(ilk, urn);
+        require(tag[ilk] != 0, 'End/tag-ilk-not-defined');
+        (, uint256 rate, , , ) = vat.ilks(ilk);
+        (uint256 ink, uint256 art) = vat.urns(ilk, urn);
 
-        uint owe = rmul(rmul(art, rate), tag[ilk]); // debt(wad) * rate(ray) * tag(ray) = ink(wad); tag = 1/spot;
-        uint wad = min(ink, owe);
+        uint256 owe = rmul(rmul(art, rate), tag[ilk]); // debt(wad) * rate(ray) * tag(ray) = ink(wad); tag = 1/spot;
+        uint256 wad = min(ink, owe);
         gap[ilk] = add(gap[ilk], sub(owe, wad));
 
-        require(wad <= 2**255 && art <= 2**255, "End/overflow");
-        vat.grab(ilk, urn, address(this), address(vow), -int(wad), -int(art));
+        require(wad <= 2**255 && art <= 2**255, 'End/overflow');
+        vat.grab(ilk, urn, address(this), address(vow), -int256(wad), -int256(art));
     }
 
     function free(bytes32 ilk) external note {
-        require(live == 0, "End/still-live");
-        (uint ink, uint art) = vat.urns(ilk, msg.sender);
-        require(art == 0, "End/art-not-zero");
-        require(ink <= 2**255, "End/overflow");
-        vat.grab(ilk, msg.sender, msg.sender, address(vow), -int(ink), 0);
+        require(live == 0, 'End/still-live');
+        (uint256 ink, uint256 art) = vat.urns(ilk, msg.sender);
+        require(art == 0, 'End/art-not-zero');
+        require(ink <= 2**255, 'End/overflow');
+        vat.grab(ilk, msg.sender, msg.sender, address(vow), -int256(ink), 0);
     }
 
     function thaw() external note {
-        require(live == 0, "End/still-live");
-        require(debt == 0, "End/debt-not-zero");
-        require(vat.dai(address(vow)) == 0, "End/surplus-not-zero");
-        require(now >= add(when, wait), "End/wait-not-finished");
+        require(live == 0, 'End/still-live');
+        require(debt == 0, 'End/debt-not-zero');
+        require(vat.dai(address(vow)) == 0, 'End/surplus-not-zero');
+        require(now >= add(when, wait), 'End/wait-not-finished');
         debt = vat.debt();
     }
-    function flow(bytes32 ilk) external note {
-        require(debt != 0, "End/debt-zero");
-        require(fix[ilk] == 0, "End/fix-ilk-already-defined");
 
-        (, uint rate,,,) = vat.ilks(ilk);
+    function flow(bytes32 ilk) external note {
+        require(debt != 0, 'End/debt-zero');
+        require(fix[ilk] == 0, 'End/fix-ilk-already-defined');
+
+        (, uint256 rate, , , ) = vat.ilks(ilk);
         uint256 wad = rmul(rmul(Art[ilk], rate), tag[ilk]);
         fix[ilk] = rdiv(mul(sub(wad, gap[ilk]), RAY), debt);
     }
 
-    function setDebt(uint debt_) external note {
+    function setDebt(uint256 debt_) external note {
         debt = debt_;
     }
 
     function pack(uint256 wad) external note {
-        require(debt != 0, "End/debt-zero");
+        require(debt != 0, 'End/debt-zero');
         vat.move(msg.sender, address(vow), mul(wad, RAY));
         bag[msg.sender] = add(bag[msg.sender], wad);
     }
 
-    function setFix(bytes32 ilk, uint fix_) external note {
+    function setFix(bytes32 ilk, uint256 fix_) external note {
         fix[ilk] = fix_;
     }
 
-    function cash(bytes32 ilk, uint wad) external note {
-        require(fix[ilk] != 0, "End/fix-ilk-not-defined");
+    function cash(bytes32 ilk, uint256 wad) external note {
+        require(fix[ilk] != 0, 'End/fix-ilk-not-defined');
         vat.flux(ilk, address(this), msg.sender, rmul(wad, fix[ilk]));
         out[ilk][msg.sender] = add(out[ilk][msg.sender], wad);
-        require(out[ilk][msg.sender] <= bag[msg.sender], "End/insufficient-bag-balance");
+        require(out[ilk][msg.sender] <= bag[msg.sender], 'End/insufficient-bag-balance');
     }
 }

--- a/contracts/external/maker/join.sol
+++ b/contracts/external/maker/join.sol
@@ -18,22 +18,38 @@
 
 pragma solidity ^0.6.0;
 
-import "./lib.sol";
+import './lib.sol';
 
 interface GemLike {
-    function decimals() external view returns (uint);
-    function transfer(address,uint) external returns (bool);
-    function transferFrom(address,address,uint) external returns (bool);
+    function decimals() external view returns (uint256);
+
+    function transfer(address, uint256) external returns (bool);
+
+    function transferFrom(
+        address,
+        address,
+        uint256
+    ) external returns (bool);
 }
 
 interface DSTokenLike {
-    function mint(address,uint) external;
-    function burn(address,uint) external;
+    function mint(address, uint256) external;
+
+    function burn(address, uint256) external;
 }
 
 interface VatLike {
-    function slip(bytes32,address,int) external;
-    function move(address,address,uint) external;
+    function slip(
+        bytes32,
+        address,
+        int256
+    ) external;
+
+    function move(
+        address,
+        address,
+        uint256
+    ) external;
 }
 
 /*
@@ -62,21 +78,32 @@ interface VatLike {
 
 contract GemJoin is LibNote {
     // --- Auth ---
-    mapping (address => uint) public wards;
-    function rely(address usr) external note auth { wards[usr] = 1; }
-    function deny(address usr) external note auth { wards[usr] = 0; }
+    mapping(address => uint256) public wards;
+
+    function rely(address usr) external note auth {
+        wards[usr] = 1;
+    }
+
+    function deny(address usr) external note auth {
+        wards[usr] = 0;
+    }
+
     modifier auth {
-        require(wards[msg.sender] == 1, "GemJoin/not-authorized");
+        require(wards[msg.sender] == 1, 'GemJoin/not-authorized');
         _;
     }
 
     VatLike public vat;
     bytes32 public ilk;
     GemLike public gem;
-    uint    public dec;
-    uint    public live;  // Access Flag
+    uint256 public dec;
+    uint256 public live; // Access Flag
 
-    constructor(address vat_, bytes32 ilk_, address gem_) public {
+    constructor(
+        address vat_,
+        bytes32 ilk_,
+        address gem_
+    ) public {
         wards[msg.sender] = 1;
         live = 1;
         vat = VatLike(vat_);
@@ -84,35 +111,45 @@ contract GemJoin is LibNote {
         gem = GemLike(gem_);
         dec = gem.decimals();
     }
+
     function cage() external note auth {
         live = 0;
     }
-    function join(address usr, uint wad) external note {
-        require(live == 1, "GemJoin/not-live");
-        require(int(wad) >= 0, "GemJoin/overflow");
-        vat.slip(ilk, usr, int(wad));
-        require(gem.transferFrom(msg.sender, address(this), wad), "GemJoin/failed-transfer");
+
+    function join(address usr, uint256 wad) external note {
+        require(live == 1, 'GemJoin/not-live');
+        require(int256(wad) >= 0, 'GemJoin/overflow');
+        vat.slip(ilk, usr, int256(wad));
+        require(gem.transferFrom(msg.sender, address(this), wad), 'GemJoin/failed-transfer');
     }
-    function exit(address usr, uint wad) external note {
-        require(wad <= 2 ** 255, "GemJoin/overflow");
-        vat.slip(ilk, msg.sender, -int(wad));
-        require(gem.transfer(usr, wad), "GemJoin/failed-transfer");
+
+    function exit(address usr, uint256 wad) external note {
+        require(wad <= 2**255, 'GemJoin/overflow');
+        vat.slip(ilk, msg.sender, -int256(wad));
+        require(gem.transfer(usr, wad), 'GemJoin/failed-transfer');
     }
 }
 
 contract ETHJoin is LibNote {
     // --- Auth ---
-    mapping (address => uint) public wards;
-    function rely(address usr) external note auth { wards[usr] = 1; }
-    function deny(address usr) external note auth { wards[usr] = 0; }
+    mapping(address => uint256) public wards;
+
+    function rely(address usr) external note auth {
+        wards[usr] = 1;
+    }
+
+    function deny(address usr) external note auth {
+        wards[usr] = 0;
+    }
+
     modifier auth {
-        require(wards[msg.sender] == 1, "ETHJoin/not-authorized");
+        require(wards[msg.sender] == 1, 'ETHJoin/not-authorized');
         _;
     }
 
     VatLike public vat;
     bytes32 public ilk;
-    uint    public live;  // Access Flag
+    uint256 public live; // Access Flag
 
     constructor(address vat_, bytes32 ilk_) public {
         wards[msg.sender] = 1;
@@ -120,34 +157,44 @@ contract ETHJoin is LibNote {
         vat = VatLike(vat_);
         ilk = ilk_;
     }
+
     function cage() external note auth {
         live = 0;
     }
+
     function join(address usr) external payable note {
-        require(live == 1, "ETHJoin/not-live");
-        require(int(msg.value) >= 0, "ETHJoin/overflow");
-        vat.slip(ilk, usr, int(msg.value));
+        require(live == 1, 'ETHJoin/not-live');
+        require(int256(msg.value) >= 0, 'ETHJoin/overflow');
+        vat.slip(ilk, usr, int256(msg.value));
     }
-    function exit(address payable usr, uint wad) external note {
-        require(int(wad) >= 0, "ETHJoin/overflow");
-        vat.slip(ilk, msg.sender, -int(wad));
+
+    function exit(address payable usr, uint256 wad) external note {
+        require(int256(wad) >= 0, 'ETHJoin/overflow');
+        vat.slip(ilk, msg.sender, -int256(wad));
         usr.transfer(wad);
     }
 }
 
 contract DaiJoin is LibNote {
     // --- Auth ---
-    mapping (address => uint) public wards;
-    function rely(address usr) external note auth { wards[usr] = 1; }
-    function deny(address usr) external note auth { wards[usr] = 0; }
+    mapping(address => uint256) public wards;
+
+    function rely(address usr) external note auth {
+        wards[usr] = 1;
+    }
+
+    function deny(address usr) external note auth {
+        wards[usr] = 0;
+    }
+
     modifier auth {
-        require(wards[msg.sender] == 1, "DaiJoin/not-authorized");
+        require(wards[msg.sender] == 1, 'DaiJoin/not-authorized');
         _;
     }
 
     VatLike public vat;
     DSTokenLike public dai;
-    uint    public live;  // Access Flag
+    uint256 public live; // Access Flag
 
     constructor(address vat_, address dai_) public {
         wards[msg.sender] = 1;
@@ -155,19 +202,24 @@ contract DaiJoin is LibNote {
         vat = VatLike(vat_);
         dai = DSTokenLike(dai_);
     }
+
     function cage() external note auth {
         live = 0;
     }
-    uint constant ONE = 10 ** 27;
-    function mul(uint x, uint y) internal pure returns (uint z) {
+
+    uint256 constant ONE = 10**27;
+
+    function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require(y == 0 || (z = x * y) / y == x);
     }
-    function join(address usr, uint wad) external note {
+
+    function join(address usr, uint256 wad) external note {
         vat.move(address(this), usr, mul(ONE, wad));
         dai.burn(msg.sender, wad);
     }
-    function exit(address usr, uint wad) external note {
-        require(live == 1, "DaiJoin/not-live");
+
+    function exit(address usr, uint256 wad) external note {
+        require(live == 1, 'DaiJoin/not-live');
         vat.move(msg.sender, address(this), mul(ONE, wad));
         dai.mint(usr, wad);
     }

--- a/contracts/external/maker/jug.sol
+++ b/contracts/external/maker/jug.sol
@@ -2,36 +2,50 @@
 
 pragma solidity ^0.6.0;
 
-import "./lib.sol";
+import './lib.sol';
 
 interface VatLike {
-    function ilks(bytes32) external returns (
-        uint256 Art,   // [wad]
-        uint256 rate   // [ray]
-    );
-    function fold(bytes32,address,int) external;
+    function ilks(bytes32)
+        external
+        returns (
+            uint256 Art, // [wad]
+            uint256 rate // [ray]
+        );
+
+    function fold(
+        bytes32,
+        address,
+        int256
+    ) external;
 }
 
 contract Jug is LibNote {
     // --- Auth ---
-    mapping (address => uint) public wards;
-    function rely(address usr) external note auth { wards[usr] = 1; }
-    function deny(address usr) external note auth { wards[usr] = 0; }
+    mapping(address => uint256) public wards;
+
+    function rely(address usr) external note auth {
+        wards[usr] = 1;
+    }
+
+    function deny(address usr) external note auth {
+        wards[usr] = 0;
+    }
+
     modifier auth {
-        require(wards[msg.sender] == 1, "Jug/not-authorized");
+        require(wards[msg.sender] == 1, 'Jug/not-authorized');
         _;
     }
 
     // --- Data ---
     struct Ilk {
-        uint256 duty;  // Collateral-specific, per-second stability fee contribution [ray]
-        uint256  rho;  // Time of last drip [unix epoch time]
+        uint256 duty; // Collateral-specific, per-second stability fee contribution [ray]
+        uint256 rho; // Time of last drip [unix epoch time]
     }
 
-    mapping (bytes32 => Ilk) public ilks;
-    VatLike                  public vat;   // CDP Engine
-    address                  public vow;   // Debt Engine
-    uint256                  public base;  // Global, per-second stability fee contribution [ray]
+    mapping(bytes32 => Ilk) public ilks;
+    VatLike public vat; // CDP Engine
+    address public vow; // Debt Engine
+    uint256 public base; // Global, per-second stability fee contribution [ray]
 
     // --- Init ---
     constructor(address vat_) public {
@@ -40,39 +54,74 @@ contract Jug is LibNote {
     }
 
     // --- Math ---
-    function rpow(uint x, uint n, uint b) internal pure returns (uint z) {
-      assembly {
-        switch x case 0 {switch n case 0 {z := b} default {z := 0}}
-        default {
-          switch mod(n, 2) case 0 { z := b } default { z := x }
-          let half := div(b, 2)  // for rounding.
-          for { n := div(n, 2) } n { n := div(n,2) } {
-            let xx := mul(x, x)
-            if iszero(eq(div(xx, x), x)) { revert(0,0) }
-            let xxRound := add(xx, half)
-            if lt(xxRound, xx) { revert(0,0) }
-            x := div(xxRound, b)
-            if mod(n,2) {
-              let zx := mul(z, x)
-              if and(iszero(iszero(x)), iszero(eq(div(zx, x), z))) { revert(0,0) }
-              let zxRound := add(zx, half)
-              if lt(zxRound, zx) { revert(0,0) }
-              z := div(zxRound, b)
-            }
-          }
+    function rpow(
+        uint256 x,
+        uint256 n,
+        uint256 b
+    ) internal pure returns (uint256 z) {
+        assembly {
+            switch x
+                case 0 {
+                    switch n
+                        case 0 {
+                            z := b
+                        }
+                        default {
+                            z := 0
+                        }
+                }
+                default {
+                    switch mod(n, 2)
+                        case 0 {
+                            z := b
+                        }
+                        default {
+                            z := x
+                        }
+                    let half := div(b, 2) // for rounding.
+                    for {
+                        n := div(n, 2)
+                    } n {
+                        n := div(n, 2)
+                    } {
+                        let xx := mul(x, x)
+                        if iszero(eq(div(xx, x), x)) {
+                            revert(0, 0)
+                        }
+                        let xxRound := add(xx, half)
+                        if lt(xxRound, xx) {
+                            revert(0, 0)
+                        }
+                        x := div(xxRound, b)
+                        if mod(n, 2) {
+                            let zx := mul(z, x)
+                            if and(iszero(iszero(x)), iszero(eq(div(zx, x), z))) {
+                                revert(0, 0)
+                            }
+                            let zxRound := add(zx, half)
+                            if lt(zxRound, zx) {
+                                revert(0, 0)
+                            }
+                            z := div(zxRound, b)
+                        }
+                    }
+                }
         }
-      }
     }
-    uint256 constant ONE = 10 ** 27;
-    function add_(uint x, uint y) internal pure returns (uint z) {
+
+    uint256 constant ONE = 10**27;
+
+    function add_(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = x + y;
         require(z >= x);
     }
-    function diff(uint x, uint y) internal pure returns (int z) {
-        z = int(x) - int(y);
-        require(int(x) >= 0 && int(y) >= 0);
+
+    function diff(uint256 x, uint256 y) internal pure returns (int256 z) {
+        z = int256(x) - int256(y);
+        require(int256(x) >= 0 && int256(y) >= 0);
     }
-    function rmul(uint x, uint y) internal pure returns (uint z) {
+
+    function rmul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = x * y;
         require(y == 0 || z / y == x);
         z = z / ONE;
@@ -81,28 +130,35 @@ contract Jug is LibNote {
     // --- Administration ---
     function init(bytes32 ilk) external note auth {
         Ilk storage i = ilks[ilk];
-        require(i.duty == 0, "Jug/ilk-already-init");
+        require(i.duty == 0, 'Jug/ilk-already-init');
         i.duty = ONE;
-        i.rho  = now;
+        i.rho = now;
     }
-    function file(bytes32 ilk, bytes32 what, uint data) external note auth {
-        require(now == ilks[ilk].rho, "Jug/rho-not-updated");
-        if (what == "duty") ilks[ilk].duty = data;
-        else revert("Jug/file-unrecognized-param");
+
+    function file(
+        bytes32 ilk,
+        bytes32 what,
+        uint256 data
+    ) external note auth {
+        require(now == ilks[ilk].rho, 'Jug/rho-not-updated');
+        if (what == 'duty') ilks[ilk].duty = data;
+        else revert('Jug/file-unrecognized-param');
     }
-    function file(bytes32 what, uint data) external note auth {
-        if (what == "base") base = data;
-        else revert("Jug/file-unrecognized-param");
+
+    function file(bytes32 what, uint256 data) external note auth {
+        if (what == 'base') base = data;
+        else revert('Jug/file-unrecognized-param');
     }
+
     function file(bytes32 what, address data) external note auth {
-        if (what == "vow") vow = data;
-        else revert("Jug/file-unrecognized-param");
+        if (what == 'vow') vow = data;
+        else revert('Jug/file-unrecognized-param');
     }
 
     // --- Stability Fee Collection ---
-    function drip(bytes32 ilk) external note returns (uint rate) {
-        require(now >= ilks[ilk].rho, "Jug/invalid-now");
-        (, uint prev) = vat.ilks(ilk);
+    function drip(bytes32 ilk) external note returns (uint256 rate) {
+        require(now >= ilks[ilk].rho, 'Jug/invalid-now');
+        (, uint256 prev) = vat.ilks(ilk);
         rate = rmul(rpow(add_(base, ilks[ilk].duty), now - ilks[ilk].rho, ONE), prev);
         vat.fold(ilk, vow, diff(rate, prev));
         ilks[ilk].rho = now;

--- a/contracts/external/maker/lib.sol
+++ b/contracts/external/maker/lib.sol
@@ -17,11 +17,11 @@ pragma solidity ^0.6.0;
 
 contract LibNote {
     event LogNote(
-        bytes4   indexed  sig,
-        address  indexed  usr,
-        bytes32  indexed  arg1,
-        bytes32  indexed  arg2,
-        bytes             data
+        bytes4 indexed sig,
+        address indexed usr,
+        bytes32 indexed arg1,
+        bytes32 indexed arg2,
+        bytes data
     ) anonymous;
 
     modifier note {

--- a/contracts/external/maker/note.sol
+++ b/contracts/external/maker/note.sol
@@ -18,12 +18,12 @@ pragma solidity >=0.4.23;
 
 contract DSNote {
     event LogNote(
-        bytes4   indexed  sig,
-        address  indexed  guy,
-        bytes32  indexed  foo,
-        bytes32  indexed  bar,
-        uint256           wad,
-        bytes             fax
+        bytes4 indexed sig,
+        address indexed guy,
+        bytes32 indexed foo,
+        bytes32 indexed bar,
+        uint256 wad,
+        bytes fax
     ) anonymous;
 
     modifier note {

--- a/contracts/external/maker/vat.sol
+++ b/contracts/external/maker/vat.sol
@@ -18,55 +18,70 @@ pragma solidity ^0.6.0;
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-
 contract Vat {
     // --- Auth ---
-    mapping (address => uint) public wards;
-    function rely(address usr) external note auth { require(live == 1, "Vat/not-live"); wards[usr] = 1; }
-    function deny(address usr) external note auth { require(live == 1, "Vat/not-live"); wards[usr] = 0; }
+    mapping(address => uint256) public wards;
+
+    function rely(address usr) external note auth {
+        require(live == 1, 'Vat/not-live');
+        wards[usr] = 1;
+    }
+
+    function deny(address usr) external note auth {
+        require(live == 1, 'Vat/not-live');
+        wards[usr] = 0;
+    }
+
     modifier auth {
-        require(wards[msg.sender] == 1, "Vat/not-authorized");
+        require(wards[msg.sender] == 1, 'Vat/not-authorized');
         _;
     }
 
-    mapping(address => mapping (address => uint)) public can;
-    function hope(address usr) external note { can[msg.sender][usr] = 1; }
-    function nope(address usr) external note { can[msg.sender][usr] = 0; }
+    mapping(address => mapping(address => uint256)) public can;
+
+    function hope(address usr) external note {
+        can[msg.sender][usr] = 1;
+    }
+
+    function nope(address usr) external note {
+        can[msg.sender][usr] = 0;
+    }
+
     function wish(address bit, address usr) internal view returns (bool) {
         return either(bit == usr, can[bit][usr] == 1);
     }
 
     // --- Data ---
     struct Ilk {
-        uint256 Art;   // Total Normalised Debt     [wad]
-        uint256 rate;  // Accumulated Rates         [ray]
-        uint256 spot;  // Price with Safety Margin  [ray]
-        uint256 line;  // Debt Ceiling              [rad]
-        uint256 dust;  // Urn Debt Floor            [rad]
+        uint256 Art; // Total Normalised Debt     [wad]
+        uint256 rate; // Accumulated Rates         [ray]
+        uint256 spot; // Price with Safety Margin  [ray]
+        uint256 line; // Debt Ceiling              [rad]
+        uint256 dust; // Urn Debt Floor            [rad]
     }
     struct Urn {
-        uint256 ink;   // Locked Collateral  [wad]
-        uint256 art;   // Normalised Debt    [wad]
+        uint256 ink; // Locked Collateral  [wad]
+        uint256 art; // Normalised Debt    [wad]
     }
 
-    mapping (bytes32 => Ilk)                       public ilks;
-    mapping (bytes32 => mapping (address => Urn )) public urns;
-    mapping (bytes32 => mapping (address => uint)) public gem;  // [wad]
-    mapping (address => uint256)                   public dai;  // [rad]
-    mapping (address => uint256)                   public sin;  // [rad]
+    mapping(bytes32 => Ilk) public ilks;
+    mapping(bytes32 => mapping(address => Urn)) public urns;
+    mapping(bytes32 => mapping(address => uint256)) public gem; // [wad]
+    mapping(address => uint256) public dai; // [rad]
+    mapping(address => uint256) public sin; // [rad]
 
-    uint256 public debt;  // Total Dai Issued    [rad]
-    uint256 public vice;  // Total Unbacked Dai  [rad]
-    uint256 public Line;  // Total Debt Ceiling  [rad]
-    uint256 public live;  // Access Flag
+    uint256 public debt; // Total Dai Issued    [rad]
+    uint256 public vice; // Total Unbacked Dai  [rad]
+    uint256 public Line; // Total Debt Ceiling  [rad]
+    uint256 public live; // Access Flag
 
     // --- Logs ---
     event LogNote(
-        bytes4   indexed  sig,
-        bytes32  indexed  arg1,
-        bytes32  indexed  arg2,
-        bytes32  indexed  arg3,
-        bytes             data
+        bytes4 indexed sig,
+        bytes32 indexed arg1,
+        bytes32 indexed arg2,
+        bytes32 indexed arg3,
+        bytes data
     ) anonymous;
 
     modifier note {
@@ -81,115 +96,161 @@ contract Vat {
     }
 
     // --- Math ---
-    function add_(uint x, int y) internal pure returns (uint z) {
-        z = x + uint(y);
-        require(y >= 0 || z <= x, "Vat/add");
-        require(y <= 0 || z >= x, "Vat/add");
+    function add_(uint256 x, int256 y) internal pure returns (uint256 z) {
+        z = x + uint256(y);
+        require(y >= 0 || z <= x, 'Vat/add');
+        require(y <= 0 || z >= x, 'Vat/add');
     }
-    function sub_(uint x, int y) internal pure returns (uint z) {
-        z = x - uint(y);
-        require(y <= 0 || z <= x, "Vat/sub");
-        require(y >= 0 || z >= x, "Vat/sub");
+
+    function sub_(uint256 x, int256 y) internal pure returns (uint256 z) {
+        z = x - uint256(y);
+        require(y <= 0 || z <= x, 'Vat/sub');
+        require(y >= 0 || z >= x, 'Vat/sub');
     }
-    function mul_(uint x, int y) internal pure returns (int z) {
-        z = int(x) * y;
-        require(int(x) >= 0, "Vat/mul");
-        require(y == 0 || z / y == int(x), "Vat/mul");
+
+    function mul_(uint256 x, int256 y) internal pure returns (int256 z) {
+        z = int256(x) * y;
+        require(int256(x) >= 0, 'Vat/mul');
+        require(y == 0 || z / y == int256(x), 'Vat/mul');
     }
-    function add_(uint x, uint y) internal pure returns (uint z) {
-        require((z = x + y) >= x, "Vat/add");
+
+    function add_(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require((z = x + y) >= x, 'Vat/add');
     }
-    function sub_(uint x, uint y) internal pure returns (uint z) {
-        require((z = x - y) <= x, "Vat/sub");
+
+    function sub_(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require((z = x - y) <= x, 'Vat/sub');
     }
-    function mul_(uint x, uint y) internal pure returns (uint z) {
-        require(y == 0 || (z = x * y) / y == x, "Vat/mul");
+
+    function mul_(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require(y == 0 || (z = x * y) / y == x, 'Vat/mul');
     }
 
     // --- Administration ---
     function init(bytes32 ilk) external note auth {
-        require(ilks[ilk].rate == 0, "Vat/ilk-already-init");
-        ilks[ilk].rate = 10 ** 27;
+        require(ilks[ilk].rate == 0, 'Vat/ilk-already-init');
+        ilks[ilk].rate = 10**27;
     }
-    function file(bytes32 what, uint data) external note auth {
-        require(live == 1, "Vat/not-live");
-        if (what == "Line") Line = data;
-        else revert("Vat/file-unrecognized-param");
+
+    function file(bytes32 what, uint256 data) external note auth {
+        require(live == 1, 'Vat/not-live');
+        if (what == 'Line') Line = data;
+        else revert('Vat/file-unrecognized-param');
     }
-    function file(bytes32 ilk, bytes32 what, uint data) external note auth {
-        require(live == 1, "Vat/not-live");
-        if (what == "spot") ilks[ilk].spot = data;
-        else if (what == "line") ilks[ilk].line = data;
-        else if (what == "dust") ilks[ilk].dust = data;
-        else revert("Vat/file-unrecognized-param");
+
+    function file(
+        bytes32 ilk,
+        bytes32 what,
+        uint256 data
+    ) external note auth {
+        require(live == 1, 'Vat/not-live');
+        if (what == 'spot') ilks[ilk].spot = data;
+        else if (what == 'line') ilks[ilk].line = data;
+        else if (what == 'dust') ilks[ilk].dust = data;
+        else revert('Vat/file-unrecognized-param');
     }
+
     function cage() external note auth {
         live = 0;
     }
 
     // --- Fungibility ---
-    function slip(bytes32 ilk, address usr, int256 wad) external note auth {
+    function slip(
+        bytes32 ilk,
+        address usr,
+        int256 wad
+    ) external note auth {
         gem[ilk][usr] = add_(gem[ilk][usr], wad);
     }
-    function flux(bytes32 ilk, address src, address dst, uint256 wad) external note {
-        require(wish(src, msg.sender), "Vat/not-allowed");
+
+    function flux(
+        bytes32 ilk,
+        address src,
+        address dst,
+        uint256 wad
+    ) external note {
+        require(wish(src, msg.sender), 'Vat/not-allowed');
         gem[ilk][src] = sub_(gem[ilk][src], wad);
         gem[ilk][dst] = add_(gem[ilk][dst], wad);
     }
-    function move(address src, address dst, uint256 rad) external note {
-        require(wish(src, msg.sender), "Vat/not-allowed");
+
+    function move(
+        address src,
+        address dst,
+        uint256 rad
+    ) external note {
+        require(wish(src, msg.sender), 'Vat/not-allowed');
         dai[src] = sub_(dai[src], rad);
         dai[dst] = add_(dai[dst], rad);
     }
 
     function either(bool x, bool y) internal pure returns (bool z) {
-        assembly{ z := or(x, y)}
+        assembly {
+            z := or(x, y)
+        }
     }
+
     function both(bool x, bool y) internal pure returns (bool z) {
-        assembly{ z := and(x, y)}
+        assembly {
+            z := and(x, y)
+        }
     }
 
     // --- CDP Manipulation ---
-    function frob(bytes32 i, address u, address v, address w, int dink, int dart) external note {
+    function frob(
+        bytes32 i,
+        address u,
+        address v,
+        address w,
+        int256 dink,
+        int256 dart
+    ) external note {
         // system is live
-        require(live == 1, "Vat/not-live");
+        require(live == 1, 'Vat/not-live');
 
         Urn memory urn = urns[i][u];
         Ilk memory ilk = ilks[i];
         // ilk has been initialised
-        require(ilk.rate != 0, "Vat/ilk-not-init");
+        require(ilk.rate != 0, 'Vat/ilk-not-init');
 
         urn.ink = add_(urn.ink, dink);
         urn.art = add_(urn.art, dart);
         ilk.Art = add_(ilk.Art, dart);
 
-        int dtab = mul_(ilk.rate, dart);
-        uint tab = mul_(ilk.rate, urn.art);
-        debt     = add_(debt, dtab);
+        int256 dtab = mul_(ilk.rate, dart);
+        uint256 tab = mul_(ilk.rate, urn.art);
+        debt = add_(debt, dtab);
 
         // either debt has decreased, or debt ceilings are not exceeded
-        require(either(dart <= 0, both(mul_(ilk.Art, ilk.rate) <= ilk.line, debt <= Line)), "Vat/ceiling-exceeded");
+        require(either(dart <= 0, both(mul_(ilk.Art, ilk.rate) <= ilk.line, debt <= Line)), 'Vat/ceiling-exceeded');
         // urn is either less risky than before, or it is safe
-        require(either(both(dart <= 0, dink >= 0), tab <= mul_(urn.ink, ilk.spot)), "Vat/not-safe");
+        require(either(both(dart <= 0, dink >= 0), tab <= mul_(urn.ink, ilk.spot)), 'Vat/not-safe');
 
         // urn is either more safe, or the owner consents
-        require(either(both(dart <= 0, dink >= 0), wish(u, msg.sender)), "Vat/not-allowed-u");
+        require(either(both(dart <= 0, dink >= 0), wish(u, msg.sender)), 'Vat/not-allowed-u');
         // collateral src consents
-        require(either(dink <= 0, wish(v, msg.sender)), "Vat/not-allowed-v");
+        require(either(dink <= 0, wish(v, msg.sender)), 'Vat/not-allowed-v');
         // debt dst consents
-        require(either(dart >= 0, wish(w, msg.sender)), "Vat/not-allowed-w");
+        require(either(dart >= 0, wish(w, msg.sender)), 'Vat/not-allowed-w');
 
         // urn has no debt, or a non-dusty amount
-        require(either(urn.art == 0, tab >= ilk.dust), "Vat/dust");
+        require(either(urn.art == 0, tab >= ilk.dust), 'Vat/dust');
 
         gem[i][v] = sub_(gem[i][v], dink);
-        dai[w]    = add_(dai[w],    dtab);
+        dai[w] = add_(dai[w], dtab);
 
         urns[i][u] = urn;
-        ilks[i]    = ilk;
+        ilks[i] = ilk;
     }
+
     // --- CDP Fungibility ---
-    function fork(bytes32 ilk, address src, address dst, int dink, int dart) external note {
+    function fork(
+        bytes32 ilk,
+        address src,
+        address dst,
+        int256 dink,
+        int256 dart
+    ) external note {
         Urn storage u = urns[ilk][src];
         Urn storage v = urns[ilk][dst];
         Ilk storage i = ilks[ilk];
@@ -199,22 +260,30 @@ contract Vat {
         v.ink = add_(v.ink, dink);
         v.art = add_(v.art, dart);
 
-        uint utab = mul_(u.art, i.rate);
-        uint vtab = mul_(v.art, i.rate);
+        uint256 utab = mul_(u.art, i.rate);
+        uint256 vtab = mul_(v.art, i.rate);
 
         // both sides consent
-        require(both(wish(src, msg.sender), wish(dst, msg.sender)), "Vat/not-allowed");
+        require(both(wish(src, msg.sender), wish(dst, msg.sender)), 'Vat/not-allowed');
 
         // both sides safe
-        require(utab <= mul_(u.ink, i.spot), "Vat/not-safe-src");
-        require(vtab <= mul_(v.ink, i.spot), "Vat/not-safe-dst");
+        require(utab <= mul_(u.ink, i.spot), 'Vat/not-safe-src');
+        require(vtab <= mul_(v.ink, i.spot), 'Vat/not-safe-dst');
 
         // both sides non-dusty
-        require(either(utab >= i.dust, u.art == 0), "Vat/dust-src");
-        require(either(vtab >= i.dust, v.art == 0), "Vat/dust-dst");
+        require(either(utab >= i.dust, u.art == 0), 'Vat/dust-src');
+        require(either(vtab >= i.dust, v.art == 0), 'Vat/dust-dst');
     }
+
     // --- CDP Confiscation ---
-    function grab(bytes32 i, address u, address v, address w, int dink, int dart) external note auth {
+    function grab(
+        bytes32 i,
+        address u,
+        address v,
+        address w,
+        int256 dink,
+        int256 dart
+    ) external note auth {
         Urn storage urn = urns[i][u];
         Ilk storage ilk = ilks[i];
 
@@ -222,35 +291,44 @@ contract Vat {
         urn.art = add_(urn.art, dart);
         ilk.Art = add_(ilk.Art, dart);
 
-        int dtab = mul_(ilk.rate, dart);
+        int256 dtab = mul_(ilk.rate, dart);
 
         gem[i][v] = sub_(gem[i][v], dink);
-        sin[w]    = sub_(sin[w],    dtab);
-        vice      = sub_(vice,      dtab);
+        sin[w] = sub_(sin[w], dtab);
+        vice = sub_(vice, dtab);
     }
 
     // --- Settlement ---
-    function heal(uint rad) external note {
+    function heal(uint256 rad) external note {
         address u = msg.sender;
         sin[u] = sub_(sin[u], rad);
         dai[u] = sub_(dai[u], rad);
-        vice   = sub_(vice,   rad);
-        debt   = sub_(debt,   rad);
+        vice = sub_(vice, rad);
+        debt = sub_(debt, rad);
     }
-    function suck(address u, address v, uint rad) external note auth {
+
+    function suck(
+        address u,
+        address v,
+        uint256 rad
+    ) external note auth {
         sin[u] = add_(sin[u], rad);
         dai[v] = add_(dai[v], rad);
-        vice   = add_(vice,   rad);
-        debt   = add_(debt,   rad);
+        vice = add_(vice, rad);
+        debt = add_(debt, rad);
     }
 
     // --- Rates ---
-    function fold(bytes32 i, address u, int rate) external note auth {
-        require(live == 1, "Vat/not-live");
+    function fold(
+        bytes32 i,
+        address u,
+        int256 rate
+    ) external note auth {
+        require(live == 1, 'Vat/not-live');
         Ilk storage ilk = ilks[i];
         ilk.rate = add_(ilk.rate, rate);
-        int rad  = mul_(ilk.Art, rate);
-        dai[u]   = add_(dai[u], rad);
-        debt     = add_(debt,   rad);
+        int256 rad = mul_(ilk.Art, rate);
+        dai[u] = add_(dai[u], rad);
+        debt = add_(debt, rad);
     }
 }

--- a/contracts/external/maker/weth.sol
+++ b/contracts/external/maker/weth.sol
@@ -17,53 +17,56 @@
 pragma solidity ^0.6.0;
 
 contract WETH9 {
-    string public name     = "Wrapped Ether";
-    string public symbol   = "WETH";
-    uint8  public decimals = 18;
+    string public name = 'Wrapped Ether';
+    string public symbol = 'WETH';
+    uint8 public decimals = 18;
 
-    event  Approval(address indexed src, address indexed guy, uint wad);
-    event  Transfer(address indexed src, address indexed dst, uint wad);
-    event  Deposit(address indexed dst, uint wad);
-    event  Withdrawal(address indexed src, uint wad);
+    event Approval(address indexed src, address indexed guy, uint256 wad);
+    event Transfer(address indexed src, address indexed dst, uint256 wad);
+    event Deposit(address indexed dst, uint256 wad);
+    event Withdrawal(address indexed src, uint256 wad);
 
-    mapping (address => uint)                       public  balanceOf;
-    mapping (address => mapping (address => uint))  public  allowance;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
 
     receive() external payable {
         deposit();
     }
+
     function deposit() public payable {
         balanceOf[msg.sender] += msg.value;
         emit Deposit(msg.sender, msg.value);
     }
-    function withdraw(uint wad) public {
+
+    function withdraw(uint256 wad) public {
         require(balanceOf[msg.sender] >= wad);
         balanceOf[msg.sender] -= wad;
         msg.sender.transfer(wad);
         emit Withdrawal(msg.sender, wad);
     }
 
-    function totalSupply() public view returns (uint) {
+    function totalSupply() public view returns (uint256) {
         return address(this).balance;
     }
 
-    function approve(address guy, uint wad) public returns (bool) {
+    function approve(address guy, uint256 wad) public returns (bool) {
         allowance[msg.sender][guy] = wad;
         emit Approval(msg.sender, guy, wad);
         return true;
     }
 
-    function transfer(address dst, uint wad) public returns (bool) {
+    function transfer(address dst, uint256 wad) public returns (bool) {
         return transferFrom(msg.sender, dst, wad);
     }
 
-    function transferFrom(address src, address dst, uint wad)
-        public
-        returns (bool)
-    {
+    function transferFrom(
+        address src,
+        address dst,
+        uint256 wad
+    ) public returns (bool) {
         require(balanceOf[src] >= wad);
 
-        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+        if (src != msg.sender && allowance[src][msg.sender] != uint256(-1)) {
             require(allowance[src][msg.sender] >= wad);
             allowance[src][msg.sender] -= wad;
         }

--- a/contracts/helpers/DecimalMath.sol
+++ b/contracts/helpers/DecimalMath.sol
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
-import "@openzeppelin/contracts/math/SafeMath.sol";
-
+import '@openzeppelin/contracts/math/SafeMath.sol';
 
 /// @dev Implements simple fixed point math mul and div operations for 27 decimals.
 contract DecimalMath {
     using SafeMath for uint256;
 
-    uint256 constant public UNIT = 1e27;
+    uint256 public constant UNIT = 1e27;
 
     /// @dev Multiplies x and y, assuming they are both fixed point with 27 digits.
     function muld(uint256 x, uint256 y) internal pure returns (uint256) {
@@ -21,16 +20,14 @@ contract DecimalMath {
 
     /// @dev Multiplies x and y, rounding up to the closest representable number.
     /// Assumes x and y are both fixed point with `decimals` digits.
-    function muldrup(uint256 x, uint256 y) internal pure returns (uint256)
-    {
+    function muldrup(uint256 x, uint256 y) internal pure returns (uint256) {
         uint256 z = x.mul(y);
         return z.mod(UNIT) == 0 ? z.div(UNIT) : z.div(UNIT).add(1);
     }
 
     /// @dev Divides x between y, rounding up to the closest representable number.
     /// Assumes x and y are both fixed point with `decimals` digits.
-    function divdrup(uint256 x, uint256 y) internal pure returns (uint256)
-    {
+    function divdrup(uint256 x, uint256 y) internal pure returns (uint256) {
         uint256 z = x.mul(UNIT);
         return z.mod(y) == 0 ? z.div(y) : z.div(y).add(1);
     }

--- a/contracts/helpers/ERC20Permit.sol
+++ b/contracts/helpers/ERC20Permit.sol
@@ -2,8 +2,8 @@
 // Adapted from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/53516bc555a454862470e7860a9b5254db4d00f5/contracts/token/ERC20/ERC20Permit.sol
 pragma solidity ^0.6.0;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "../interfaces/IERC2612.sol";
+import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
+import '../interfaces/IERC2612.sol';
 
 /**
  * @dev Extension of {ERC20} that allows token holders to use their tokens
@@ -14,9 +14,10 @@ import "../interfaces/IERC2612.sol";
  * The {permit} signature mechanism conforms to the {IERC2612} interface.
  */
 abstract contract ERC20Permit is ERC20, IERC2612 {
-    mapping (address => uint256) public override nonces;
+    mapping(address => uint256) public override nonces;
 
-    bytes32 public immutable PERMIT_TYPEHASH = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 public immutable PERMIT_TYPEHASH =
+        keccak256('Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)');
     bytes32 public immutable DOMAIN_SEPARATOR;
 
     constructor(string memory name_, string memory symbol_) internal ERC20(name_, symbol_) {
@@ -27,9 +28,9 @@ abstract contract ERC20Permit is ERC20, IERC2612 {
 
         DOMAIN_SEPARATOR = keccak256(
             abi.encode(
-                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'),
                 keccak256(bytes(name_)),
-                keccak256(bytes("1")),
+                keccak256(bytes('1')),
                 chainId,
                 address(this)
             )
@@ -42,33 +43,23 @@ abstract contract ERC20Permit is ERC20, IERC2612 {
      * In cases where the free option is not a concern, deadline can simply be
      * set to uint(-1), so it should be seen as an optional parameter
      */
-    function permit(address owner, address spender, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) public virtual override {
-        require(deadline >= block.timestamp, "ERC20Permit: expired deadline");
+    function permit(
+        address owner,
+        address spender,
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public virtual override {
+        require(deadline >= block.timestamp, 'ERC20Permit: expired deadline');
 
-        bytes32 hashStruct = keccak256(
-            abi.encode(
-                PERMIT_TYPEHASH,
-                owner,
-                spender,
-                amount,
-                nonces[owner]++,
-                deadline
-            )
-        );
+        bytes32 hashStruct = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, amount, nonces[owner]++, deadline));
 
-        bytes32 hash = keccak256(
-            abi.encodePacked(
-                '\x19\x01',
-                DOMAIN_SEPARATOR,
-                hashStruct
-            )
-        );
+        bytes32 hash = keccak256(abi.encodePacked('\x19\x01', DOMAIN_SEPARATOR, hashStruct));
 
         address signer = ecrecover(hash, v, r, s);
-        require(
-            signer != address(0) && signer == owner,
-            "ERC20Permit: invalid signature"
-        );
+        require(signer != address(0) && signer == owner, 'ERC20Permit: invalid signature');
 
         _approve(owner, spender, amount);
     }

--- a/contracts/helpers/Orchestrated.sol
+++ b/contracts/helpers/Orchestrated.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
-import "@openzeppelin/contracts/access/Ownable.sol";
-
+import '@openzeppelin/contracts/access/Ownable.sol';
 
 /**
  * @dev Orchestrated allows to define static access control between multiple contracts.
@@ -14,12 +13,12 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 contract Orchestrated is Ownable {
     event GrantedAccess(address access, bytes4 signature);
 
-    mapping(address => mapping (bytes4 => bool)) public orchestration;
+    mapping(address => mapping(bytes4 => bool)) public orchestration;
 
-    constructor () public Ownable() {}
+    constructor() public Ownable() {}
 
     /// @dev Restrict usage to authorized users
-    /// @param err The error to display if the validation fails 
+    /// @param err The error to display if the validation fails
     modifier onlyOrchestrated(string memory err) {
         require(orchestration[msg.sender][msg.sig], err);
         _;

--- a/contracts/helpers/SafeCast.sol
+++ b/contracts/helpers/SafeCast.sol
@@ -1,23 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-
 library SafeCast {
     /// @dev Safe casting from uint256 to uint128
-    function toUint128(uint256 x) internal pure returns(uint128) {
-        require(
-            x <= type(uint128).max,
-            "YieldProxy: Cast overflow"
-        );
+    function toUint128(uint256 x) internal pure returns (uint128) {
+        require(x <= type(uint128).max, 'YieldProxy: Cast overflow');
         return uint128(x);
     }
 
     /// @dev Safe casting from uint256 to int256
-    function toInt256(uint256 x) internal pure returns(int256) {
-        require(
-            x <= uint256(type(int256).max),
-            "YieldProxy: Cast overflow"
-        );
+    function toInt256(uint256 x) internal pure returns (int256) {
+        require(x <= uint256(type(int256).max), 'YieldProxy: Cast overflow');
         return int256(x);
     }
 }

--- a/contracts/helpers/YieldAuth.sol
+++ b/contracts/helpers/YieldAuth.sol
@@ -1,15 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-import "../interfaces/IERC2612.sol";
-import "../interfaces/IDai.sol";
-import "../interfaces/IDelegable.sol";
+import '../interfaces/IERC2612.sol';
+import '../interfaces/IDai.sol';
+import '../interfaces/IDelegable.sol';
 
 /// @dev This library encapsulates methods obtain authorizations using packed signatures
 library YieldAuth {
-
     /// @dev Unpack r, s and v from a `bytes` signature
-    function unpack(bytes memory signature) internal pure returns (bytes32 r, bytes32 s, uint8 v) {
+    function unpack(bytes memory signature)
+        internal
+        pure
+        returns (
+            bytes32 r,
+            bytes32 s,
+            uint8 v
+        )
+    {
         assembly {
             r := mload(add(signature, 0x20))
             s := mload(add(signature, 0x40))
@@ -28,7 +35,11 @@ library YieldAuth {
     }
 
     /// @dev Use a packed `signature` to approve `spender` on the `dai` contract for the maximum amount.
-    function permitPackedDai(IDai dai, address spender, bytes memory signature) internal {
+    function permitPackedDai(
+        IDai dai,
+        address spender,
+        bytes memory signature
+    ) internal {
         bytes32 r;
         bytes32 s;
         uint8 v;
@@ -38,7 +49,11 @@ library YieldAuth {
     }
 
     /// @dev Use a packed `signature` to approve `spender` on the target IERC2612 `token` contract for the maximum amount.
-    function permitPacked(IERC2612 token, address spender, bytes memory signature) internal {
+    function permitPacked(
+        IERC2612 token,
+        address spender,
+        bytes memory signature
+    ) internal {
         bytes32 r;
         bytes32 s;
         uint8 v;

--- a/contracts/interfaces/IChai.sol
+++ b/contracts/interfaces/IChai.sol
@@ -1,14 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "./IERC2612.sol";
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import './IERC2612.sol';
 
 /// @dev interface for the chai contract
 /// Taken from https://github.com/makerdao/developerguides/blob/master/dai/dsr-integration-guide/dsr.sol
 interface IChai is IERC20, IERC2612 {
-    function move(address src, address dst, uint wad) external returns (bool);
-    function dai(address usr) external returns (uint wad);
-    function join(address dst, uint wad) external;
-    function exit(address src, uint wad) external;
-    function draw(address src, uint wad) external;
+    function move(
+        address src,
+        address dst,
+        uint256 wad
+    ) external returns (bool);
+
+    function dai(address usr) external returns (uint256 wad);
+
+    function join(address dst, uint256 wad) external;
+
+    function exit(address src, uint256 wad) external;
+
+    function draw(address src, uint256 wad) external;
 }

--- a/contracts/interfaces/IController.sol
+++ b/contracts/interfaces/IController.sol
@@ -1,30 +1,92 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-import "./IDelegable.sol";
-import "./ITreasury.sol";
-import "./IFYDai.sol";
-
+import './IDelegable.sol';
+import './ITreasury.sol';
+import './IFYDai.sol';
 
 interface IController is IDelegable {
     function treasury() external view returns (ITreasury);
+
     function series(uint256) external view returns (IFYDai);
+
     function seriesIterator(uint256) external view returns (uint256);
+
     function totalSeries() external view returns (uint256);
+
     function containsSeries(uint256) external view returns (bool);
+
     function posted(bytes32, address) external view returns (uint256);
+
     function locked(bytes32, address) external view returns (uint256);
-    function debtFYDai(bytes32, uint256, address) external view returns (uint256);
-    function debtDai(bytes32, uint256, address) external view returns (uint256);
+
+    function debtFYDai(
+        bytes32,
+        uint256,
+        address
+    ) external view returns (uint256);
+
+    function debtDai(
+        bytes32,
+        uint256,
+        address
+    ) external view returns (uint256);
+
     function totalDebtDai(bytes32, address) external view returns (uint256);
+
     function isCollateralized(bytes32, address) external view returns (bool);
-    function inDai(bytes32, uint256, uint256) external view returns (uint256);
-    function inFYDai(bytes32, uint256, uint256) external view returns (uint256);
+
+    function inDai(
+        bytes32,
+        uint256,
+        uint256
+    ) external view returns (uint256);
+
+    function inFYDai(
+        bytes32,
+        uint256,
+        uint256
+    ) external view returns (uint256);
+
     function erase(bytes32, address) external returns (uint256, uint256);
+
     function shutdown() external;
-    function post(bytes32, address, address, uint256) external;
-    function withdraw(bytes32, address, address, uint256) external;
-    function borrow(bytes32, uint256, address, address, uint256) external;
-    function repayFYDai(bytes32, uint256, address, address, uint256) external returns (uint256);
-    function repayDai(bytes32, uint256, address, address, uint256) external returns (uint256);
+
+    function post(
+        bytes32,
+        address,
+        address,
+        uint256
+    ) external;
+
+    function withdraw(
+        bytes32,
+        address,
+        address,
+        uint256
+    ) external;
+
+    function borrow(
+        bytes32,
+        uint256,
+        address,
+        address,
+        uint256
+    ) external;
+
+    function repayFYDai(
+        bytes32,
+        uint256,
+        address,
+        address,
+        uint256
+    ) external returns (uint256);
+
+    function repayDai(
+        bytes32,
+        uint256,
+        address,
+        address,
+        uint256
+    ) external returns (uint256);
 }

--- a/contracts/interfaces/IDai.sol
+++ b/contracts/interfaces/IDai.sol
@@ -1,9 +1,20 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 
-interface IDai is IERC20 { // Doesn't conform to IERC2612
+interface IDai is
+    IERC20 // Doesn't conform to IERC2612
+{
     function nonces(address user) external view returns (uint256);
-    function permit(address holder, address spender, uint256 nonce, uint256 expiry,
-                    bool allowed, uint8 v, bytes32 r, bytes32 s) external;
+
+    function permit(
+        address holder,
+        address spender,
+        uint256 nonce,
+        uint256 expiry,
+        bool allowed,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
 }

--- a/contracts/interfaces/IDaiJoin.sol
+++ b/contracts/interfaces/IDaiJoin.sol
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-
 /// @dev Interface to interact with the `Join.sol` contract from MakerDAO using Dai
 interface IDaiJoin {
     function rely(address usr) external;
+
     function deny(address usr) external;
+
     function cage() external;
-    function join(address usr, uint WAD) external;
-    function exit(address usr, uint WAD) external;
+
+    function join(address usr, uint256 WAD) external;
+
+    function exit(address usr, uint256 WAD) external;
 }

--- a/contracts/interfaces/IDelegable.sol
+++ b/contracts/interfaces/IDelegable.sol
@@ -1,9 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-
 interface IDelegable {
     function addDelegate(address) external;
-    function addDelegateBySignature(address, address, uint, uint8, bytes32, bytes32) external;
+
+    function addDelegateBySignature(
+        address,
+        address,
+        uint256,
+        uint8,
+        bytes32,
+        bytes32
+    ) external;
+
     function delegated(address, address) external view returns (bool);
 }

--- a/contracts/interfaces/IERC2612.sol
+++ b/contracts/interfaces/IERC2612.sol
@@ -34,7 +34,15 @@ interface IERC2612 {
      * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP
      * section].
      */
-    function permit(address owner, address spender, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
+    function permit(
+        address owner,
+        address spender,
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
 
     /**
      * @dev Returns the current ERC2612 nonce for `owner`. This value must be

--- a/contracts/interfaces/IEnd.sol
+++ b/contracts/interfaces/IEnd.sol
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-
 /// @dev interface for the End contract from MakerDAO
 interface IEnd {
-    function tag(bytes32) external returns(uint256);
-    function fix(bytes32) external returns(uint256);
+    function tag(bytes32) external returns (uint256);
+
+    function fix(bytes32) external returns (uint256);
+
     function skim(bytes32, address) external;
+
     function free(bytes32) external;
+
     function pack(uint256) external;
-    function cash(bytes32, uint) external;
+
+    function cash(bytes32, uint256) external;
 }

--- a/contracts/interfaces/IFYDai.sol
+++ b/contracts/interfaces/IFYDai.sol
@@ -1,22 +1,37 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "./IERC2612.sol";
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import './IERC2612.sol';
 
 interface IFYDai is IERC20, IERC2612 {
-    function isMature() external view returns(bool);
-    function maturity() external view returns(uint);
-    function chi0() external view returns(uint);
-    function rate0() external view returns(uint);
-    function chiGrowth() external view returns(uint);
-    function rateGrowth() external view returns(uint);
+    function isMature() external view returns (bool);
+
+    function maturity() external view returns (uint256);
+
+    function chi0() external view returns (uint256);
+
+    function rate0() external view returns (uint256);
+
+    function chiGrowth() external view returns (uint256);
+
+    function rateGrowth() external view returns (uint256);
+
     function mature() external;
-    function unlocked() external view returns (uint);
-    function mint(address, uint) external;
-    function burn(address, uint) external;
-    function flashMint(uint, bytes calldata) external;
-    function redeem(address, address, uint256) external returns (uint256);
+
+    function unlocked() external view returns (uint256);
+
+    function mint(address, uint256) external;
+
+    function burn(address, uint256) external;
+
+    function flashMint(uint256, bytes calldata) external;
+
+    function redeem(
+        address,
+        address,
+        uint256
+    ) external returns (uint256);
     // function transfer(address, uint) external returns (bool);
     // function transferFrom(address, address, uint) external returns (bool);
     // function approve(address, uint) external returns (bool);

--- a/contracts/interfaces/IFlashMinter.sol
+++ b/contracts/interfaces/IFlashMinter.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-
 interface IFlashMinter {
     function executeOnFlashMint(uint256 fyDaiAmount, bytes calldata data) external;
 }

--- a/contracts/interfaces/IGemJoin.sol
+++ b/contracts/interfaces/IGemJoin.sol
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-
 /// @dev Interface to interact with the `Join.sol` contract from MakerDAO using ERC20
 interface IGemJoin {
     function rely(address usr) external;
+
     function deny(address usr) external;
+
     function cage() external;
-    function join(address usr, uint WAD) external;
-    function exit(address usr, uint WAD) external;
+
+    function join(address usr, uint256 WAD) external;
+
+    function exit(address usr, uint256 WAD) external;
 }

--- a/contracts/interfaces/ILiquidations.sol
+++ b/contracts/interfaces/ILiquidations.sol
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
-import "./IController.sol";
-
+import './IController.sol';
 
 interface ILiquidations {
     function shutdown() external;
-    function totals() external view returns(uint128, uint128);
-    function erase(address) external returns(uint128, uint128);
 
-    function controller() external returns(IController);
+    function totals() external view returns (uint128, uint128);
+
+    function erase(address) external returns (uint128, uint128);
+
+    function controller() external returns (IController);
 }

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -1,24 +1,61 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "./IDelegable.sol";
-import "./IERC2612.sol";
-import "./IFYDai.sol";
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import './IDelegable.sol';
+import './IERC2612.sol';
+import './IFYDai.sol';
 
 interface IPool is IDelegable, IERC20, IERC2612 {
-    function dai() external view returns(IERC20);
-    function fyDai() external view returns(IFYDai);
-    function getDaiReserves() external view returns(uint128);
-    function getFYDaiReserves() external view returns(uint128);
-    function sellDai(address from, address to, uint128 daiIn) external returns(uint128);
-    function buyDai(address from, address to, uint128 daiOut) external returns(uint128);
-    function sellFYDai(address from, address to, uint128 fyDaiIn) external returns(uint128);
-    function buyFYDai(address from, address to, uint128 fyDaiOut) external returns(uint128);
-    function sellDaiPreview(uint128 daiIn) external view returns(uint128);
-    function buyDaiPreview(uint128 daiOut) external view returns(uint128);
-    function sellFYDaiPreview(uint128 fyDaiIn) external view returns(uint128);
-    function buyFYDaiPreview(uint128 fyDaiOut) external view returns(uint128);
-    function mint(address from, address to, uint256 daiOffered) external returns (uint256);
-    function burn(address from, address to, uint256 tokensBurned) external returns (uint256, uint256);
+    function dai() external view returns (IERC20);
+
+    function fyDai() external view returns (IFYDai);
+
+    function getDaiReserves() external view returns (uint128);
+
+    function getFYDaiReserves() external view returns (uint128);
+
+    function sellDai(
+        address from,
+        address to,
+        uint128 daiIn
+    ) external returns (uint128);
+
+    function buyDai(
+        address from,
+        address to,
+        uint128 daiOut
+    ) external returns (uint128);
+
+    function sellFYDai(
+        address from,
+        address to,
+        uint128 fyDaiIn
+    ) external returns (uint128);
+
+    function buyFYDai(
+        address from,
+        address to,
+        uint128 fyDaiOut
+    ) external returns (uint128);
+
+    function sellDaiPreview(uint128 daiIn) external view returns (uint128);
+
+    function buyDaiPreview(uint128 daiOut) external view returns (uint128);
+
+    function sellFYDaiPreview(uint128 fyDaiIn) external view returns (uint128);
+
+    function buyFYDaiPreview(uint128 fyDaiOut) external view returns (uint128);
+
+    function mint(
+        address from,
+        address to,
+        uint256 daiOffered
+    ) external returns (uint256);
+
+    function burn(
+        address from,
+        address to,
+        uint256 tokensBurned
+    ) external returns (uint256, uint256);
 }

--- a/contracts/interfaces/IPot.sol
+++ b/contracts/interfaces/IPot.sol
@@ -1,14 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-
 /// @dev interface for the pot contract from MakerDao
 /// Taken from https://github.com/makerdao/developerguides/blob/master/dai/dsr-integration-guide/dsr.sol
 interface IPot {
     function chi() external view returns (uint256);
+
     function pie(address) external view returns (uint256); // Not a function, but a public variable.
+
     function rho() external returns (uint256);
+
     function drip() external returns (uint256);
+
     function join(uint256) external;
+
     function exit(uint256) external;
 }

--- a/contracts/interfaces/ITreasury.sol
+++ b/contracts/interfaces/ITreasury.sol
@@ -1,31 +1,46 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "./IVat.sol";
-import "./IWeth.sol";
-import "./IGemJoin.sol";
-import "./IDaiJoin.sol";
-import "./IPot.sol";
-import "./IChai.sol";
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import './IVat.sol';
+import './IWeth.sol';
+import './IGemJoin.sol';
+import './IDaiJoin.sol';
+import './IPot.sol';
+import './IChai.sol';
 
 interface ITreasury {
-    function debt() external view returns(uint256);
-    function savings() external view returns(uint256);
+    function debt() external view returns (uint256);
+
+    function savings() external view returns (uint256);
+
     function pushDai(address user, uint256 dai) external;
+
     function pullDai(address user, uint256 dai) external;
+
     function pushChai(address user, uint256 chai) external;
+
     function pullChai(address user, uint256 chai) external;
+
     function pushWeth(address to, uint256 weth) external;
+
     function pullWeth(address to, uint256 weth) external;
+
     function shutdown() external;
-    function live() external view returns(bool);
+
+    function live() external view returns (bool);
 
     function vat() external view returns (IVat);
+
     function weth() external view returns (IWeth);
+
     function dai() external view returns (IERC20);
+
     function daiJoin() external view returns (IDaiJoin);
+
     function wethJoin() external view returns (IGemJoin);
+
     function pot() external view returns (IPot);
+
     function chai() external view returns (IChai);
 }

--- a/contracts/interfaces/IVat.sol
+++ b/contracts/interfaces/IVat.sol
@@ -1,20 +1,59 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-
 /// @dev Interface to interact with the vat contract from MakerDAO
 /// Taken from https://github.com/makerdao/developerguides/blob/master/devtools/working-with-dsproxy/working-with-dsproxy.md
 interface IVat {
     // function can(address, address) external view returns (uint);
     function hope(address) external;
+
     function nope(address) external;
-    function live() external view returns (uint);
-    function ilks(bytes32) external view returns (uint, uint, uint, uint, uint);
-    function urns(bytes32, address) external view returns (uint, uint);
-    function gem(bytes32, address) external view returns (uint);
+
+    function live() external view returns (uint256);
+
+    function ilks(bytes32)
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256
+        );
+
+    function urns(bytes32, address) external view returns (uint256, uint256);
+
+    function gem(bytes32, address) external view returns (uint256);
+
     // function dai(address) external view returns (uint);
-    function frob(bytes32, address, address, address, int, int) external;
-    function fork(bytes32, address, address, int, int) external;
-    function move(address, address, uint) external;
-    function flux(bytes32, address, address, uint) external;
+    function frob(
+        bytes32,
+        address,
+        address,
+        address,
+        int256,
+        int256
+    ) external;
+
+    function fork(
+        bytes32,
+        address,
+        address,
+        int256,
+        int256
+    ) external;
+
+    function move(
+        address,
+        address,
+        uint256
+    ) external;
+
+    function flux(
+        bytes32,
+        address,
+        address,
+        uint256
+    ) external;
 }

--- a/contracts/interfaces/IWeth.sol
+++ b/contracts/interfaces/IWeth.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 
 interface IWeth is IERC20 {
     function deposit() external payable;
-    function withdraw(uint) external;
+
+    function withdraw(uint256) external;
 }

--- a/contracts/invariants/DecimalMathInvariant.sol
+++ b/contracts/invariants/DecimalMathInvariant.sol
@@ -1,48 +1,46 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
-import "../helpers/DecimalMath.sol";
-
+import '../helpers/DecimalMath.sol';
 
 /// @dev Implements simple fixed point math mul and div operations for 27 decimals.
 contract DecimalMathInvariant is DecimalMath {
-    constructor () public {
-    }
+    constructor() public {}
 
     function muld_(uint256 x, uint256 y) public pure returns (uint256) {
-        uint z = muld(x, y);
+        uint256 z = muld(x, y);
         assert((x * y) / UNIT == z); // Assert math
-        assert (divd(z, y) <= x);    // We are rounding down
+        assert(divd(z, y) <= x); // We are rounding down
         // Assert revert on overflow
-        if(y > UNIT) assert(z >= x); // x could be zero
-        if(y < UNIT) assert(z <= x); // y could be zero
+        if (y > UNIT) assert(z >= x); // x could be zero
+        if (y < UNIT) assert(z <= x); // y could be zero
     }
 
     function divd_(uint256 x, uint256 y) public pure returns (uint256) {
-        uint z = divd(x, y);
+        uint256 z = divd(x, y);
         assert((x * UNIT) / y == z); // Assert math
-        assert (muld(z, y) <= x);    // We are rounding down
+        assert(muld(z, y) <= x); // We are rounding down
         // Assert revert on overflow
-        if(y > UNIT) assert(z <= x); // x could be zero
-        if(y < UNIT) assert(z >= x); // x or y could be zero
+        if (y > UNIT) assert(z <= x); // x could be zero
+        if (y < UNIT) assert(z >= x); // x or y could be zero
     }
 
     function divdrup_(uint256 x, uint256 y) public pure returns (uint256) {
-        uint z = divdrup(x, y);
+        uint256 z = divdrup(x, y);
 
-        assert (muld(z, y) >= x); // We are rounding up
-        if (muld(z, y) > x) assert (divd(x, y) == z - 1); // Unless z * y is exactly x, we have rounded up.
+        assert(muld(z, y) >= x); // We are rounding up
+        if (muld(z, y) > x) assert(divd(x, y) == z - 1); // Unless z * y is exactly x, we have rounded up.
 
-        if(y > UNIT) assert(z <= x); // x could be zero
-        if(y < UNIT) assert(z >= x); // x or y could be zero
+        if (y > UNIT) assert(z <= x); // x could be zero
+        if (y < UNIT) assert(z >= x); // x or y could be zero
     }
 
     function muldrup_(uint256 x, uint256 y) public pure returns (uint256) {
-        uint z = muldrup(x, y);
-        
-        assert (divd(z, y) >= x); // We are rounding up
-        if (divd(z, y) > x) assert (muld(x, y) == z - 1);  // Unless z / y is exactly x, we have rounded up.
+        uint256 z = muldrup(x, y);
 
-        if(y > UNIT) assert(z >= x); // x could be zero
-        if(y < UNIT) assert(z <= x); // x or y could be zero
+        assert(divd(z, y) >= x); // We are rounding up
+        if (divd(z, y) > x) assert(muld(x, y) == z - 1); // Unless z / y is exactly x, we have rounded up.
+
+        if (y > UNIT) assert(z >= x); // x could be zero
+        if (y < UNIT) assert(z <= x); // x or y could be zero
     }
 }

--- a/contracts/invariants/InvariantWrapper.sol
+++ b/contracts/invariants/InvariantWrapper.sol
@@ -1,45 +1,57 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
-import "./TradeReversalInvariant.sol";
-import "./WhitepaperInvariant.sol";
-
+import './TradeReversalInvariant.sol';
+import './WhitepaperInvariant.sol';
 
 contract TradeReversalInvariantWrapper is TradeReversalInvariant {
-
     /// @dev Sell fyDai and sell the obtained Dai back for fyDai
-    function sellFYDaiAndReverse(uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiIn, uint128 timeTillMaturity)
-        public pure returns (uint128)
-    {
+    function sellFYDaiAndReverse(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiIn,
+        uint128 timeTillMaturity
+    ) public pure returns (uint128) {
         return _sellFYDaiAndReverse(daiReserves, fyDaiReserves, fyDaiIn, timeTillMaturity);
     }
 
     /// @dev Buy fyDai and sell it back
-    function buyFYDaiAndReverse(uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiOut, uint128 timeTillMaturity)
-        public pure returns (uint128)
-    {
+    function buyFYDaiAndReverse(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiOut,
+        uint128 timeTillMaturity
+    ) public pure returns (uint128) {
         return _buyFYDaiAndReverse(daiReserves, fyDaiReserves, fyDaiOut, timeTillMaturity);
     }
 
     /// @dev Sell fyDai and sell the obtained Dai back for fyDai
-    function sellDaiAndReverse(uint128 daiReserves, uint128 fyDaiReserves, uint128 daiIn, uint128 timeTillMaturity)
-        public pure returns (uint128)
-    {
+    function sellDaiAndReverse(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiIn,
+        uint128 timeTillMaturity
+    ) public pure returns (uint128) {
         return _sellDaiAndReverse(daiReserves, fyDaiReserves, daiIn, timeTillMaturity);
     }
 
     /// @dev Buy fyDai and sell it back
-    function buyDaiAndReverse(uint128 daiReserves, uint128 fyDaiReserves, uint128 daiOut, uint128 timeTillMaturity)
-        public pure returns (uint128)
-    {
+    function buyDaiAndReverse(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiOut,
+        uint128 timeTillMaturity
+    ) public pure returns (uint128) {
         return _buyDaiAndReverse(daiReserves, fyDaiReserves, daiOut, timeTillMaturity);
     }
 }
 
 contract WhitepaperInvariantWrapper is WhitepaperInvariant {
     /// @dev Calculates the value of the reserves
-    function whitepaperInvariant(uint128 daiReserves, uint128 fyDaiReserves, uint128 timeTillMaturity)
-        public pure returns (uint128)
-    {
+    function whitepaperInvariant(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 timeTillMaturity
+    ) public pure returns (uint128) {
         return _whitepaperInvariant(daiReserves, fyDaiReserves, timeTillMaturity);
     }
 }

--- a/contracts/invariants/TradeReversalInvariant.sol
+++ b/contracts/invariants/TradeReversalInvariant.sol
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
-import "../pool/YieldMath.sol"; // 64 bits
-import "../pool/Math64x64.sol";
-import "@nomiclabs/buidler/console.sol";
-
+import '../pool/YieldMath.sol'; // 64 bits
+import '../pool/Math64x64.sol';
+import '@nomiclabs/buidler/console.sol';
 
 contract TradeReversalInvariant {
-    uint128 constant internal precision = 1e12;
-    int128 constant internal k = int128(uint256((1 << 64)) / 126144000); // 1 / Seconds in 4 years, in 64.64
-    int128 constant internal g1 = int128(uint256((950 << 64)) / 1000); // To be used when selling Dai to the pool. All constants are `ufixed`, to divide them they must be converted to uint256
-    int128 constant internal g2 = int128(uint256((1000 << 64)) / 950); // To be used when selling fyDai to the pool. All constants are `ufixed`, to divide them they must be converted to uint256
+    uint128 internal constant precision = 1e12;
+    int128 internal constant k = int128(uint256((1 << 64)) / 126144000); // 1 / Seconds in 4 years, in 64.64
+    int128 internal constant g1 = int128(uint256((950 << 64)) / 1000); // To be used when selling Dai to the pool. All constants are `ufixed`, to divide them they must be converted to uint256
+    int128 internal constant g2 = int128(uint256((1000 << 64)) / 950); // To be used when selling fyDai to the pool. All constants are `ufixed`, to divide them they must be converted to uint256
 
     uint128 minDaiReserves = 10**21; // $1000
     uint128 minFYDaiReserves = minDaiReserves + 1;
@@ -21,29 +20,31 @@ contract TradeReversalInvariant {
     uint128 maxTimeTillMaturity = 31556952;
 
     constructor() public {}
-    
+
     /// @dev Overflow-protected addition, from OpenZeppelin
-    function add(uint128 a, uint128 b)
-        internal pure returns (uint128)
-    {
+    function add(uint128 a, uint128 b) internal pure returns (uint128) {
         uint128 c = a + b;
-        require(c >= a, "Pool: Dai reserves too high");
+        require(c >= a, 'Pool: Dai reserves too high');
         return c;
     }
+
     /// @dev Overflow-protected substraction, from OpenZeppelin
     function sub(uint128 a, uint128 b) internal pure returns (uint128) {
-        require(b <= a, "Pool: fyDai reserves too low");
+        require(b <= a, 'Pool: fyDai reserves too low');
         uint128 c = a - b;
         return c;
     }
 
     /// @dev Ensures that if we sell fyDai for DAI and back we get less fyDai than we had
-    function testSellFYDaiAndReverse(uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiIn, uint128 timeTillMaturity)
-        public view returns (uint128)
-    {
-        daiReserves = minDaiReserves + daiReserves % maxDaiReserves;
-        fyDaiReserves = minFYDaiReserves + fyDaiReserves % maxFYDaiReserves;
-        timeTillMaturity = minTimeTillMaturity + timeTillMaturity % maxTimeTillMaturity;
+    function testSellFYDaiAndReverse(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiIn,
+        uint128 timeTillMaturity
+    ) public view returns (uint128) {
+        daiReserves = minDaiReserves + (daiReserves % maxDaiReserves);
+        fyDaiReserves = minFYDaiReserves + (fyDaiReserves % maxFYDaiReserves);
+        timeTillMaturity = minTimeTillMaturity + (timeTillMaturity % maxTimeTillMaturity);
 
         uint128 fyDaiOut = _sellFYDaiAndReverse(daiReserves, fyDaiReserves, fyDaiIn, timeTillMaturity);
         assert(fyDaiOut <= fyDaiIn);
@@ -51,12 +52,15 @@ contract TradeReversalInvariant {
     }
 
     /// @dev Ensures that if we buy fyDai for DAI and back we get less DAI than we had
-    function testBuyFYDaiAndReverse(uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiOut, uint128 timeTillMaturity)
-        public view returns (uint128)
-    {
-        daiReserves = minDaiReserves + daiReserves % maxDaiReserves;
-        fyDaiReserves = minFYDaiReserves + fyDaiReserves % maxFYDaiReserves;
-        timeTillMaturity = minTimeTillMaturity + timeTillMaturity % maxTimeTillMaturity;
+    function testBuyFYDaiAndReverse(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiOut,
+        uint128 timeTillMaturity
+    ) public view returns (uint128) {
+        daiReserves = minDaiReserves + (daiReserves % maxDaiReserves);
+        fyDaiReserves = minFYDaiReserves + (fyDaiReserves % maxFYDaiReserves);
+        timeTillMaturity = minTimeTillMaturity + (timeTillMaturity % maxTimeTillMaturity);
 
         uint128 fyDaiIn = _buyFYDaiAndReverse(daiReserves, fyDaiReserves, fyDaiOut, timeTillMaturity);
         assert(fyDaiOut <= fyDaiIn);
@@ -64,12 +68,15 @@ contract TradeReversalInvariant {
     }
 
     /// @dev Ensures that if we sell DAI for fyDai and back we get less DAI than we had
-    function testSellDaiAndReverse(uint128 daiReserves, uint128 fyDaiReserves, uint128 daiIn, uint128 timeTillMaturity)
-        public view returns (uint128)
-    {
-        daiReserves = minDaiReserves + daiReserves % maxDaiReserves;
-        fyDaiReserves = minFYDaiReserves + fyDaiReserves % maxFYDaiReserves;
-        timeTillMaturity = minTimeTillMaturity + timeTillMaturity % maxTimeTillMaturity;
+    function testSellDaiAndReverse(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiIn,
+        uint128 timeTillMaturity
+    ) public view returns (uint128) {
+        daiReserves = minDaiReserves + (daiReserves % maxDaiReserves);
+        fyDaiReserves = minFYDaiReserves + (fyDaiReserves % maxFYDaiReserves);
+        timeTillMaturity = minTimeTillMaturity + (timeTillMaturity % maxTimeTillMaturity);
 
         uint128 daiOut = _sellDaiAndReverse(daiReserves, fyDaiReserves, daiIn, timeTillMaturity);
         assert(daiOut <= daiIn);
@@ -77,12 +84,15 @@ contract TradeReversalInvariant {
     }
 
     /// @dev Ensures that if we buy DAI for fyDai and back we get less fyDai than we had
-    function testBuyDaiAndReverse(uint128 daiReserves, uint128 fyDaiReserves, uint128 daiOut, uint128 timeTillMaturity)
-        public view returns (uint128)
-    {
-        daiReserves = minDaiReserves + daiReserves % maxDaiReserves;
-        fyDaiReserves = minFYDaiReserves + fyDaiReserves % maxFYDaiReserves;
-        timeTillMaturity = minTimeTillMaturity + timeTillMaturity % maxTimeTillMaturity;
+    function testBuyDaiAndReverse(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiOut,
+        uint128 timeTillMaturity
+    ) public view returns (uint128) {
+        daiReserves = minDaiReserves + (daiReserves % maxDaiReserves);
+        fyDaiReserves = minFYDaiReserves + (fyDaiReserves % maxFYDaiReserves);
+        timeTillMaturity = minTimeTillMaturity + (timeTillMaturity % maxTimeTillMaturity);
 
         uint128 daiIn = _buyFYDaiAndReverse(daiReserves, fyDaiReserves, daiOut, timeTillMaturity);
         assert(daiOut <= daiIn);
@@ -91,51 +101,95 @@ contract TradeReversalInvariant {
 
     /// @dev Ensures log_2 grows as x grows
     function testLog2MonotonicallyGrows(uint128 x) internal pure {
-        uint128 z1= YieldMath.log_2(x);
-        uint128 z2= YieldMath.log_2(x + 1);
+        uint128 z1 = YieldMath.log_2(x);
+        uint128 z2 = YieldMath.log_2(x + 1);
         assert(z2 >= z1);
     }
 
     /// @dev Sell fyDai and sell the obtained Dai back for fyDai
-    function _sellFYDaiAndReverse(uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiIn, uint128 timeTillMaturity)
-        internal pure returns (uint128)
-    {
+    function _sellFYDaiAndReverse(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiIn,
+        uint128 timeTillMaturity
+    ) internal pure returns (uint128) {
         uint128 daiAmount = YieldMath.daiOutForFYDaiIn(daiReserves, fyDaiReserves, fyDaiIn, timeTillMaturity, k, g2);
         require(add(fyDaiReserves, fyDaiIn) >= sub(daiReserves, daiAmount));
-        uint128 fyDaiOut = YieldMath.fyDaiOutForDaiIn(sub(daiReserves, daiAmount), add(fyDaiReserves, fyDaiIn), daiAmount, timeTillMaturity, k, g1);
+        uint128 fyDaiOut =
+            YieldMath.fyDaiOutForDaiIn(
+                sub(daiReserves, daiAmount),
+                add(fyDaiReserves, fyDaiIn),
+                daiAmount,
+                timeTillMaturity,
+                k,
+                g1
+            );
         require(sub(add(fyDaiReserves, fyDaiIn), fyDaiOut) >= daiReserves);
         return fyDaiOut;
     }
 
     /// @dev Buy fyDai and sell it back
-    function _buyFYDaiAndReverse(uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiOut, uint128 timeTillMaturity)
-        internal pure returns (uint128)
-    {
+    function _buyFYDaiAndReverse(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiOut,
+        uint128 timeTillMaturity
+    ) internal pure returns (uint128) {
         uint128 daiAmount = YieldMath.daiInForFYDaiOut(daiReserves, fyDaiReserves, fyDaiOut, timeTillMaturity, k, g1);
         require(sub(fyDaiReserves, fyDaiOut) >= add(daiReserves, daiAmount));
-        uint128 fyDaiIn = YieldMath.fyDaiInForDaiOut(add(daiReserves, daiAmount), sub(fyDaiReserves, fyDaiOut), daiAmount, timeTillMaturity, k, g2);
+        uint128 fyDaiIn =
+            YieldMath.fyDaiInForDaiOut(
+                add(daiReserves, daiAmount),
+                sub(fyDaiReserves, fyDaiOut),
+                daiAmount,
+                timeTillMaturity,
+                k,
+                g2
+            );
         require(add(sub(fyDaiReserves, fyDaiOut), fyDaiIn) >= daiReserves);
         return fyDaiIn;
     }
 
     /// @dev Sell fyDai and sell the obtained Dai back for fyDai
-    function _sellDaiAndReverse(uint128 daiReserves, uint128 fyDaiReserves, uint128 daiIn, uint128 timeTillMaturity)
-        internal pure returns (uint128)
-    {
+    function _sellDaiAndReverse(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiIn,
+        uint128 timeTillMaturity
+    ) internal pure returns (uint128) {
         uint128 fyDaiAmount = YieldMath.fyDaiOutForDaiIn(daiReserves, fyDaiReserves, daiIn, timeTillMaturity, k, g1);
         require(sub(fyDaiReserves, fyDaiAmount) >= add(daiReserves, daiIn));
-        uint128 daiOut = YieldMath.daiOutForFYDaiIn(add(daiReserves, daiIn), sub(fyDaiReserves, fyDaiAmount), fyDaiAmount, timeTillMaturity, k, g2);
+        uint128 daiOut =
+            YieldMath.daiOutForFYDaiIn(
+                add(daiReserves, daiIn),
+                sub(fyDaiReserves, fyDaiAmount),
+                fyDaiAmount,
+                timeTillMaturity,
+                k,
+                g2
+            );
         require(fyDaiReserves >= sub(add(daiReserves, daiIn), daiOut));
         return daiOut;
     }
 
     /// @dev Buy fyDai and sell it back
-    function _buyDaiAndReverse(uint128 daiReserves, uint128 fyDaiReserves, uint128 daiOut, uint128 timeTillMaturity)
-        internal pure returns (uint128)
-    {
+    function _buyDaiAndReverse(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiOut,
+        uint128 timeTillMaturity
+    ) internal pure returns (uint128) {
         uint128 fyDaiAmount = YieldMath.fyDaiInForDaiOut(daiReserves, fyDaiReserves, daiOut, timeTillMaturity, k, g2);
         require(add(fyDaiReserves, fyDaiAmount) >= sub(daiReserves, daiOut));
-        uint128 daiIn = YieldMath.daiInForFYDaiOut(sub(daiReserves, daiOut), add(fyDaiReserves, fyDaiAmount), fyDaiAmount, timeTillMaturity, k, g1);
+        uint128 daiIn =
+            YieldMath.daiInForFYDaiOut(
+                sub(daiReserves, daiOut),
+                add(fyDaiReserves, fyDaiAmount),
+                fyDaiAmount,
+                timeTillMaturity,
+                k,
+                g1
+            );
         require(fyDaiReserves >= add(sub(daiReserves, daiOut), daiIn));
         return daiIn;
     }

--- a/contracts/invariants/WhitepaperInvariant.sol
+++ b/contracts/invariants/WhitepaperInvariant.sol
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
-import "../pool/YieldMath.sol";     // 64 bits (for trading)
-import "../mocks/YieldMath128.sol"; // 128 bits (for reserves calculation)
-import "../pool/Math64x64.sol";
-import "@nomiclabs/buidler/console.sol";
-
+import '../pool/YieldMath.sol'; // 64 bits (for trading)
+import '../mocks/YieldMath128.sol'; // 128 bits (for reserves calculation)
+import '../pool/Math64x64.sol';
+import '@nomiclabs/buidler/console.sol';
 
 contract WhitepaperInvariant {
-    uint128 constant internal precision = 1e12;
-    int128 constant internal k = int128(uint256((1 << 64)) / 126144000); // 1 / Seconds in 4 years, in 64.64
-    int128 constant internal g1 = int128(uint256((950 << 64)) / 1000); // To be used when selling Dai to the pool. All constants are `ufixed`, to divide them they must be converted to uint256
-    int128 constant internal g2 = int128(uint256((1000 << 64)) / 950); // To be used when selling fyDai to the pool. All constants are `ufixed`, to divide them they must be converted to uint256
+    uint128 internal constant precision = 1e12;
+    int128 internal constant k = int128(uint256((1 << 64)) / 126144000); // 1 / Seconds in 4 years, in 64.64
+    int128 internal constant g1 = int128(uint256((950 << 64)) / 1000); // To be used when selling Dai to the pool. All constants are `ufixed`, to divide them they must be converted to uint256
+    int128 internal constant g2 = int128(uint256((1000 << 64)) / 950); // To be used when selling fyDai to the pool. All constants are `ufixed`, to divide them they must be converted to uint256
 
     uint128 minDaiReserves = 10**21; // $1000
     uint128 minFYDaiReserves = minDaiReserves + 1;
@@ -22,94 +21,109 @@ contract WhitepaperInvariant {
     uint128 maxTimeTillMaturity = 31556952;
 
     constructor() public {}
-    
+
     /// @dev Overflow-protected addition, from OpenZeppelin
-    function add(uint128 a, uint128 b)
-        internal pure returns (uint128)
-    {
+    function add(uint128 a, uint128 b) internal pure returns (uint128) {
         uint128 c = a + b;
-        require(c >= a, "Pool: Dai reserves too high");
+        require(c >= a, 'Pool: Dai reserves too high');
         return c;
     }
+
     /// @dev Overflow-protected substraction, from OpenZeppelin
     function sub(uint128 a, uint128 b) internal pure returns (uint128) {
-        require(b <= a, "Pool: fyDai reserves too low");
+        require(b <= a, 'Pool: fyDai reserves too low');
         uint128 c = a - b;
         return c;
     }
 
     /// @dev Ensures that reserves grow with any daiOutForFYDaiIn trade.
-    function testLiquiditfyDaiOutForFYDaiIn(uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiIn, uint128 timeTillMaturity)
-        public view returns (bool)
-    {
-        daiReserves = minDaiReserves + daiReserves % maxDaiReserves;
-        fyDaiReserves = minFYDaiReserves + fyDaiReserves % maxFYDaiReserves;
-        timeTillMaturity = minTimeTillMaturity + timeTillMaturity % maxTimeTillMaturity;
-        require (daiReserves <= fyDaiReserves);
+    function testLiquiditfyDaiOutForFYDaiIn(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiIn,
+        uint128 timeTillMaturity
+    ) public view returns (bool) {
+        daiReserves = minDaiReserves + (daiReserves % maxDaiReserves);
+        fyDaiReserves = minFYDaiReserves + (fyDaiReserves % maxFYDaiReserves);
+        timeTillMaturity = minTimeTillMaturity + (timeTillMaturity % maxTimeTillMaturity);
+        require(daiReserves <= fyDaiReserves);
 
         uint128 whitepaperInvariant_0 = _whitepaperInvariant(daiReserves, fyDaiReserves, timeTillMaturity);
         uint128 daiOut = YieldMath.daiOutForFYDaiIn(daiReserves, fyDaiReserves, fyDaiIn, timeTillMaturity, k, g2);
         require(add(fyDaiReserves, fyDaiIn) >= sub(daiReserves, daiOut));
-        uint128 whitepaperInvariant_1 = _whitepaperInvariant(sub(daiReserves, daiOut), add(fyDaiReserves, fyDaiIn), sub(timeTillMaturity, 1));
+        uint128 whitepaperInvariant_1 =
+            _whitepaperInvariant(sub(daiReserves, daiOut), add(fyDaiReserves, fyDaiIn), sub(timeTillMaturity, 1));
         assert(whitepaperInvariant_0 < whitepaperInvariant_1);
         return whitepaperInvariant_0 < whitepaperInvariant_1;
     }
 
     /// @dev Ensures that reserves grow with any fyDaiInForDaiOut trade.
-    function testLiquiditfyDaiInForFYDaiOut(uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiOut, uint128 timeTillMaturity)
-        public view returns (bool)
-    {
-        daiReserves = minDaiReserves + daiReserves % maxDaiReserves;
-        fyDaiReserves = minFYDaiReserves + fyDaiReserves % maxFYDaiReserves;
-        timeTillMaturity = minTimeTillMaturity + timeTillMaturity % maxTimeTillMaturity;
-        require (daiReserves <= fyDaiReserves - fyDaiOut);
+    function testLiquiditfyDaiInForFYDaiOut(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiOut,
+        uint128 timeTillMaturity
+    ) public view returns (bool) {
+        daiReserves = minDaiReserves + (daiReserves % maxDaiReserves);
+        fyDaiReserves = minFYDaiReserves + (fyDaiReserves % maxFYDaiReserves);
+        timeTillMaturity = minTimeTillMaturity + (timeTillMaturity % maxTimeTillMaturity);
+        require(daiReserves <= fyDaiReserves - fyDaiOut);
 
         uint128 whitepaperInvariant_0 = _whitepaperInvariant(daiReserves, fyDaiReserves, timeTillMaturity);
         uint128 daiIn = YieldMath.daiInForFYDaiOut(daiReserves, fyDaiReserves, fyDaiOut, timeTillMaturity, k, g1);
         require(sub(fyDaiReserves, fyDaiOut) >= add(daiReserves, daiIn));
-        uint128 whitepaperInvariant_1 = _whitepaperInvariant(add(daiReserves, daiIn), sub(fyDaiReserves, fyDaiOut), sub(timeTillMaturity, 1));
+        uint128 whitepaperInvariant_1 =
+            _whitepaperInvariant(add(daiReserves, daiIn), sub(fyDaiReserves, fyDaiOut), sub(timeTillMaturity, 1));
         assert(whitepaperInvariant_0 < whitepaperInvariant_1);
         return whitepaperInvariant_0 < whitepaperInvariant_1;
     }
 
     /// @dev Ensures that reserves grow with any fyDaiOutForDaiIn trade.
-    function testLiquidityFYDaiOutForDaiIn(uint128 daiReserves, uint128 fyDaiReserves, uint128 daiIn, uint128 timeTillMaturity)
-        public view returns (bool)
-    {
-        daiReserves = minDaiReserves + daiReserves % maxDaiReserves;
-        fyDaiReserves = minFYDaiReserves + fyDaiReserves % maxFYDaiReserves;
-        timeTillMaturity = minTimeTillMaturity + timeTillMaturity % maxTimeTillMaturity;
-        require (daiReserves + daiIn <= fyDaiReserves);
+    function testLiquidityFYDaiOutForDaiIn(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiIn,
+        uint128 timeTillMaturity
+    ) public view returns (bool) {
+        daiReserves = minDaiReserves + (daiReserves % maxDaiReserves);
+        fyDaiReserves = minFYDaiReserves + (fyDaiReserves % maxFYDaiReserves);
+        timeTillMaturity = minTimeTillMaturity + (timeTillMaturity % maxTimeTillMaturity);
+        require(daiReserves + daiIn <= fyDaiReserves);
 
         uint128 whitepaperInvariant_0 = _whitepaperInvariant(daiReserves, fyDaiReserves, timeTillMaturity);
         uint128 fyDaiOut = YieldMath.fyDaiOutForDaiIn(daiReserves, fyDaiReserves, daiIn, timeTillMaturity, k, g1);
         require(sub(fyDaiReserves, fyDaiOut) >= add(daiReserves, daiIn));
-        uint128 whitepaperInvariant_1 = _whitepaperInvariant(add(daiReserves, daiIn), sub(fyDaiReserves, fyDaiOut), sub(timeTillMaturity, 1));
+        uint128 whitepaperInvariant_1 =
+            _whitepaperInvariant(add(daiReserves, daiIn), sub(fyDaiReserves, fyDaiOut), sub(timeTillMaturity, 1));
         assert(whitepaperInvariant_0 < whitepaperInvariant_1);
         return whitepaperInvariant_0 < whitepaperInvariant_1;
     }
 
     /// @dev Ensures that reserves grow with any fyDaiInForDaiOut trade.
-    function testLiquidityFYDaiInForDaiOut(uint128 daiReserves, uint128 fyDaiReserves, uint128 daiOut, uint128 timeTillMaturity)
-        public view returns (bool)
-    {
-        daiReserves = minDaiReserves + daiReserves % maxDaiReserves;
-        fyDaiReserves = minFYDaiReserves + fyDaiReserves % maxFYDaiReserves;
-        timeTillMaturity = minTimeTillMaturity + timeTillMaturity % maxTimeTillMaturity;
-        require (daiReserves <= fyDaiReserves);
-        
+    function testLiquidityFYDaiInForDaiOut(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiOut,
+        uint128 timeTillMaturity
+    ) public view returns (bool) {
+        daiReserves = minDaiReserves + (daiReserves % maxDaiReserves);
+        fyDaiReserves = minFYDaiReserves + (fyDaiReserves % maxFYDaiReserves);
+        timeTillMaturity = minTimeTillMaturity + (timeTillMaturity % maxTimeTillMaturity);
+        require(daiReserves <= fyDaiReserves);
+
         uint128 whitepaperInvariant_0 = _whitepaperInvariant(daiReserves, fyDaiReserves, timeTillMaturity);
         uint128 fyDaiIn = YieldMath.fyDaiInForDaiOut(daiReserves, fyDaiReserves, daiOut, timeTillMaturity, k, g2);
         require(add(fyDaiReserves, fyDaiIn) >= sub(daiReserves, daiOut));
-        uint128 whitepaperInvariant_1 = _whitepaperInvariant(sub(daiReserves, daiOut), add(fyDaiReserves, fyDaiIn), sub(timeTillMaturity, 1));
+        uint128 whitepaperInvariant_1 =
+            _whitepaperInvariant(sub(daiReserves, daiOut), add(fyDaiReserves, fyDaiIn), sub(timeTillMaturity, 1));
         assert(whitepaperInvariant_0 < whitepaperInvariant_1);
         return whitepaperInvariant_0 < whitepaperInvariant_1;
     }
 
     /// @dev Ensures log_2 grows as x grows
     function testLog2MonotonicallyGrows(uint128 x) internal pure {
-        uint128 z1= YieldMath.log_2(x);
-        uint128 z2= YieldMath.log_2(x + 1);
+        uint128 z1 = YieldMath.log_2(x);
+        uint128 z2 = YieldMath.log_2(x + 1);
         assert(z2 >= z1);
     }
 
@@ -121,22 +135,23 @@ contract WhitepaperInvariant {
      * @param timeTillMaturity time till maturity in seconds
      * @return estimated value of reserves
      */
-    function _whitepaperInvariant (
-        uint128 daiReserves, uint128 fyDaiReserves, uint128 timeTillMaturity)
-        internal pure returns (uint128)
-    {
+    function _whitepaperInvariant(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 timeTillMaturity
+    ) internal pure returns (uint128) {
         // a = (1 - k * timeTillMaturity)
-        int128 a = Math64x64.sub (0x10000000000000000, Math64x64.mul (k, Math64x64.fromUInt (timeTillMaturity)));
-        require (a > 0);
+        int128 a = Math64x64.sub(0x10000000000000000, Math64x64.mul(k, Math64x64.fromUInt(timeTillMaturity)));
+        require(a > 0);
 
         uint256 sum =
-        uint256 (YieldMath128.pow (daiReserves, uint128 (a), 0x10000000000000000)) +
-        uint256 (YieldMath128.pow (fyDaiReserves, uint128 (a), 0x10000000000000000)) >> 1;
-        require (sum < 0x100000000000000000000000000000000);
+            (uint256(YieldMath128.pow(daiReserves, uint128(a), 0x10000000000000000)) +
+                uint256(YieldMath128.pow(fyDaiReserves, uint128(a), 0x10000000000000000))) >> 1;
+        require(sum < 0x100000000000000000000000000000000);
 
-        uint256 result = uint256 (YieldMath128.pow (uint128 (sum), 0x10000000000000000, uint128 (a))) << 1;
-        require (result < 0x100000000000000000000000000000000);
+        uint256 result = uint256(YieldMath128.pow(uint128(sum), 0x10000000000000000, uint128(a))) << 1;
+        require(result < 0x100000000000000000000000000000000);
 
-        return uint128 (result);
+        return uint128(result);
     }
 }

--- a/contracts/mocks/DecimalMathMock.sol
+++ b/contracts/mocks/DecimalMathMock.sol
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
-import "../helpers/DecimalMath.sol";
-
+import '../helpers/DecimalMath.sol';
 
 /// @dev Implements simple fixed point math mul and div operations for 27 decimals.
 contract DecimalMathMock is DecimalMath {
-
     function muld_(uint256 x, uint256 y) public pure returns (uint256) {
         return muld(x, y);
     }
@@ -14,13 +12,11 @@ contract DecimalMathMock is DecimalMath {
         return divd(x, y);
     }
 
-    function divdrup_(uint256 x, uint256 y) public pure returns (uint256)
-    {
+    function divdrup_(uint256 x, uint256 y) public pure returns (uint256) {
         return divdrup(x, y);
     }
 
-    function muldrup_(uint256 x, uint256 y) public pure returns (uint256)
-    {
+    function muldrup_(uint256 x, uint256 y) public pure returns (uint256) {
         return muldrup(x, y);
     }
 }

--- a/contracts/mocks/FlashMintRedeemerMock.sol
+++ b/contracts/mocks/FlashMintRedeemerMock.sol
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-import "../interfaces/IFlashMinter.sol";
-import "../interfaces/IFYDai.sol";
-
+import '../interfaces/IFlashMinter.sol';
+import '../interfaces/IFYDai.sol';
 
 contract FlashMintRedeemerMock is IFlashMinter {
-
     event Parameters(uint256 amount, bytes data);
 
     uint256 public flashBalance;
@@ -17,7 +15,11 @@ contract FlashMintRedeemerMock is IFlashMinter {
         emit Parameters(fyDaiAmount, data);
     }
 
-    function flashMint(address fyDai, uint256 amount, bytes calldata data) public {
+    function flashMint(
+        address fyDai,
+        uint256 amount,
+        bytes calldata data
+    ) public {
         IFYDai(fyDai).flashMint(amount, data);
     }
 }

--- a/contracts/mocks/FlashMinterMock.sol
+++ b/contracts/mocks/FlashMinterMock.sol
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-import "../interfaces/IFlashMinter.sol";
-import "../interfaces/IFYDai.sol";
-
+import '../interfaces/IFlashMinter.sol';
+import '../interfaces/IFYDai.sol';
 
 contract FlashMinterMock is IFlashMinter {
-
     event Parameters(uint256 amount, bytes data);
 
     uint256 public flashBalance;
@@ -16,7 +14,11 @@ contract FlashMinterMock is IFlashMinter {
         emit Parameters(fyDaiAmount, data);
     }
 
-    function flashMint(address fyDai, uint256 amount, bytes calldata data) public {
+    function flashMint(
+        address fyDai,
+        uint256 amount,
+        bytes calldata data
+    ) public {
         IFYDai(fyDai).flashMint(amount, data);
     }
 }

--- a/contracts/mocks/TestERC20.sol
+++ b/contracts/mocks/TestERC20.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-import "../helpers/ERC20Permit.sol";
+import '../helpers/ERC20Permit.sol';
 
 contract TestERC20 is ERC20Permit {
-    constructor (uint256 supply) public ERC20Permit("Test", "TST") {
+    constructor(uint256 supply) public ERC20Permit('Test', 'TST') {
         _mint(msg.sender, supply);
     }
 

--- a/contracts/mocks/YieldMath128.sol
+++ b/contracts/mocks/YieldMath128.sol
@@ -1,478 +1,996 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.0;
 
-import "../pool/Math64x64.sol";
+import '../pool/Math64x64.sol';
 
 /**
  * Ethereum smart contract library implementing Yield Math model for DAI/fyDai
  * swaps.
  */
 library YieldMath128 {
-  /**
-   * Calculate the amount of fyDai a user would get for given amount of DAI.
-   *
-   * @param daiReserves DAI reserves amount
-   * @param fyDaiReserves fyDai reserves amount
-   * @param daiAmount DAI amount to be traded
-   * @param timeTillMaturity time till maturity in seconds
-   * @param k time till maturity coefficient, multiplied by 2^64
-   * @param g fee coefficient, multiplied by 2^64
-   * @return the amount of fyDai a user would get for given amount of DAI
-   */
-  function fyDaiOutForDaiIn (
-    uint128 daiReserves, uint128 fyDaiReserves, uint128 daiAmount,
-    uint128 timeTillMaturity, int128 k, int128 g)
-  internal pure returns (uint128) {
-    // t = k * timeTillMaturity
-    int128 t = Math64x64.mul (k, Math64x64.fromUInt (timeTillMaturity));
+    /**
+     * Calculate the amount of fyDai a user would get for given amount of DAI.
+     *
+     * @param daiReserves DAI reserves amount
+     * @param fyDaiReserves fyDai reserves amount
+     * @param daiAmount DAI amount to be traded
+     * @param timeTillMaturity time till maturity in seconds
+     * @param k time till maturity coefficient, multiplied by 2^64
+     * @param g fee coefficient, multiplied by 2^64
+     * @return the amount of fyDai a user would get for given amount of DAI
+     */
+    function fyDaiOutForDaiIn(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) internal pure returns (uint128) {
+        // t = k * timeTillMaturity
+        int128 t = Math64x64.mul(k, Math64x64.fromUInt(timeTillMaturity));
 
-    // a = (1 - gt)
-    int128 a = Math64x64.sub (0x10000000000000000, Math64x64.mul (g, t));
-    require (a > 0);
+        // a = (1 - gt)
+        int128 a = Math64x64.sub(0x10000000000000000, Math64x64.mul(g, t));
+        require(a > 0);
 
-    // zdz = daiReserves + daiAmount
-    uint256 zdz = uint256 (daiReserves) + uint256 (daiAmount);
-    require (zdz < 0x100000000000000000000000000000000);
+        // zdz = daiReserves + daiAmount
+        uint256 zdz = uint256(daiReserves) + uint256(daiAmount);
+        require(zdz < 0x100000000000000000000000000000000);
 
-    uint256 sum =
-      pow (daiReserves, uint128 (a), 0x10000000000000000) +
-      uint256 (pow (fyDaiReserves, uint128 (a), 0x10000000000000000)) -
-      pow (uint128 (zdz), uint128 (a), 0x10000000000000000);
-    require (sum < 0x100000000000000000000000000000000);
+        uint256 sum =
+            pow(daiReserves, uint128(a), 0x10000000000000000) +
+                uint256(pow(fyDaiReserves, uint128(a), 0x10000000000000000)) -
+                pow(uint128(zdz), uint128(a), 0x10000000000000000);
+        require(sum < 0x100000000000000000000000000000000);
 
-    uint256 result = fyDaiReserves - pow (uint128 (sum), 0x10000000000000000, uint128 (a));
-    require (result < 0x100000000000000000000000000000000);
+        uint256 result = fyDaiReserves - pow(uint128(sum), 0x10000000000000000, uint128(a));
+        require(result < 0x100000000000000000000000000000000);
 
-    return uint128 (result);
-  }
-
-  /**
-   * Calculate the amount of DAI a user would get for certain amount of fyDai.
-   *
-   * @param daiReserves DAI reserves amount
-   * @param fyDaiReserves fyDai reserves amount
-   * @param fyDaiAmount fyDai amount to be traded
-   * @param timeTillMaturity time till maturity in seconds
-   * @param k time till maturity coefficient, multiplied by 2^64
-   * @param g fee coefficient, multiplied by 2^64
-   * @return the amount of DAI a user would get for given amount of fyDai
-   */
-  function daiOutForFYDaiIn (
-    uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiAmount,
-    uint128 timeTillMaturity, int128 k, int128 g)
-  internal pure returns (uint128) {
-    // t = k * timeTillMaturity
-    int128 t = Math64x64.mul (k, Math64x64.fromUInt (timeTillMaturity));
-
-    // a = (1 - gt)
-    int128 a = Math64x64.sub (0x10000000000000000, Math64x64.mul (g, t));
-    require (a > 0);
-
-    // ydy = fyDaiReserves + fyDaiAmount;
-    uint256 ydy = uint256 (fyDaiReserves) + uint256 (fyDaiAmount);
-    require (ydy < 0x100000000000000000000000000000000);
-
-    uint256 sum =
-      uint256 (pow (daiReserves, uint128 (a), 0x10000000000000000)) -
-      (uint256 (pow (uint128 (ydy), uint128 (a), 0x10000000000000000)) -
-      uint256 (pow (fyDaiReserves, uint128 (a), 0x10000000000000000)));
-    require (sum < 0x100000000000000000000000000000000);
-
-    uint256 result =
-      daiReserves -
-      pow (uint128 (sum), 0x10000000000000000, uint128 (a));
-    require (result < 0x100000000000000000000000000000000);
-
-    return uint128 (result);
-  }
-
-  /**
-   * Calculate the amount of fyDai a user could sell for given amount of DAI.
-   *
-   * @param daiReserves DAI reserves amount
-   * @param fyDaiReserves fyDai reserves amount
-   * @param daiAmount DAI amount to be traded
-   * @param timeTillMaturity time till maturity in seconds
-   * @param k time till maturity coefficient, multiplied by 2^64
-   * @param g fee coefficient, multiplied by 2^64
-   * @return the amount of fyDai a user could sell for given amount of DAI
-   */
-  function fyDaiInForDaiOut (
-    uint128 daiReserves, uint128 fyDaiReserves, uint128 daiAmount,
-    uint128 timeTillMaturity, int128 k, int128 g)
-  internal pure returns (uint128) {
-    require (daiAmount <= daiReserves);
-
-    // t = k * timeTillMaturity
-    int128 t = Math64x64.mul (k, Math64x64.fromUInt (timeTillMaturity));
-
-    // a = (1 - gt)
-    int128 a = Math64x64.sub (0x10000000000000000, Math64x64.mul (g, t));
-    require (a > 0);
-
-    // zdz = daiReserves - daiAmount
-    uint256 zdz = uint256 (daiReserves) - uint256 (daiAmount);
-    require (zdz < 0x100000000000000000000000000000000);
-
-    uint256 sum =
-      pow (daiReserves, uint128 (a), 0x10000000000000000) +
-      uint256 (pow (fyDaiReserves, uint128 (a), 0x10000000000000000)) -
-      pow (uint128 (zdz), uint128 (a), 0x10000000000000000);
-    require (sum < 0x100000000000000000000000000000000);
-
-    uint256 result = pow (uint128 (sum), 0x10000000000000000, uint128 (a)) - fyDaiReserves;
-    require (result < 0x100000000000000000000000000000000);
-
-    return uint128 (result);
-  }
-
-  /**
-   * Calculate the amount of DAI a user would have to pay for certain amount of
-   * fyDai.
-   *
-   * @param daiReserves DAI reserves amount
-   * @param fyDaiReserves fyDai reserves amount
-   * @param fyDaiAmount fyDai amount to be traded
-   * @param timeTillMaturity time till maturity in seconds
-   * @param k time till maturity coefficient, multiplied by 2^64
-   * @param g fee coefficient, multiplied by 2^64
-   * @return the amount of DAI a user would have to pay for given amount of
-   *         fyDai
-   */
-  function daiInForFYDaiOut (
-    uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiAmount,
-    uint128 timeTillMaturity, int128 k, int128 g)
-  internal pure returns (uint128) {
-    require (fyDaiAmount <= fyDaiReserves);
-
-    // a = (1 - g * k * timeTillMaturity)
-    int128 a = Math64x64.sub (0x10000000000000000, Math64x64.mul (g, Math64x64.mul (k, Math64x64.fromUInt (timeTillMaturity))));
-    require (a > 0);
-
-    // ydy = fyDaiReserves - fyDaiAmount;
-    uint256 ydy = uint256 (fyDaiReserves) - uint256 (fyDaiAmount);
-    require (ydy < 0x100000000000000000000000000000000);
-
-    uint256 sum =
-      uint256 (pow (daiReserves, uint128 (a), 0x10000000000000000)) +
-      uint256 (pow (fyDaiReserves, uint128 (a), 0x10000000000000000)) -
-      uint256 (pow (uint128 (ydy), uint128 (a), 0x10000000000000000));
-    require (sum < 0x100000000000000000000000000000000);
-
-    uint256 result =
-      pow (uint128 (sum), 0x10000000000000000, uint128 (a)) -
-      daiReserves;
-    require (result < 0x100000000000000000000000000000000);
-
-    return uint128 (result);
-  }
-
-  /**
-   * Raise given number x into power specified as a simple fraction y/z and then
-   * multiply the result by the normalization factor 2^(128 * (1 - y/z)).
-   * Revert if z is zero, or if both x and y are zeros.
-   *
-   * @param x number to raise into given power y/z
-   * @param y numerator of the power to raise x into
-   * @param z denominator of the power to raise x into
-   * @return x raised into power y/z and then multiplied by 2^(128 * (1 - y/z))
-   */
-  function pow (uint128 x, uint128 y, uint128 z)
-  internal pure returns (uint128) {
-    require (z != 0);
-
-    if (x == 0) {
-      require (y != 0);
-      return 0;
-    } else {
-      uint256 l =
-        uint256 (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF - log_2 (x)) * y / z;
-      if (l > 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) return 0;
-      else return pow_2 (uint128 (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF - l));
+        return uint128(result);
     }
-  }
 
-  /**
-   * Calculate base 2 logarithm of an unsigned 128-bit integer number.  Revert
-   * in case x is zero.
-   *
-   * @param x number to calculate base 2 logarithm of
-   * @return base 2 logarithm of x, multiplied by 2^121
-   */
-  function log_2 (uint128 x)
-  internal pure returns (uint128) {
-    require (x != 0);
+    /**
+     * Calculate the amount of DAI a user would get for certain amount of fyDai.
+     *
+     * @param daiReserves DAI reserves amount
+     * @param fyDaiReserves fyDai reserves amount
+     * @param fyDaiAmount fyDai amount to be traded
+     * @param timeTillMaturity time till maturity in seconds
+     * @param k time till maturity coefficient, multiplied by 2^64
+     * @param g fee coefficient, multiplied by 2^64
+     * @return the amount of DAI a user would get for given amount of fyDai
+     */
+    function daiOutForFYDaiIn(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) internal pure returns (uint128) {
+        // t = k * timeTillMaturity
+        int128 t = Math64x64.mul(k, Math64x64.fromUInt(timeTillMaturity));
 
-    uint b = x;
+        // a = (1 - gt)
+        int128 a = Math64x64.sub(0x10000000000000000, Math64x64.mul(g, t));
+        require(a > 0);
 
-    uint l = 0xFE000000000000000000000000000000;
+        // ydy = fyDaiReserves + fyDaiAmount;
+        uint256 ydy = uint256(fyDaiReserves) + uint256(fyDaiAmount);
+        require(ydy < 0x100000000000000000000000000000000);
 
-    if (b < 0x10000000000000000) {l -= 0x80000000000000000000000000000000; b <<= 64;}
-    if (b < 0x1000000000000000000000000) {l -= 0x40000000000000000000000000000000; b <<= 32;}
-    if (b < 0x10000000000000000000000000000) {l -= 0x20000000000000000000000000000000; b <<= 16;}
-    if (b < 0x1000000000000000000000000000000) {l -= 0x10000000000000000000000000000000; b <<= 8;}
-    if (b < 0x10000000000000000000000000000000) {l -= 0x8000000000000000000000000000000; b <<= 4;}
-    if (b < 0x40000000000000000000000000000000) {l -= 0x4000000000000000000000000000000; b <<= 2;}
-    if (b < 0x80000000000000000000000000000000) {l -= 0x2000000000000000000000000000000; b <<= 1;}
+        uint256 sum =
+            uint256(pow(daiReserves, uint128(a), 0x10000000000000000)) -
+                (uint256(pow(uint128(ydy), uint128(a), 0x10000000000000000)) -
+                    uint256(pow(fyDaiReserves, uint128(a), 0x10000000000000000)));
+        require(sum < 0x100000000000000000000000000000000);
 
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x1000000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x800000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x400000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x200000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x100000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x80000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x40000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x20000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x10000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x8000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x4000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x2000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x1000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x800000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x400000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x200000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x100000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x80000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x40000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x20000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x10000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x8000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x4000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x2000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x1000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x800000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x400000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x200000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x100000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x80000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x40000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x20000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x10000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x8000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x4000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x2000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x1000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x800000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x400000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x200000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x100000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x80000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x40000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x20000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x10000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x8000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x4000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x2000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x1000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x800000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x400000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x200000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x100000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x80000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x40000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x20000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x10000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x8000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x4000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x2000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x1000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x800000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x400000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x200000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x100000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x80000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x40000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x20000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x10000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x8000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x4000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x2000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x1000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x800000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x400000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x200000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x100000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x80000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x40000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x20000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x10000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x8000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x4000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x2000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x1000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x800000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x400000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x200000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x100000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x80000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x40000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x20000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x10000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x8000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x4000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x2000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x1000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x800000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x400000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x200000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x100000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x80000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x40000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x20000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x10000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x8000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x4000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x2000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x1000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x800;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x400;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x200;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x100;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x80;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x40;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x20;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x10;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x8;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x4;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x2;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) l |= 0x1;
+        uint256 result = daiReserves - pow(uint128(sum), 0x10000000000000000, uint128(a));
+        require(result < 0x100000000000000000000000000000000);
 
-    return uint128 (l);
-  }
+        return uint128(result);
+    }
 
-  /**
-   * Calculate 2 raised into given power.
-   *
-   * @param x power to raise 2 into, multiplied by 2^121
-   * @return 2 raised into given power
-   */
-  function pow_2 (uint128 x)
-  internal pure returns (uint128) {
-    uint r = 0x80000000000000000000000000000000;
-    if (x & 0x1000000000000000000000000000000 > 0) r = r * 0xb504f333f9de6484597d89b3754abe9f >> 127;
-    if (x & 0x800000000000000000000000000000 > 0) r = r * 0x9837f0518db8a96f46ad23182e42f6f6 >> 127;
-    if (x & 0x400000000000000000000000000000 > 0) r = r * 0x8b95c1e3ea8bd6e6fbe4628758a53c90 >> 127;
-    if (x & 0x200000000000000000000000000000 > 0) r = r * 0x85aac367cc487b14c5c95b8c2154c1b2 >> 127;
-    if (x & 0x100000000000000000000000000000 > 0) r = r * 0x82cd8698ac2ba1d73e2a475b46520bff >> 127;
-    if (x & 0x80000000000000000000000000000 > 0) r = r * 0x8164d1f3bc0307737be56527bd14def4 >> 127;
-    if (x & 0x40000000000000000000000000000 > 0) r = r * 0x80b1ed4fd999ab6c25335719b6e6fd20 >> 127;
-    if (x & 0x20000000000000000000000000000 > 0) r = r * 0x8058d7d2d5e5f6b094d589f608ee4aa2 >> 127;
-    if (x & 0x10000000000000000000000000000 > 0) r = r * 0x802c6436d0e04f50ff8ce94a6797b3ce >> 127;
-    if (x & 0x8000000000000000000000000000 > 0) r = r * 0x8016302f174676283690dfe44d11d008 >> 127;
-    if (x & 0x4000000000000000000000000000 > 0) r = r * 0x800b179c82028fd0945e54e2ae18f2f0 >> 127;
-    if (x & 0x2000000000000000000000000000 > 0) r = r * 0x80058baf7fee3b5d1c718b38e549cb93 >> 127;
-    if (x & 0x1000000000000000000000000000 > 0) r = r * 0x8002c5d00fdcfcb6b6566a58c048be1f >> 127;
-    if (x & 0x800000000000000000000000000 > 0) r = r * 0x800162e61bed4a48e84c2e1a463473d9 >> 127;
-    if (x & 0x400000000000000000000000000 > 0) r = r * 0x8000b17292f702a3aa22beacca949013 >> 127;
-    if (x & 0x200000000000000000000000000 > 0) r = r * 0x800058b92abbae02030c5fa5256f41fe >> 127;
-    if (x & 0x100000000000000000000000000 > 0) r = r * 0x80002c5c8dade4d71776c0f4dbea67d6 >> 127;
-    if (x & 0x80000000000000000000000000 > 0) r = r * 0x8000162e44eaf636526be456600bdbe4 >> 127;
-    if (x & 0x40000000000000000000000000 > 0) r = r * 0x80000b1721fa7c188307016c1cd4e8b6 >> 127;
-    if (x & 0x20000000000000000000000000 > 0) r = r * 0x8000058b90de7e4cecfc487503488bb1 >> 127;
-    if (x & 0x10000000000000000000000000 > 0) r = r * 0x800002c5c8678f36cbfce50a6de60b14 >> 127;
-    if (x & 0x8000000000000000000000000 > 0) r = r * 0x80000162e431db9f80b2347b5d62e516 >> 127;
-    if (x & 0x4000000000000000000000000 > 0) r = r * 0x800000b1721872d0c7b08cf1e0114152 >> 127;
-    if (x & 0x2000000000000000000000000 > 0) r = r * 0x80000058b90c1aa8a5c3736cb77e8dff >> 127;
-    if (x & 0x1000000000000000000000000 > 0) r = r * 0x8000002c5c8605a4635f2efc2362d978 >> 127;
-    if (x & 0x800000000000000000000000 > 0) r = r * 0x800000162e4300e635cf4a109e3939bd >> 127;
-    if (x & 0x400000000000000000000000 > 0) r = r * 0x8000000b17217ff81bef9c551590cf83 >> 127;
-    if (x & 0x200000000000000000000000 > 0) r = r * 0x800000058b90bfdd4e39cd52c0cfa27c >> 127;
-    if (x & 0x100000000000000000000000 > 0) r = r * 0x80000002c5c85fe6f72d669e0e76e411 >> 127;
-    if (x & 0x80000000000000000000000 > 0) r = r * 0x8000000162e42ff18f9ad35186d0df28 >> 127;
-    if (x & 0x40000000000000000000000 > 0) r = r * 0x80000000b17217f84cce71aa0dcfffe7 >> 127;
-    if (x & 0x20000000000000000000000 > 0) r = r * 0x8000000058b90bfc07a77ad56ed22aaa >> 127;
-    if (x & 0x10000000000000000000000 > 0) r = r * 0x800000002c5c85fdfc23cdead40da8d6 >> 127;
-    if (x & 0x8000000000000000000000 > 0) r = r * 0x80000000162e42fefc25eb1571853a66 >> 127;
-    if (x & 0x4000000000000000000000 > 0) r = r * 0x800000000b17217f7d97f692baacded5 >> 127;
-    if (x & 0x2000000000000000000000 > 0) r = r * 0x80000000058b90bfbead3b8b5dd254d7 >> 127;
-    if (x & 0x1000000000000000000000 > 0) r = r * 0x8000000002c5c85fdf4eedd62f084e67 >> 127;
-    if (x & 0x800000000000000000000 > 0) r = r * 0x800000000162e42fefa58aef378bf586 >> 127;
-    if (x & 0x400000000000000000000 > 0) r = r * 0x8000000000b17217f7d24a78a3c7ef02 >> 127;
-    if (x & 0x200000000000000000000 > 0) r = r * 0x800000000058b90bfbe9067c93e474a6 >> 127;
-    if (x & 0x100000000000000000000 > 0) r = r * 0x80000000002c5c85fdf47b8e5a72599f >> 127;
-    if (x & 0x80000000000000000000 > 0) r = r * 0x8000000000162e42fefa3bdb315934a2 >> 127;
-    if (x & 0x40000000000000000000 > 0) r = r * 0x80000000000b17217f7d1d7299b49c46 >> 127;
-    if (x & 0x20000000000000000000 > 0) r = r * 0x8000000000058b90bfbe8e9a8d1c4ea0 >> 127;
-    if (x & 0x10000000000000000000 > 0) r = r * 0x800000000002c5c85fdf4745969ea76f >> 127;
-    if (x & 0x8000000000000000000 > 0) r = r * 0x80000000000162e42fefa3a0df5373bf >> 127;
-    if (x & 0x4000000000000000000 > 0) r = r * 0x800000000000b17217f7d1cff4aac1e1 >> 127;
-    if (x & 0x2000000000000000000 > 0) r = r * 0x80000000000058b90bfbe8e7db95a2f1 >> 127;
-    if (x & 0x1000000000000000000 > 0) r = r * 0x8000000000002c5c85fdf473e61ae1f8 >> 127;
-    if (x & 0x800000000000000000 > 0) r = r * 0x800000000000162e42fefa39f121751c >> 127;
-    if (x & 0x400000000000000000 > 0) r = r * 0x8000000000000b17217f7d1cf815bb96 >> 127;
-    if (x & 0x200000000000000000 > 0) r = r * 0x800000000000058b90bfbe8e7bec1e0d >> 127;
-    if (x & 0x100000000000000000 > 0) r = r * 0x80000000000002c5c85fdf473dee5f17 >> 127;
-    if (x & 0x80000000000000000 > 0) r = r * 0x8000000000000162e42fefa39ef5438f >> 127;
-    if (x & 0x40000000000000000 > 0) r = r * 0x80000000000000b17217f7d1cf7a26c8 >> 127;
-    if (x & 0x20000000000000000 > 0) r = r * 0x8000000000000058b90bfbe8e7bcf4a4 >> 127;
-    if (x & 0x10000000000000000 > 0) r = r * 0x800000000000002c5c85fdf473de72a2 >> 127;
-    if (x & 0x8000000000000000 > 0) r = r * 0x80000000000000162e42fefa39ef3765 >> 127;
-    if (x & 0x4000000000000000 > 0) r = r * 0x800000000000000b17217f7d1cf79b37 >> 127;
-    if (x & 0x2000000000000000 > 0) r = r * 0x80000000000000058b90bfbe8e7bcd7d >> 127;
-    if (x & 0x1000000000000000 > 0) r = r * 0x8000000000000002c5c85fdf473de6b6 >> 127;
-    if (x & 0x800000000000000 > 0) r = r * 0x800000000000000162e42fefa39ef359 >> 127;
-    if (x & 0x400000000000000 > 0) r = r * 0x8000000000000000b17217f7d1cf79ac >> 127;
-    if (x & 0x200000000000000 > 0) r = r * 0x800000000000000058b90bfbe8e7bcd6 >> 127;
-    if (x & 0x100000000000000 > 0) r = r * 0x80000000000000002c5c85fdf473de6a >> 127;
-    if (x & 0x80000000000000 > 0) r = r * 0x8000000000000000162e42fefa39ef35 >> 127;
-    if (x & 0x40000000000000 > 0) r = r * 0x80000000000000000b17217f7d1cf79a >> 127;
-    if (x & 0x20000000000000 > 0) r = r * 0x8000000000000000058b90bfbe8e7bcd >> 127;
-    if (x & 0x10000000000000 > 0) r = r * 0x800000000000000002c5c85fdf473de6 >> 127;
-    if (x & 0x8000000000000 > 0) r = r * 0x80000000000000000162e42fefa39ef3 >> 127;
-    if (x & 0x4000000000000 > 0) r = r * 0x800000000000000000b17217f7d1cf79 >> 127;
-    if (x & 0x2000000000000 > 0) r = r * 0x80000000000000000058b90bfbe8e7bc >> 127;
-    if (x & 0x1000000000000 > 0) r = r * 0x8000000000000000002c5c85fdf473de >> 127;
-    if (x & 0x800000000000 > 0) r = r * 0x800000000000000000162e42fefa39ef >> 127;
-    if (x & 0x400000000000 > 0) r = r * 0x8000000000000000000b17217f7d1cf7 >> 127;
-    if (x & 0x200000000000 > 0) r = r * 0x800000000000000000058b90bfbe8e7b >> 127;
-    if (x & 0x100000000000 > 0) r = r * 0x80000000000000000002c5c85fdf473d >> 127;
-    if (x & 0x80000000000 > 0) r = r * 0x8000000000000000000162e42fefa39e >> 127;
-    if (x & 0x40000000000 > 0) r = r * 0x80000000000000000000b17217f7d1cf >> 127;
-    if (x & 0x20000000000 > 0) r = r * 0x8000000000000000000058b90bfbe8e7 >> 127;
-    if (x & 0x10000000000 > 0) r = r * 0x800000000000000000002c5c85fdf473 >> 127;
-    if (x & 0x8000000000 > 0) r = r * 0x80000000000000000000162e42fefa39 >> 127;
-    if (x & 0x4000000000 > 0) r = r * 0x800000000000000000000b17217f7d1c >> 127;
-    if (x & 0x2000000000 > 0) r = r * 0x80000000000000000000058b90bfbe8e >> 127;
-    if (x & 0x1000000000 > 0) r = r * 0x8000000000000000000002c5c85fdf47 >> 127;
-    if (x & 0x800000000 > 0) r = r * 0x800000000000000000000162e42fefa3 >> 127;
-    if (x & 0x400000000 > 0) r = r * 0x8000000000000000000000b17217f7d1 >> 127;
-    if (x & 0x200000000 > 0) r = r * 0x800000000000000000000058b90bfbe8 >> 127;
-    if (x & 0x100000000 > 0) r = r * 0x80000000000000000000002c5c85fdf4 >> 127;
-    if (x & 0x80000000 > 0) r = r * 0x8000000000000000000000162e42fefa >> 127;
-    if (x & 0x40000000 > 0) r = r * 0x80000000000000000000000b17217f7d >> 127;
-    if (x & 0x20000000 > 0) r = r * 0x8000000000000000000000058b90bfbe >> 127;
-    if (x & 0x10000000 > 0) r = r * 0x800000000000000000000002c5c85fdf >> 127;
-    if (x & 0x8000000 > 0) r = r * 0x80000000000000000000000162e42fef >> 127;
-    if (x & 0x4000000 > 0) r = r * 0x800000000000000000000000b17217f7 >> 127;
-    if (x & 0x2000000 > 0) r = r * 0x80000000000000000000000058b90bfb >> 127;
-    if (x & 0x1000000 > 0) r = r * 0x8000000000000000000000002c5c85fd >> 127;
-    if (x & 0x800000 > 0) r = r * 0x800000000000000000000000162e42fe >> 127;
-    if (x & 0x400000 > 0) r = r * 0x8000000000000000000000000b17217f >> 127;
-    if (x & 0x200000 > 0) r = r * 0x800000000000000000000000058b90bf >> 127;
-    if (x & 0x100000 > 0) r = r * 0x80000000000000000000000002c5c85f >> 127;
-    if (x & 0x80000 > 0) r = r * 0x8000000000000000000000000162e42f >> 127;
-    if (x & 0x40000 > 0) r = r * 0x80000000000000000000000000b17217 >> 127;
-    if (x & 0x20000 > 0) r = r * 0x8000000000000000000000000058b90b >> 127;
-    if (x & 0x10000 > 0) r = r * 0x800000000000000000000000002c5c85 >> 127;
-    if (x & 0x8000 > 0) r = r * 0x80000000000000000000000000162e42 >> 127;
-    if (x & 0x4000 > 0) r = r * 0x800000000000000000000000000b1721 >> 127;
-    if (x & 0x2000 > 0) r = r * 0x80000000000000000000000000058b90 >> 127;
-    if (x & 0x1000 > 0) r = r * 0x8000000000000000000000000002c5c8 >> 127;
-    if (x & 0x800 > 0) r = r * 0x800000000000000000000000000162e4 >> 127;
-    if (x & 0x400 > 0) r = r * 0x8000000000000000000000000000b172 >> 127;
-    if (x & 0x200 > 0) r = r * 0x800000000000000000000000000058b9 >> 127;
-    if (x & 0x100 > 0) r = r * 0x80000000000000000000000000002c5c >> 127;
-    if (x & 0x80 > 0) r = r * 0x8000000000000000000000000000162e >> 127;
-    if (x & 0x40 > 0) r = r * 0x80000000000000000000000000000b17 >> 127;
-    if (x & 0x20 > 0) r = r * 0x8000000000000000000000000000058b >> 127;
-    if (x & 0x10 > 0) r = r * 0x800000000000000000000000000002c5 >> 127;
-    if (x & 0x8 > 0) r = r * 0x80000000000000000000000000000162 >> 127;
-    if (x & 0x4 > 0) r = r * 0x800000000000000000000000000000b1 >> 127;
-    if (x & 0x2 > 0) r = r * 0x80000000000000000000000000000058 >> 127;
-    if (x & 0x1 > 0) r = r * 0x8000000000000000000000000000002c >> 127;
+    /**
+     * Calculate the amount of fyDai a user could sell for given amount of DAI.
+     *
+     * @param daiReserves DAI reserves amount
+     * @param fyDaiReserves fyDai reserves amount
+     * @param daiAmount DAI amount to be traded
+     * @param timeTillMaturity time till maturity in seconds
+     * @param k time till maturity coefficient, multiplied by 2^64
+     * @param g fee coefficient, multiplied by 2^64
+     * @return the amount of fyDai a user could sell for given amount of DAI
+     */
+    function fyDaiInForDaiOut(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) internal pure returns (uint128) {
+        require(daiAmount <= daiReserves);
 
-    r >>= 127 - (x >> 121);
+        // t = k * timeTillMaturity
+        int128 t = Math64x64.mul(k, Math64x64.fromUInt(timeTillMaturity));
 
-    return uint128 (r);
-  }
+        // a = (1 - gt)
+        int128 a = Math64x64.sub(0x10000000000000000, Math64x64.mul(g, t));
+        require(a > 0);
+
+        // zdz = daiReserves - daiAmount
+        uint256 zdz = uint256(daiReserves) - uint256(daiAmount);
+        require(zdz < 0x100000000000000000000000000000000);
+
+        uint256 sum =
+            pow(daiReserves, uint128(a), 0x10000000000000000) +
+                uint256(pow(fyDaiReserves, uint128(a), 0x10000000000000000)) -
+                pow(uint128(zdz), uint128(a), 0x10000000000000000);
+        require(sum < 0x100000000000000000000000000000000);
+
+        uint256 result = pow(uint128(sum), 0x10000000000000000, uint128(a)) - fyDaiReserves;
+        require(result < 0x100000000000000000000000000000000);
+
+        return uint128(result);
+    }
+
+    /**
+     * Calculate the amount of DAI a user would have to pay for certain amount of
+     * fyDai.
+     *
+     * @param daiReserves DAI reserves amount
+     * @param fyDaiReserves fyDai reserves amount
+     * @param fyDaiAmount fyDai amount to be traded
+     * @param timeTillMaturity time till maturity in seconds
+     * @param k time till maturity coefficient, multiplied by 2^64
+     * @param g fee coefficient, multiplied by 2^64
+     * @return the amount of DAI a user would have to pay for given amount of
+     *         fyDai
+     */
+    function daiInForFYDaiOut(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) internal pure returns (uint128) {
+        require(fyDaiAmount <= fyDaiReserves);
+
+        // a = (1 - g * k * timeTillMaturity)
+        int128 a =
+            Math64x64.sub(
+                0x10000000000000000,
+                Math64x64.mul(g, Math64x64.mul(k, Math64x64.fromUInt(timeTillMaturity)))
+            );
+        require(a > 0);
+
+        // ydy = fyDaiReserves - fyDaiAmount;
+        uint256 ydy = uint256(fyDaiReserves) - uint256(fyDaiAmount);
+        require(ydy < 0x100000000000000000000000000000000);
+
+        uint256 sum =
+            uint256(pow(daiReserves, uint128(a), 0x10000000000000000)) +
+                uint256(pow(fyDaiReserves, uint128(a), 0x10000000000000000)) -
+                uint256(pow(uint128(ydy), uint128(a), 0x10000000000000000));
+        require(sum < 0x100000000000000000000000000000000);
+
+        uint256 result = pow(uint128(sum), 0x10000000000000000, uint128(a)) - daiReserves;
+        require(result < 0x100000000000000000000000000000000);
+
+        return uint128(result);
+    }
+
+    /**
+     * Raise given number x into power specified as a simple fraction y/z and then
+     * multiply the result by the normalization factor 2^(128 * (1 - y/z)).
+     * Revert if z is zero, or if both x and y are zeros.
+     *
+     * @param x number to raise into given power y/z
+     * @param y numerator of the power to raise x into
+     * @param z denominator of the power to raise x into
+     * @return x raised into power y/z and then multiplied by 2^(128 * (1 - y/z))
+     */
+    function pow(
+        uint128 x,
+        uint128 y,
+        uint128 z
+    ) internal pure returns (uint128) {
+        require(z != 0);
+
+        if (x == 0) {
+            require(y != 0);
+            return 0;
+        } else {
+            uint256 l = (uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF - log_2(x)) * y) / z;
+            if (l > 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) return 0;
+            else return pow_2(uint128(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF - l));
+        }
+    }
+
+    /**
+     * Calculate base 2 logarithm of an unsigned 128-bit integer number.  Revert
+     * in case x is zero.
+     *
+     * @param x number to calculate base 2 logarithm of
+     * @return base 2 logarithm of x, multiplied by 2^121
+     */
+    function log_2(uint128 x) internal pure returns (uint128) {
+        require(x != 0);
+
+        uint256 b = x;
+
+        uint256 l = 0xFE000000000000000000000000000000;
+
+        if (b < 0x10000000000000000) {
+            l -= 0x80000000000000000000000000000000;
+            b <<= 64;
+        }
+        if (b < 0x1000000000000000000000000) {
+            l -= 0x40000000000000000000000000000000;
+            b <<= 32;
+        }
+        if (b < 0x10000000000000000000000000000) {
+            l -= 0x20000000000000000000000000000000;
+            b <<= 16;
+        }
+        if (b < 0x1000000000000000000000000000000) {
+            l -= 0x10000000000000000000000000000000;
+            b <<= 8;
+        }
+        if (b < 0x10000000000000000000000000000000) {
+            l -= 0x8000000000000000000000000000000;
+            b <<= 4;
+        }
+        if (b < 0x40000000000000000000000000000000) {
+            l -= 0x4000000000000000000000000000000;
+            b <<= 2;
+        }
+        if (b < 0x80000000000000000000000000000000) {
+            l -= 0x2000000000000000000000000000000;
+            b <<= 1;
+        }
+
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x1000000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x800000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x400000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x200000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x100000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x80000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x40000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x20000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x10000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x8000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x4000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x2000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x1000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x800000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x400000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x200000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x100000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x80000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x40000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x20000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x10000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x8000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x4000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x2000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x1000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x800000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x400000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x200000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x100000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x80000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x40000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x20000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x10000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x8000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x4000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x2000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x1000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x800000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x400000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x200000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x100000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x80000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x40000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x20000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x10000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x8000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x4000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x2000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x1000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x800000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x400000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x200000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x100000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x80000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x40000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x20000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x10000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x8000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x4000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x2000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x1000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x800000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x400000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x200000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x100000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x80000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x40000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x20000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x10000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x8000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x4000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x2000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x1000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x800000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x400000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x200000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x100000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x80000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x40000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x20000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x10000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x8000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x4000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x2000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x1000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x800000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x400000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x200000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x100000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x80000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x40000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x20000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x10000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x8000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x4000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x2000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x1000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x800000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x400000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x200000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x100000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x80000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x40000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x20000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x10000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x8000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x4000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x2000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x1000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x800;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x400;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x200;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x100;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x80;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x40;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x20;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x10;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x8;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x4;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x2;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) l |= 0x1;
+
+        return uint128(l);
+    }
+
+    /**
+     * Calculate 2 raised into given power.
+     *
+     * @param x power to raise 2 into, multiplied by 2^121
+     * @return 2 raised into given power
+     */
+    function pow_2(uint128 x) internal pure returns (uint128) {
+        uint256 r = 0x80000000000000000000000000000000;
+        if (x & 0x1000000000000000000000000000000 > 0) r = (r * 0xb504f333f9de6484597d89b3754abe9f) >> 127;
+        if (x & 0x800000000000000000000000000000 > 0) r = (r * 0x9837f0518db8a96f46ad23182e42f6f6) >> 127;
+        if (x & 0x400000000000000000000000000000 > 0) r = (r * 0x8b95c1e3ea8bd6e6fbe4628758a53c90) >> 127;
+        if (x & 0x200000000000000000000000000000 > 0) r = (r * 0x85aac367cc487b14c5c95b8c2154c1b2) >> 127;
+        if (x & 0x100000000000000000000000000000 > 0) r = (r * 0x82cd8698ac2ba1d73e2a475b46520bff) >> 127;
+        if (x & 0x80000000000000000000000000000 > 0) r = (r * 0x8164d1f3bc0307737be56527bd14def4) >> 127;
+        if (x & 0x40000000000000000000000000000 > 0) r = (r * 0x80b1ed4fd999ab6c25335719b6e6fd20) >> 127;
+        if (x & 0x20000000000000000000000000000 > 0) r = (r * 0x8058d7d2d5e5f6b094d589f608ee4aa2) >> 127;
+        if (x & 0x10000000000000000000000000000 > 0) r = (r * 0x802c6436d0e04f50ff8ce94a6797b3ce) >> 127;
+        if (x & 0x8000000000000000000000000000 > 0) r = (r * 0x8016302f174676283690dfe44d11d008) >> 127;
+        if (x & 0x4000000000000000000000000000 > 0) r = (r * 0x800b179c82028fd0945e54e2ae18f2f0) >> 127;
+        if (x & 0x2000000000000000000000000000 > 0) r = (r * 0x80058baf7fee3b5d1c718b38e549cb93) >> 127;
+        if (x & 0x1000000000000000000000000000 > 0) r = (r * 0x8002c5d00fdcfcb6b6566a58c048be1f) >> 127;
+        if (x & 0x800000000000000000000000000 > 0) r = (r * 0x800162e61bed4a48e84c2e1a463473d9) >> 127;
+        if (x & 0x400000000000000000000000000 > 0) r = (r * 0x8000b17292f702a3aa22beacca949013) >> 127;
+        if (x & 0x200000000000000000000000000 > 0) r = (r * 0x800058b92abbae02030c5fa5256f41fe) >> 127;
+        if (x & 0x100000000000000000000000000 > 0) r = (r * 0x80002c5c8dade4d71776c0f4dbea67d6) >> 127;
+        if (x & 0x80000000000000000000000000 > 0) r = (r * 0x8000162e44eaf636526be456600bdbe4) >> 127;
+        if (x & 0x40000000000000000000000000 > 0) r = (r * 0x80000b1721fa7c188307016c1cd4e8b6) >> 127;
+        if (x & 0x20000000000000000000000000 > 0) r = (r * 0x8000058b90de7e4cecfc487503488bb1) >> 127;
+        if (x & 0x10000000000000000000000000 > 0) r = (r * 0x800002c5c8678f36cbfce50a6de60b14) >> 127;
+        if (x & 0x8000000000000000000000000 > 0) r = (r * 0x80000162e431db9f80b2347b5d62e516) >> 127;
+        if (x & 0x4000000000000000000000000 > 0) r = (r * 0x800000b1721872d0c7b08cf1e0114152) >> 127;
+        if (x & 0x2000000000000000000000000 > 0) r = (r * 0x80000058b90c1aa8a5c3736cb77e8dff) >> 127;
+        if (x & 0x1000000000000000000000000 > 0) r = (r * 0x8000002c5c8605a4635f2efc2362d978) >> 127;
+        if (x & 0x800000000000000000000000 > 0) r = (r * 0x800000162e4300e635cf4a109e3939bd) >> 127;
+        if (x & 0x400000000000000000000000 > 0) r = (r * 0x8000000b17217ff81bef9c551590cf83) >> 127;
+        if (x & 0x200000000000000000000000 > 0) r = (r * 0x800000058b90bfdd4e39cd52c0cfa27c) >> 127;
+        if (x & 0x100000000000000000000000 > 0) r = (r * 0x80000002c5c85fe6f72d669e0e76e411) >> 127;
+        if (x & 0x80000000000000000000000 > 0) r = (r * 0x8000000162e42ff18f9ad35186d0df28) >> 127;
+        if (x & 0x40000000000000000000000 > 0) r = (r * 0x80000000b17217f84cce71aa0dcfffe7) >> 127;
+        if (x & 0x20000000000000000000000 > 0) r = (r * 0x8000000058b90bfc07a77ad56ed22aaa) >> 127;
+        if (x & 0x10000000000000000000000 > 0) r = (r * 0x800000002c5c85fdfc23cdead40da8d6) >> 127;
+        if (x & 0x8000000000000000000000 > 0) r = (r * 0x80000000162e42fefc25eb1571853a66) >> 127;
+        if (x & 0x4000000000000000000000 > 0) r = (r * 0x800000000b17217f7d97f692baacded5) >> 127;
+        if (x & 0x2000000000000000000000 > 0) r = (r * 0x80000000058b90bfbead3b8b5dd254d7) >> 127;
+        if (x & 0x1000000000000000000000 > 0) r = (r * 0x8000000002c5c85fdf4eedd62f084e67) >> 127;
+        if (x & 0x800000000000000000000 > 0) r = (r * 0x800000000162e42fefa58aef378bf586) >> 127;
+        if (x & 0x400000000000000000000 > 0) r = (r * 0x8000000000b17217f7d24a78a3c7ef02) >> 127;
+        if (x & 0x200000000000000000000 > 0) r = (r * 0x800000000058b90bfbe9067c93e474a6) >> 127;
+        if (x & 0x100000000000000000000 > 0) r = (r * 0x80000000002c5c85fdf47b8e5a72599f) >> 127;
+        if (x & 0x80000000000000000000 > 0) r = (r * 0x8000000000162e42fefa3bdb315934a2) >> 127;
+        if (x & 0x40000000000000000000 > 0) r = (r * 0x80000000000b17217f7d1d7299b49c46) >> 127;
+        if (x & 0x20000000000000000000 > 0) r = (r * 0x8000000000058b90bfbe8e9a8d1c4ea0) >> 127;
+        if (x & 0x10000000000000000000 > 0) r = (r * 0x800000000002c5c85fdf4745969ea76f) >> 127;
+        if (x & 0x8000000000000000000 > 0) r = (r * 0x80000000000162e42fefa3a0df5373bf) >> 127;
+        if (x & 0x4000000000000000000 > 0) r = (r * 0x800000000000b17217f7d1cff4aac1e1) >> 127;
+        if (x & 0x2000000000000000000 > 0) r = (r * 0x80000000000058b90bfbe8e7db95a2f1) >> 127;
+        if (x & 0x1000000000000000000 > 0) r = (r * 0x8000000000002c5c85fdf473e61ae1f8) >> 127;
+        if (x & 0x800000000000000000 > 0) r = (r * 0x800000000000162e42fefa39f121751c) >> 127;
+        if (x & 0x400000000000000000 > 0) r = (r * 0x8000000000000b17217f7d1cf815bb96) >> 127;
+        if (x & 0x200000000000000000 > 0) r = (r * 0x800000000000058b90bfbe8e7bec1e0d) >> 127;
+        if (x & 0x100000000000000000 > 0) r = (r * 0x80000000000002c5c85fdf473dee5f17) >> 127;
+        if (x & 0x80000000000000000 > 0) r = (r * 0x8000000000000162e42fefa39ef5438f) >> 127;
+        if (x & 0x40000000000000000 > 0) r = (r * 0x80000000000000b17217f7d1cf7a26c8) >> 127;
+        if (x & 0x20000000000000000 > 0) r = (r * 0x8000000000000058b90bfbe8e7bcf4a4) >> 127;
+        if (x & 0x10000000000000000 > 0) r = (r * 0x800000000000002c5c85fdf473de72a2) >> 127;
+        if (x & 0x8000000000000000 > 0) r = (r * 0x80000000000000162e42fefa39ef3765) >> 127;
+        if (x & 0x4000000000000000 > 0) r = (r * 0x800000000000000b17217f7d1cf79b37) >> 127;
+        if (x & 0x2000000000000000 > 0) r = (r * 0x80000000000000058b90bfbe8e7bcd7d) >> 127;
+        if (x & 0x1000000000000000 > 0) r = (r * 0x8000000000000002c5c85fdf473de6b6) >> 127;
+        if (x & 0x800000000000000 > 0) r = (r * 0x800000000000000162e42fefa39ef359) >> 127;
+        if (x & 0x400000000000000 > 0) r = (r * 0x8000000000000000b17217f7d1cf79ac) >> 127;
+        if (x & 0x200000000000000 > 0) r = (r * 0x800000000000000058b90bfbe8e7bcd6) >> 127;
+        if (x & 0x100000000000000 > 0) r = (r * 0x80000000000000002c5c85fdf473de6a) >> 127;
+        if (x & 0x80000000000000 > 0) r = (r * 0x8000000000000000162e42fefa39ef35) >> 127;
+        if (x & 0x40000000000000 > 0) r = (r * 0x80000000000000000b17217f7d1cf79a) >> 127;
+        if (x & 0x20000000000000 > 0) r = (r * 0x8000000000000000058b90bfbe8e7bcd) >> 127;
+        if (x & 0x10000000000000 > 0) r = (r * 0x800000000000000002c5c85fdf473de6) >> 127;
+        if (x & 0x8000000000000 > 0) r = (r * 0x80000000000000000162e42fefa39ef3) >> 127;
+        if (x & 0x4000000000000 > 0) r = (r * 0x800000000000000000b17217f7d1cf79) >> 127;
+        if (x & 0x2000000000000 > 0) r = (r * 0x80000000000000000058b90bfbe8e7bc) >> 127;
+        if (x & 0x1000000000000 > 0) r = (r * 0x8000000000000000002c5c85fdf473de) >> 127;
+        if (x & 0x800000000000 > 0) r = (r * 0x800000000000000000162e42fefa39ef) >> 127;
+        if (x & 0x400000000000 > 0) r = (r * 0x8000000000000000000b17217f7d1cf7) >> 127;
+        if (x & 0x200000000000 > 0) r = (r * 0x800000000000000000058b90bfbe8e7b) >> 127;
+        if (x & 0x100000000000 > 0) r = (r * 0x80000000000000000002c5c85fdf473d) >> 127;
+        if (x & 0x80000000000 > 0) r = (r * 0x8000000000000000000162e42fefa39e) >> 127;
+        if (x & 0x40000000000 > 0) r = (r * 0x80000000000000000000b17217f7d1cf) >> 127;
+        if (x & 0x20000000000 > 0) r = (r * 0x8000000000000000000058b90bfbe8e7) >> 127;
+        if (x & 0x10000000000 > 0) r = (r * 0x800000000000000000002c5c85fdf473) >> 127;
+        if (x & 0x8000000000 > 0) r = (r * 0x80000000000000000000162e42fefa39) >> 127;
+        if (x & 0x4000000000 > 0) r = (r * 0x800000000000000000000b17217f7d1c) >> 127;
+        if (x & 0x2000000000 > 0) r = (r * 0x80000000000000000000058b90bfbe8e) >> 127;
+        if (x & 0x1000000000 > 0) r = (r * 0x8000000000000000000002c5c85fdf47) >> 127;
+        if (x & 0x800000000 > 0) r = (r * 0x800000000000000000000162e42fefa3) >> 127;
+        if (x & 0x400000000 > 0) r = (r * 0x8000000000000000000000b17217f7d1) >> 127;
+        if (x & 0x200000000 > 0) r = (r * 0x800000000000000000000058b90bfbe8) >> 127;
+        if (x & 0x100000000 > 0) r = (r * 0x80000000000000000000002c5c85fdf4) >> 127;
+        if (x & 0x80000000 > 0) r = (r * 0x8000000000000000000000162e42fefa) >> 127;
+        if (x & 0x40000000 > 0) r = (r * 0x80000000000000000000000b17217f7d) >> 127;
+        if (x & 0x20000000 > 0) r = (r * 0x8000000000000000000000058b90bfbe) >> 127;
+        if (x & 0x10000000 > 0) r = (r * 0x800000000000000000000002c5c85fdf) >> 127;
+        if (x & 0x8000000 > 0) r = (r * 0x80000000000000000000000162e42fef) >> 127;
+        if (x & 0x4000000 > 0) r = (r * 0x800000000000000000000000b17217f7) >> 127;
+        if (x & 0x2000000 > 0) r = (r * 0x80000000000000000000000058b90bfb) >> 127;
+        if (x & 0x1000000 > 0) r = (r * 0x8000000000000000000000002c5c85fd) >> 127;
+        if (x & 0x800000 > 0) r = (r * 0x800000000000000000000000162e42fe) >> 127;
+        if (x & 0x400000 > 0) r = (r * 0x8000000000000000000000000b17217f) >> 127;
+        if (x & 0x200000 > 0) r = (r * 0x800000000000000000000000058b90bf) >> 127;
+        if (x & 0x100000 > 0) r = (r * 0x80000000000000000000000002c5c85f) >> 127;
+        if (x & 0x80000 > 0) r = (r * 0x8000000000000000000000000162e42f) >> 127;
+        if (x & 0x40000 > 0) r = (r * 0x80000000000000000000000000b17217) >> 127;
+        if (x & 0x20000 > 0) r = (r * 0x8000000000000000000000000058b90b) >> 127;
+        if (x & 0x10000 > 0) r = (r * 0x800000000000000000000000002c5c85) >> 127;
+        if (x & 0x8000 > 0) r = (r * 0x80000000000000000000000000162e42) >> 127;
+        if (x & 0x4000 > 0) r = (r * 0x800000000000000000000000000b1721) >> 127;
+        if (x & 0x2000 > 0) r = (r * 0x80000000000000000000000000058b90) >> 127;
+        if (x & 0x1000 > 0) r = (r * 0x8000000000000000000000000002c5c8) >> 127;
+        if (x & 0x800 > 0) r = (r * 0x800000000000000000000000000162e4) >> 127;
+        if (x & 0x400 > 0) r = (r * 0x8000000000000000000000000000b172) >> 127;
+        if (x & 0x200 > 0) r = (r * 0x800000000000000000000000000058b9) >> 127;
+        if (x & 0x100 > 0) r = (r * 0x80000000000000000000000000002c5c) >> 127;
+        if (x & 0x80 > 0) r = (r * 0x8000000000000000000000000000162e) >> 127;
+        if (x & 0x40 > 0) r = (r * 0x80000000000000000000000000000b17) >> 127;
+        if (x & 0x20 > 0) r = (r * 0x8000000000000000000000000000058b) >> 127;
+        if (x & 0x10 > 0) r = (r * 0x800000000000000000000000000002c5) >> 127;
+        if (x & 0x8 > 0) r = (r * 0x80000000000000000000000000000162) >> 127;
+        if (x & 0x4 > 0) r = (r * 0x800000000000000000000000000000b1) >> 127;
+        if (x & 0x2 > 0) r = (r * 0x80000000000000000000000000000058) >> 127;
+        if (x & 0x1 > 0) r = (r * 0x8000000000000000000000000000002c) >> 127;
+
+        r >>= 127 - (x >> 121);
+
+        return uint128(r);
+    }
 }

--- a/contracts/mocks/YieldMathMock.sol
+++ b/contracts/mocks/YieldMathMock.sol
@@ -1,112 +1,159 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-import "../mocks/YieldMath48.sol";
-import "../pool/YieldMath.sol"; // 64 bits
-import "../mocks/YieldMath128.sol";
+import '../mocks/YieldMath48.sol';
+import '../pool/YieldMath.sol'; // 64 bits
+import '../mocks/YieldMath128.sol';
 
 /// @dev Gives access to the YieldMath functions for several precisions
 contract YieldMathMock {
-
     // --- 128 ---
 
-    function fyDaiOutForDaiIn128 (
-        uint128 daiReserves, uint128 fyDaiReserves, uint128 daiAmount,
-        uint128 timeTillMaturity, int128 k, int128 g)
-    external pure returns (uint128) {
+    function fyDaiOutForDaiIn128(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) external pure returns (uint128) {
         return YieldMath128.fyDaiOutForDaiIn(daiReserves, fyDaiReserves, daiAmount, timeTillMaturity, k, g);
     }
 
-    function daiOutForFYDaiIn128 (
-        uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiAmount,
-        uint128 timeTillMaturity, int128 k, int128 g)
-    external pure returns (uint128) {
+    function daiOutForFYDaiIn128(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) external pure returns (uint128) {
         return YieldMath128.daiOutForFYDaiIn(daiReserves, fyDaiReserves, fyDaiAmount, timeTillMaturity, k, g);
     }
 
-    function fyDaiInForDaiOut128 (
-        uint128 daiReserves, uint128 fyDaiReserves, uint128 daiAmount,
-        uint128 timeTillMaturity, int128 k, int128 g)
-    external pure returns (uint128) {
+    function fyDaiInForDaiOut128(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) external pure returns (uint128) {
         return YieldMath128.fyDaiInForDaiOut(daiReserves, fyDaiReserves, daiAmount, timeTillMaturity, k, g);
     }
 
-    function daiInForFYDaiOut128 (
-        uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiAmount,
-        uint128 timeTillMaturity, int128 k, int128 g)
-    external pure returns (uint128) {
+    function daiInForFYDaiOut128(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) external pure returns (uint128) {
         return YieldMath128.daiInForFYDaiOut(daiReserves, fyDaiReserves, fyDaiAmount, timeTillMaturity, k, g);
     }
 
-    function log_2_128 (uint128 x) external pure returns (uint128) {
+    function log_2_128(uint128 x) external pure returns (uint128) {
         return YieldMath128.log_2(x);
     }
 
     // --- 64 ---
 
-    function fyDaiOutForDaiIn64 (
-        uint128 daiReserves, uint128 fyDaiReserves, uint128 daiAmount,
-        uint128 timeTillMaturity, int128 k, int128 g)
-    external pure returns (uint128) {
+    function fyDaiOutForDaiIn64(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) external pure returns (uint128) {
         return YieldMath.fyDaiOutForDaiIn(daiReserves, fyDaiReserves, daiAmount, timeTillMaturity, k, g);
     }
 
-    function daiOutForFYDaiIn64 (
-        uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiAmount,
-        uint128 timeTillMaturity, int128 k, int128 g)
-    external pure returns (uint128) {
+    function daiOutForFYDaiIn64(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) external pure returns (uint128) {
         return YieldMath.daiOutForFYDaiIn(daiReserves, fyDaiReserves, fyDaiAmount, timeTillMaturity, k, g);
     }
 
-    function fyDaiInForDaiOut64 (
-        uint128 daiReserves, uint128 fyDaiReserves, uint128 daiAmount,
-        uint128 timeTillMaturity, int128 k, int128 g)
-    external pure returns (uint128) {
+    function fyDaiInForDaiOut64(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) external pure returns (uint128) {
         return YieldMath.fyDaiInForDaiOut(daiReserves, fyDaiReserves, daiAmount, timeTillMaturity, k, g);
     }
 
-    function daiInForFYDaiOut64 (
-        uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiAmount,
-        uint128 timeTillMaturity, int128 k, int128 g)
-    external pure returns (uint128) {
+    function daiInForFYDaiOut64(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) external pure returns (uint128) {
         return YieldMath.daiInForFYDaiOut(daiReserves, fyDaiReserves, fyDaiAmount, timeTillMaturity, k, g);
     }
 
-    function log_2_64 (uint128 x) external pure returns (uint128) {
+    function log_2_64(uint128 x) external pure returns (uint128) {
         return YieldMath.log_2(x);
     }
 
     // --- 48 ---
 
-    function fyDaiOutForDaiIn48 (
-        uint128 daiReserves, uint128 fyDaiReserves, uint128 daiAmount,
-        uint128 timeTillMaturity, int128 k, int128 g)
-    external pure returns (uint128) {
+    function fyDaiOutForDaiIn48(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) external pure returns (uint128) {
         return YieldMath48.fyDaiOutForDaiIn(daiReserves, fyDaiReserves, daiAmount, timeTillMaturity, k, g);
     }
 
-    function daiOutForFYDaiIn48 (
-        uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiAmount,
-        uint128 timeTillMaturity, int128 k, int128 g)
-    external pure returns (uint128) {
+    function daiOutForFYDaiIn48(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) external pure returns (uint128) {
         return YieldMath48.daiOutForFYDaiIn(daiReserves, fyDaiReserves, fyDaiAmount, timeTillMaturity, k, g);
     }
 
-    function fyDaiInForDaiOut48 (
-        uint128 daiReserves, uint128 fyDaiReserves, uint128 daiAmount,
-        uint128 timeTillMaturity, int128 k, int128 g)
-    external pure returns (uint128) {
+    function fyDaiInForDaiOut48(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) external pure returns (uint128) {
         return YieldMath48.fyDaiInForDaiOut(daiReserves, fyDaiReserves, daiAmount, timeTillMaturity, k, g);
     }
 
-    function daiInForFYDaiOut48 (
-        uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiAmount,
-        uint128 timeTillMaturity, int128 k, int128 g)
-    external pure returns (uint128) {
+    function daiInForFYDaiOut48(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) external pure returns (uint128) {
         return YieldMath48.daiInForFYDaiOut(daiReserves, fyDaiReserves, fyDaiAmount, timeTillMaturity, k, g);
     }
 
-    function log_2 (uint128 x) external pure returns (uint128) {
+    function log_2(uint128 x) external pure returns (uint128) {
         return YieldMath48.log_2(x);
     }
 }

--- a/contracts/peripheral/PoolProxy.sol
+++ b/contracts/peripheral/PoolProxy.sol
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-import "../interfaces/IDai.sol";
-import "../interfaces/IPool.sol";
-import "../interfaces/IFYDai.sol";
-import "../interfaces/IChai.sol";
-import "../interfaces/ITreasury.sol";
-import "../interfaces/IController.sol";
-import "../helpers/DecimalMath.sol";
-import "../helpers/SafeCast.sol";
-import "../helpers/YieldAuth.sol";
-
+import '../interfaces/IDai.sol';
+import '../interfaces/IPool.sol';
+import '../interfaces/IFYDai.sol';
+import '../interfaces/IChai.sol';
+import '../interfaces/ITreasury.sol';
+import '../interfaces/IController.sol';
+import '../helpers/DecimalMath.sol';
+import '../helpers/SafeCast.sol';
+import '../helpers/YieldAuth.sol';
 
 contract PoolProxy is DecimalMath {
     using SafeCast for uint256;
@@ -24,9 +23,14 @@ contract PoolProxy is DecimalMath {
     IController public immutable controller;
     address immutable treasury;
 
-    bytes32 public constant CHAI = "CHAI";
+    bytes32 public constant CHAI = 'CHAI';
 
-    constructor(address dai_, address chai_, address treasury_, address controller_) public {
+    constructor(
+        address dai_,
+        address chai_,
+        address treasury_,
+        address controller_
+    ) public {
         controller = IController(controller_);
         treasury = treasury_;
         dai = IDai(dai_);
@@ -36,35 +40,39 @@ contract PoolProxy is DecimalMath {
     /// @dev Mints liquidity with provided Dai by borrowing fyDai with some of the Dai.
     /// Caller must have approved the proxy using`controller.addDelegate(yieldProxy)`
     /// Caller must have approved the dai transfer with `dai.approve(daiUsed)`
-    /// @param daiUsed amount of Dai to use to mint liquidity. 
-    /// @param maxFYDai maximum amount of fyDai to be borrowed to mint liquidity. 
-    /// @return The amount of liquidity tokens minted.  
-    function addLiquidity(IPool pool, uint256 daiUsed, uint256 maxFYDai) public returns (uint256) {
+    /// @param daiUsed amount of Dai to use to mint liquidity.
+    /// @param maxFYDai maximum amount of fyDai to be borrowed to mint liquidity.
+    /// @return The amount of liquidity tokens minted.
+    function addLiquidity(
+        IPool pool,
+        uint256 daiUsed,
+        uint256 maxFYDai
+    ) public returns (uint256) {
         IFYDai fyDai = pool.fyDai();
-        require(fyDai.isMature() != true, "YieldProxy: Only before maturity");
-        require(dai.transferFrom(msg.sender, address(this), daiUsed), "YieldProxy: Transfer Failed");
+        require(fyDai.isMature() != true, 'YieldProxy: Only before maturity');
+        require(dai.transferFrom(msg.sender, address(this), daiUsed), 'YieldProxy: Transfer Failed');
 
         // Allow the Treasury to take chai when posting
         if (chai.allowance(address(this), treasury) < type(uint256).max) chai.approve(treasury, type(uint256).max);
 
         // Allow Chai to take dai for wrapping
-        if (dai.allowance(address(this), address(chai)) < type(uint256).max) dai.approve(address(chai), type(uint256).max);
+        if (dai.allowance(address(this), address(chai)) < type(uint256).max)
+            dai.approve(address(chai), type(uint256).max);
 
         // Allow pool to take dai for minting
-        if (dai.allowance(address(this), address(pool)) < type(uint256).max) dai.approve(address(pool), type(uint256).max);
+        if (dai.allowance(address(this), address(pool)) < type(uint256).max)
+            dai.approve(address(pool), type(uint256).max);
 
         // Allow pool to take fyDai for minting
-        if (fyDai.allowance(address(this), address(pool)) < type(uint112).max) fyDai.approve(address(pool), type(uint256).max);
+        if (fyDai.allowance(address(this), address(pool)) < type(uint112).max)
+            fyDai.approve(address(pool), type(uint256).max);
 
         // calculate needed fyDai
         uint256 daiReserves = dai.balanceOf(address(pool));
         uint256 fyDaiReserves = fyDai.balanceOf(address(pool));
         uint256 daiToAdd = daiUsed.mul(daiReserves).div(fyDaiReserves.add(daiReserves));
         uint256 daiToConvert = daiUsed.sub(daiToAdd);
-        require(
-            daiToConvert <= maxFYDai,
-            "YieldProxy: maxFYDai exceeded"
-        ); // 1 Dai == 1 fyDai
+        require(daiToConvert <= maxFYDai, 'YieldProxy: maxFYDai exceeded'); // 1 Dai == 1 fyDai
 
         // convert dai to chai and borrow needed fyDai
         chai.join(address(this), daiToConvert);
@@ -72,47 +80,52 @@ contract PoolProxy is DecimalMath {
         uint256 toBorrow = chai.dai(address(this));
         controller.post(CHAI, address(this), msg.sender, chai.balanceOf(address(this)));
         controller.borrow(CHAI, fyDai.maturity(), msg.sender, address(this), toBorrow);
-        
+
         // mint liquidity tokens
         return pool.mint(address(this), msg.sender, daiToAdd);
     }
 
     /// @dev Burns tokens and sells Dai proceedings for fyDai. Pays as much debt as possible, then sells back any remaining fyDai for Dai. Then returns all Dai, and if there is no debt in the Controller, all posted Chai.
     /// Caller must have approved the proxy using`controller.addDelegate(yieldProxy)` and `pool.addDelegate(yieldProxy)`
-    /// @param poolTokens amount of pool tokens to burn. 
+    /// @param poolTokens amount of pool tokens to burn.
     /// @param minimumDaiPrice minimum fyDai/Dai price to be accepted when internally selling Dai.
     /// @param minimumFYDaiPrice minimum Dai/fyDai price to be accepted when internally selling fyDai.
-    function removeLiquidityEarlyDaiPool(IPool pool, uint256 poolTokens, uint256 minimumDaiPrice, uint256 minimumFYDaiPrice) public {
-
+    function removeLiquidityEarlyDaiPool(
+        IPool pool,
+        uint256 poolTokens,
+        uint256 minimumDaiPrice,
+        uint256 minimumFYDaiPrice
+    ) public {
         IFYDai fyDai = pool.fyDai();
         uint256 maturity = fyDai.maturity();
 
         // Allow pool to take dai for trading
-        if (dai.allowance(address(this), address(pool)) < type(uint256).max) dai.approve(address(pool), type(uint256).max);
+        if (dai.allowance(address(this), address(pool)) < type(uint256).max)
+            dai.approve(address(pool), type(uint256).max);
 
         // Allow pool to take fyDai for trading
-        if (fyDai.allowance(address(this), address(pool)) < type(uint112).max) fyDai.approve(address(pool), type(uint256).max);
+        if (fyDai.allowance(address(this), address(pool)) < type(uint112).max)
+            fyDai.approve(address(pool), type(uint256).max);
 
         (uint256 daiObtained, uint256 fyDaiObtained) = pool.burn(msg.sender, address(this), poolTokens);
 
         // Exchange Dai for fyDai to pay as much debt as possible
         uint256 fyDaiBought = pool.sellDai(address(this), address(this), daiObtained.toUint128());
-        require(
-            fyDaiBought >= muld(daiObtained, minimumDaiPrice),
-            "YieldProxy: minimumDaiPrice not reached"
-        );
+        require(fyDaiBought >= muld(daiObtained, minimumDaiPrice), 'YieldProxy: minimumDaiPrice not reached');
         fyDaiObtained = fyDaiObtained.add(fyDaiBought);
-        
+
         uint256 fyDaiUsed;
         if (fyDaiObtained > 0 && controller.debtFYDai(CHAI, maturity, msg.sender) > 0) {
             fyDaiUsed = controller.repayFYDai(CHAI, maturity, address(this), msg.sender, fyDaiObtained);
         }
         uint256 fyDaiRemaining = fyDaiObtained.sub(fyDaiUsed);
 
-        if (fyDaiRemaining > 0) {// There is fyDai left, so exchange it for Dai to withdraw only Dai and Chai
+        if (fyDaiRemaining > 0) {
+            // There is fyDai left, so exchange it for Dai to withdraw only Dai and Chai
             require(
-                pool.sellFYDai(address(this), address(this), uint128(fyDaiRemaining)) >= muld(fyDaiRemaining, minimumFYDaiPrice),
-                "YieldProxy: minimumFYDaiPrice not reached"
+                pool.sellFYDai(address(this), address(this), uint128(fyDaiRemaining)) >=
+                    muld(fyDaiRemaining, minimumFYDaiPrice),
+                'YieldProxy: minimumFYDaiPrice not reached'
             );
         }
         withdrawAssets();
@@ -121,10 +134,13 @@ contract PoolProxy is DecimalMath {
     /// @dev Burns tokens and repays debt with proceedings. Sells any excess fyDai for Dai, then returns all Dai, and if there is no debt in the Controller, all posted Chai.
     /// Caller must have approved the proxy using`controller.addDelegate(yieldProxy)` and `pool.addDelegate(yieldProxy)`
     /// Caller must have approved the liquidity burn with `pool.approve(poolTokens)`
-    /// @param poolTokens amount of pool tokens to burn. 
+    /// @param poolTokens amount of pool tokens to burn.
     /// @param minimumFYDaiPrice minimum Dai/fyDai price to be accepted when internally selling fyDai.
-    function removeLiquidityEarlyDaiFixed(IPool pool, uint256 poolTokens, uint256 minimumFYDaiPrice) public {
-
+    function removeLiquidityEarlyDaiFixed(
+        IPool pool,
+        uint256 poolTokens,
+        uint256 minimumFYDaiPrice
+    ) public {
         IFYDai fyDai = pool.fyDai();
         uint256 maturity = fyDai.maturity();
 
@@ -132,7 +148,8 @@ contract PoolProxy is DecimalMath {
         if (dai.allowance(address(this), treasury) < type(uint256).max) dai.approve(treasury, type(uint256).max);
 
         // Allow pool to take fyDai for trading
-        if (fyDai.allowance(address(this), address(pool)) < type(uint112).max) fyDai.approve(address(pool), type(uint256).max);
+        if (fyDai.allowance(address(this), address(pool)) < type(uint112).max)
+            fyDai.approve(address(pool), type(uint256).max);
 
         (uint256 daiObtained, uint256 fyDaiObtained) = pool.burn(msg.sender, address(this), poolTokens);
         uint256 fyDaiUsed;
@@ -141,24 +158,26 @@ contract PoolProxy is DecimalMath {
         }
 
         uint256 fyDaiRemaining = fyDaiObtained.sub(fyDaiUsed);
-        if (fyDaiRemaining == 0) { // We used all the fyDai, so probably there is debt left, so pay with Dai
+        if (fyDaiRemaining == 0) {
+            // We used all the fyDai, so probably there is debt left, so pay with Dai
             if (daiObtained > 0 && controller.debtFYDai(CHAI, maturity, msg.sender) > 0) {
                 controller.repayDai(CHAI, maturity, address(this), msg.sender, daiObtained);
             }
-        } else { // Exchange remaining fyDai for Dai to withdraw only Dai and Chai
+        } else {
+            // Exchange remaining fyDai for Dai to withdraw only Dai and Chai
             require(
-                pool.sellFYDai(address(this), address(this), uint128(fyDaiRemaining)) >= muld(fyDaiRemaining, minimumFYDaiPrice),
-                "YieldProxy: minimumFYDaiPrice not reached"
+                pool.sellFYDai(address(this), address(this), uint128(fyDaiRemaining)) >=
+                    muld(fyDaiRemaining, minimumFYDaiPrice),
+                'YieldProxy: minimumFYDaiPrice not reached'
             );
         }
         withdrawAssets();
     }
 
-    /// @dev Burns tokens and repays fyDai debt after Maturity. 
+    /// @dev Burns tokens and repays fyDai debt after Maturity.
     /// Caller must have approved the proxy using`controller.addDelegate(yieldProxy)`
     /// @param poolTokens amount of pool tokens to burn.
     function removeLiquidityMature(IPool pool, uint256 poolTokens) public {
-
         IFYDai fyDai = pool.fyDai();
         uint256 maturity = fyDai.maturity();
 
@@ -169,7 +188,7 @@ contract PoolProxy is DecimalMath {
         if (fyDaiObtained > 0) {
             daiObtained = daiObtained.add(fyDai.redeem(address(this), address(this), fyDaiObtained));
         }
-        
+
         // Repay debt
         if (daiObtained > 0 && controller.debtFYDai(CHAI, maturity, msg.sender) > 0) {
             controller.repayDai(CHAI, maturity, address(this), msg.sender, daiObtained);
@@ -181,10 +200,10 @@ contract PoolProxy is DecimalMath {
     function withdrawAssets() internal {
         uint256 posted = controller.posted(CHAI, msg.sender);
         uint256 locked = controller.locked(CHAI, msg.sender);
-        require (posted >= locked, "YieldProxy: Undercollateralized");
+        require(posted >= locked, 'YieldProxy: Undercollateralized');
         controller.withdraw(CHAI, msg.sender, address(this), posted - locked);
         chai.exit(address(this), chai.balanceOf(address(this)));
-        require(dai.transfer(msg.sender, dai.balanceOf(address(this))), "YieldProxy: Dai Transfer Failed");
+        require(dai.transfer(msg.sender, dai.balanceOf(address(this))), 'YieldProxy: Dai Transfer Failed');
     }
 
     /// --------------------------------------------------
@@ -194,11 +213,11 @@ contract PoolProxy is DecimalMath {
     /// @dev Mints liquidity with provided Dai by borrowing fyDai with some of the Dai.
     /// Caller must have approved the proxy using`controller.addDelegate(yieldProxy)`
     /// Caller must have approved the dai transfer with `dai.approve(daiUsed)`
-    /// @param daiUsed amount of Dai to use to mint liquidity. 
+    /// @param daiUsed amount of Dai to use to mint liquidity.
     /// @param maxFYDai maximum amount of fyDai to be borrowed to mint liquidity.
     /// @param daiSig packed signature for permit of dai transfers to this proxy. Ignored if '0x'.
     /// @param controllerSig packed signature for delegation of this proxy in the controller. Ignored if '0x'.
-    /// @return The amount of liquidity tokens minted.  
+    /// @return The amount of liquidity tokens minted.
     function addLiquidityWithSignature(
         IPool pool,
         uint256 daiUsed,
@@ -212,7 +231,7 @@ contract PoolProxy is DecimalMath {
     }
 
     /// @dev Burns tokens and sells Dai proceedings for fyDai. Pays as much debt as possible, then sells back any remaining fyDai for Dai. Then returns all Dai, and all unlocked Chai.
-    /// @param poolTokens amount of pool tokens to burn. 
+    /// @param poolTokens amount of pool tokens to burn.
     /// @param minimumDaiPrice minimum fyDai/Dai price to be accepted when internally selling Dai.
     /// @param minimumFYDaiPrice minimum Dai/fyDai price to be accepted when internally selling fyDai.
     /// @param controllerSig packed signature for delegation of this proxy in the controller. Ignored if '0x'.
@@ -231,7 +250,7 @@ contract PoolProxy is DecimalMath {
     }
 
     /// @dev Burns tokens and repays debt with proceedings. Sells any excess fyDai for Dai, then returns all Dai, and all unlocked Chai.
-    /// @param poolTokens amount of pool tokens to burn. 
+    /// @param poolTokens amount of pool tokens to burn.
     /// @param minimumFYDaiPrice minimum Dai/fyDai price to be accepted when internally selling fyDai.
     /// @param controllerSig packed signature for delegation of this proxy in the controller. Ignored if '0x'.
     /// @param poolSig packed signature for delegation of this proxy in a pool. Ignored if '0x'.

--- a/contracts/pool/Math64x64.sol
+++ b/contracts/pool/Math64x64.sol
@@ -14,686 +14,669 @@ pragma solidity ^0.6.0;
  * represented by int128 type holding only the numerator.
  */
 library Math64x64 {
-  /**
-   * @dev Minimum value signed 64.64-bit fixed point number may have. 
-   */
-  int128 private constant MIN_64x64 = -0x80000000000000000000000000000000;
+    /**
+     * @dev Minimum value signed 64.64-bit fixed point number may have.
+     */
+    int128 private constant MIN_64x64 = -0x80000000000000000000000000000000;
 
-  /**
-   * @dev Maximum value signed 64.64-bit fixed point number may have. 
-   */
-  int128 private constant MAX_64x64 = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+    /**
+     * @dev Maximum value signed 64.64-bit fixed point number may have.
+     */
+    int128 private constant MAX_64x64 = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
 
-  /**
-   * @dev Convert signed 256-bit integer number into signed 64.64-bit fixed point
-   * number.  Revert on overflow.
-   *
-   * @param x signed 256-bit integer number
-   * @return signed 64.64-bit fixed point number
-   */
-  function fromInt (int256 x) internal pure returns (int128) {
-    require (x >= -0x8000000000000000 && x <= 0x7FFFFFFFFFFFFFFF);
-    return int128 (x << 64);
-  }
-
-  /**
-   * @dev Convert signed 64.64 fixed point number into signed 64-bit integer number
-   * rounding down.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @return signed 64-bit integer number
-   */
-  function toInt (int128 x) internal pure returns (int64) {
-    return int64 (x >> 64);
-  }
-
-  /**
-   * @dev Convert unsigned 256-bit integer number into signed 64.64-bit fixed point
-   * number.  Revert on overflow.
-   *
-   * @param x unsigned 256-bit integer number
-   * @return signed 64.64-bit fixed point number
-   */
-  function fromUInt (uint256 x) internal pure returns (int128) {
-    require (x <= 0x7FFFFFFFFFFFFFFF);
-    return int128 (x << 64);
-  }
-
-  /**
-   * @dev Convert signed 64.64 fixed point number into unsigned 64-bit integer
-   * number rounding down.  Revert on underflow.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @return unsigned 64-bit integer number
-   */
-  function toUInt (int128 x) internal pure returns (uint64) {
-    require (x >= 0);
-    return uint64 (x >> 64);
-  }
-
-  /**
-   * @dev Convert signed 128.128 fixed point number into signed 64.64-bit fixed point
-   * number rounding down.  Revert on overflow.
-   *
-   * @param x signed 128.128-bin fixed point number
-   * @return signed 64.64-bit fixed point number
-   */
-  function from128x128 (int256 x) internal pure returns (int128) {
-    int256 result = x >> 64;
-    require (result >= MIN_64x64 && result <= MAX_64x64);
-    return int128 (result);
-  }
-
-  /**
-   * @dev Convert signed 64.64 fixed point number into signed 128.128 fixed point
-   * number.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @return signed 128.128 fixed point number
-   */
-  function to128x128 (int128 x) internal pure returns (int256) {
-    return int256 (x) << 64;
-  }
-
-  /**
-   * @dev Calculate x + y.  Revert on overflow.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @param y signed 64.64-bit fixed point number
-   * @return signed 64.64-bit fixed point number
-   */
-  function add (int128 x, int128 y) internal pure returns (int128) {
-    int256 result = int256(x) + y;
-    require (result >= MIN_64x64 && result <= MAX_64x64);
-    return int128 (result);
-  }
-
-  /**
-   * @dev Calculate x - y.  Revert on overflow.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @param y signed 64.64-bit fixed point number
-   * @return signed 64.64-bit fixed point number
-   */
-  function sub (int128 x, int128 y) internal pure returns (int128) {
-    int256 result = int256(x) - y;
-    require (result >= MIN_64x64 && result <= MAX_64x64);
-    return int128 (result);
-  }
-
-  /**
-   * @dev Calculate x * y rounding down.  Revert on overflow.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @param y signed 64.64-bit fixed point number
-   * @return signed 64.64-bit fixed point number
-   */
-  function mul (int128 x, int128 y) internal pure returns (int128) {
-    int256 result = int256(x) * y >> 64;
-    require (result >= MIN_64x64 && result <= MAX_64x64);
-    return int128 (result);
-  }
-
-  /**
-   * @dev Calculate x * y rounding towards zero, where x is signed 64.64 fixed point
-   * number and y is signed 256-bit integer number.  Revert on overflow.
-   *
-   * @param x signed 64.64 fixed point number
-   * @param y signed 256-bit integer number
-   * @return signed 256-bit integer number
-   */
-  function muli (int128 x, int256 y) internal pure returns (int256) {
-    if (x == MIN_64x64) {
-      require (y >= -0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF &&
-        y <= 0x1000000000000000000000000000000000000000000000000);
-      return -y << 63;
-    } else {
-      bool negativeResult = false;
-      if (x < 0) {
-        x = -x;
-        negativeResult = true;
-      }
-      if (y < 0) {
-        y = -y; // We rely on overflow behavior here
-        negativeResult = !negativeResult;
-      }
-      uint256 absoluteResult = mulu (x, uint256 (y));
-      if (negativeResult) {
-        require (absoluteResult <=
-          0x8000000000000000000000000000000000000000000000000000000000000000);
-        return -int256 (absoluteResult); // We rely on overflow behavior here
-      } else {
-        require (absoluteResult <=
-          0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
-        return int256 (absoluteResult);
-      }
-    }
-  }
-
-  /**
-   * @dev Calculate x * y rounding down, where x is signed 64.64 fixed point number
-   * and y is unsigned 256-bit integer number.  Revert on overflow.
-   *
-   * @param x signed 64.64 fixed point number
-   * @param y unsigned 256-bit integer number
-   * @return unsigned 256-bit integer number
-   */
-  function mulu (int128 x, uint256 y) internal pure returns (uint256) {
-    if (y == 0) return 0;
-
-    require (x >= 0);
-
-    uint256 lo = (uint256 (x) * (y & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)) >> 64;
-    uint256 hi = uint256 (x) * (y >> 128);
-
-    require (hi <= 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
-    hi <<= 64;
-
-    require (hi <=
-      0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF - lo);
-    return hi + lo;
-  }
-
-  /**
-   * @dev Calculate x / y rounding towards zero.  Revert on overflow or when y is
-   * zero.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @param y signed 64.64-bit fixed point number
-   * @return signed 64.64-bit fixed point number
-   */
-  function div (int128 x, int128 y) internal pure returns (int128) {
-    require (y != 0);
-    int256 result = (int256 (x) << 64) / y;
-    require (result >= MIN_64x64 && result <= MAX_64x64);
-    return int128 (result);
-  }
-
-  /**
-   * @dev Calculate x / y rounding towards zero, where x and y are signed 256-bit
-   * integer numbers.  Revert on overflow or when y is zero.
-   *
-   * @param x signed 256-bit integer number
-   * @param y signed 256-bit integer number
-   * @return signed 64.64-bit fixed point number
-   */
-  function divi (int256 x, int256 y) internal pure returns (int128) {
-    require (y != 0);
-
-    bool negativeResult = false;
-    if (x < 0) {
-      x = -x; // We rely on overflow behavior here
-      negativeResult = true;
-    }
-    if (y < 0) {
-      y = -y; // We rely on overflow behavior here
-      negativeResult = !negativeResult;
-    }
-    uint128 absoluteResult = divuu (uint256 (x), uint256 (y));
-    if (negativeResult) {
-      require (absoluteResult <= 0x80000000000000000000000000000000);
-      return -int128 (absoluteResult); // We rely on overflow behavior here
-    } else {
-      require (absoluteResult <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
-      return int128 (absoluteResult); // We rely on overflow behavior here
-    }
-  }
-
-  /**
-   * @dev Calculate x / y rounding towards zero, where x and y are unsigned 256-bit
-   * integer numbers.  Revert on overflow or when y is zero.
-   *
-   * @param x unsigned 256-bit integer number
-   * @param y unsigned 256-bit integer number
-   * @return signed 64.64-bit fixed point number
-   */
-  function divu (uint256 x, uint256 y) internal pure returns (int128) {
-    require (y != 0);
-    uint128 result = divuu (x, y);
-    require (result <= uint128 (MAX_64x64));
-    return int128 (result);
-  }
-
-  /**
-   * @dev Calculate -x.  Revert on overflow.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @return signed 64.64-bit fixed point number
-   */
-  function neg (int128 x) internal pure returns (int128) {
-    require (x != MIN_64x64);
-    return -x;
-  }
-
-  /**
-   * @dev Calculate |x|.  Revert on overflow.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @return signed 64.64-bit fixed point number
-   */
-  function abs (int128 x) internal pure returns (int128) {
-    require (x != MIN_64x64);
-    return x < 0 ? -x : x;
-  }
-
-  /**
-   * @dev Calculate 1 / x rounding towards zero.  Revert on overflow or when x is
-   * zero.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @return signed 64.64-bit fixed point number
-   */
-  function inv (int128 x) internal pure returns (int128) {
-    require (x != 0);
-    int256 result = int256 (0x100000000000000000000000000000000) / x;
-    require (result >= MIN_64x64 && result <= MAX_64x64);
-    return int128 (result);
-  }
-
-  /**
-   * @dev Calculate arithmetics average of x and y, i.e. (x + y) / 2 rounding down.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @param y signed 64.64-bit fixed point number
-   * @return signed 64.64-bit fixed point number
-   */
-  function avg (int128 x, int128 y) internal pure returns (int128) {
-    return int128 ((int256 (x) + int256 (y)) >> 1);
-  }
-
-  /**
-   * @dev Calculate geometric average of x and y, i.e. sqrt (x * y) rounding down.
-   * Revert on overflow or in case x * y is negative.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @param y signed 64.64-bit fixed point number
-   * @return signed 64.64-bit fixed point number
-   */
-  function gavg (int128 x, int128 y) internal pure returns (int128) {
-    int256 m = int256 (x) * int256 (y);
-    require (m >= 0);
-    require (m <
-        0x4000000000000000000000000000000000000000000000000000000000000000);
-    return int128 (sqrtu (uint256 (m), uint256 (x) + uint256 (y) >> 1));
-  }
-
-  /**
-   * @dev Calculate x^y assuming 0^0 is 1, where x is signed 64.64 fixed point number
-   * and y is unsigned 256-bit integer number.  Revert on overflow.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @param y uint256 value
-   * @return signed 64.64-bit fixed point number
-   */
-  function pow (int128 x, uint256 y) internal pure returns (int128) {
-    uint256 absoluteResult;
-    bool negativeResult = false;
-    if (x >= 0) {
-      absoluteResult = powu (uint256 (x) << 63, y);
-    } else {
-      // We rely on overflow behavior here
-      absoluteResult = powu (uint256 (uint128 (-x)) << 63, y);
-      negativeResult = y & 1 > 0;
+    /**
+     * @dev Convert signed 256-bit integer number into signed 64.64-bit fixed point
+     * number.  Revert on overflow.
+     *
+     * @param x signed 256-bit integer number
+     * @return signed 64.64-bit fixed point number
+     */
+    function fromInt(int256 x) internal pure returns (int128) {
+        require(x >= -0x8000000000000000 && x <= 0x7FFFFFFFFFFFFFFF);
+        return int128(x << 64);
     }
 
-    absoluteResult >>= 63;
-
-    if (negativeResult) {
-      require (absoluteResult <= 0x80000000000000000000000000000000);
-      return -int128 (absoluteResult); // We rely on overflow behavior here
-    } else {
-      require (absoluteResult <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
-      return int128 (absoluteResult); // We rely on overflow behavior here
-    }
-  }
-
-  /**
-   * @dev Calculate sqrt (x) rounding down.  Revert if x < 0.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @return signed 64.64-bit fixed point number
-   */
-  function sqrt (int128 x) internal pure returns (int128) {
-    require (x >= 0);
-    return int128 (sqrtu (uint256 (x) << 64, 0x10000000000000000));
-  }
-
-  /**
-   * @dev Calculate binary logarithm of x.  Revert if x <= 0.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @return signed 64.64-bit fixed point number
-   */
-  function log_2 (int128 x) internal pure returns (int128) {
-    require (x > 0);
-
-    int256 msb = 0;
-    int256 xc = x;
-    if (xc >= 0x10000000000000000) { xc >>= 64; msb += 64; }
-    if (xc >= 0x100000000) { xc >>= 32; msb += 32; }
-    if (xc >= 0x10000) { xc >>= 16; msb += 16; }
-    if (xc >= 0x100) { xc >>= 8; msb += 8; }
-    if (xc >= 0x10) { xc >>= 4; msb += 4; }
-    if (xc >= 0x4) { xc >>= 2; msb += 2; }
-    if (xc >= 0x2) msb += 1;  // No need to shift xc anymore
-
-    int256 result = msb - 64 << 64;
-    uint256 ux = uint256 (x) << 127 - msb;
-    for (int256 bit = 0x8000000000000000; bit > 0; bit >>= 1) {
-      ux *= ux;
-      uint256 b = ux >> 255;
-      ux >>= 127 + b;
-      result += bit * int256 (b);
+    /**
+     * @dev Convert signed 64.64 fixed point number into signed 64-bit integer number
+     * rounding down.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @return signed 64-bit integer number
+     */
+    function toInt(int128 x) internal pure returns (int64) {
+        return int64(x >> 64);
     }
 
-    return int128 (result);
-  }
-
-  /**
-   * @dev Calculate natural logarithm of x.  Revert if x <= 0.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @return signed 64.64-bit fixed point number
-   */
-  function ln (int128 x) internal pure returns (int128) {
-    require (x > 0);
-
-    return int128 (
-        uint256 (log_2 (x)) * 0xB17217F7D1CF79ABC9E3B39803F2F6AF >> 128);
-  }
-
-  /**
-   * @dev Calculate binary exponent of x.  Revert on overflow.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @return signed 64.64-bit fixed point number
-   */
-  function exp_2 (int128 x) internal pure returns (int128) {
-    require (x < 0x400000000000000000); // Overflow
-
-    if (x < -0x400000000000000000) return 0; // Underflow
-
-    uint256 result = 0x80000000000000000000000000000000;
-
-    if (x & 0x8000000000000000 > 0)
-      result = result * 0x16A09E667F3BCC908B2FB1366EA957D3E >> 128;
-    if (x & 0x4000000000000000 > 0)
-      result = result * 0x1306FE0A31B7152DE8D5A46305C85EDEC >> 128;
-    if (x & 0x2000000000000000 > 0)
-      result = result * 0x1172B83C7D517ADCDF7C8C50EB14A791F >> 128;
-    if (x & 0x1000000000000000 > 0)
-      result = result * 0x10B5586CF9890F6298B92B71842A98363 >> 128;
-    if (x & 0x800000000000000 > 0)
-      result = result * 0x1059B0D31585743AE7C548EB68CA417FD >> 128;
-    if (x & 0x400000000000000 > 0)
-      result = result * 0x102C9A3E778060EE6F7CACA4F7A29BDE8 >> 128;
-    if (x & 0x200000000000000 > 0)
-      result = result * 0x10163DA9FB33356D84A66AE336DCDFA3F >> 128;
-    if (x & 0x100000000000000 > 0)
-      result = result * 0x100B1AFA5ABCBED6129AB13EC11DC9543 >> 128;
-    if (x & 0x80000000000000 > 0)
-      result = result * 0x10058C86DA1C09EA1FF19D294CF2F679B >> 128;
-    if (x & 0x40000000000000 > 0)
-      result = result * 0x1002C605E2E8CEC506D21BFC89A23A00F >> 128;
-    if (x & 0x20000000000000 > 0)
-      result = result * 0x100162F3904051FA128BCA9C55C31E5DF >> 128;
-    if (x & 0x10000000000000 > 0)
-      result = result * 0x1000B175EFFDC76BA38E31671CA939725 >> 128;
-    if (x & 0x8000000000000 > 0)
-      result = result * 0x100058BA01FB9F96D6CACD4B180917C3D >> 128;
-    if (x & 0x4000000000000 > 0)
-      result = result * 0x10002C5CC37DA9491D0985C348C68E7B3 >> 128;
-    if (x & 0x2000000000000 > 0)
-      result = result * 0x1000162E525EE054754457D5995292026 >> 128;
-    if (x & 0x1000000000000 > 0)
-      result = result * 0x10000B17255775C040618BF4A4ADE83FC >> 128;
-    if (x & 0x800000000000 > 0)
-      result = result * 0x1000058B91B5BC9AE2EED81E9B7D4CFAB >> 128;
-    if (x & 0x400000000000 > 0)
-      result = result * 0x100002C5C89D5EC6CA4D7C8ACC017B7C9 >> 128;
-    if (x & 0x200000000000 > 0)
-      result = result * 0x10000162E43F4F831060E02D839A9D16D >> 128;
-    if (x & 0x100000000000 > 0)
-      result = result * 0x100000B1721BCFC99D9F890EA06911763 >> 128;
-    if (x & 0x80000000000 > 0)
-      result = result * 0x10000058B90CF1E6D97F9CA14DBCC1628 >> 128;
-    if (x & 0x40000000000 > 0)
-      result = result * 0x1000002C5C863B73F016468F6BAC5CA2B >> 128;
-    if (x & 0x20000000000 > 0)
-      result = result * 0x100000162E430E5A18F6119E3C02282A5 >> 128;
-    if (x & 0x10000000000 > 0)
-      result = result * 0x1000000B1721835514B86E6D96EFD1BFE >> 128;
-    if (x & 0x8000000000 > 0)
-      result = result * 0x100000058B90C0B48C6BE5DF846C5B2EF >> 128;
-    if (x & 0x4000000000 > 0)
-      result = result * 0x10000002C5C8601CC6B9E94213C72737A >> 128;
-    if (x & 0x2000000000 > 0)
-      result = result * 0x1000000162E42FFF037DF38AA2B219F06 >> 128;
-    if (x & 0x1000000000 > 0)
-      result = result * 0x10000000B17217FBA9C739AA5819F44F9 >> 128;
-    if (x & 0x800000000 > 0)
-      result = result * 0x1000000058B90BFCDEE5ACD3C1CEDC823 >> 128;
-    if (x & 0x400000000 > 0)
-      result = result * 0x100000002C5C85FE31F35A6A30DA1BE50 >> 128;
-    if (x & 0x200000000 > 0)
-      result = result * 0x10000000162E42FF0999CE3541B9FFFCF >> 128;
-    if (x & 0x100000000 > 0)
-      result = result * 0x100000000B17217F80F4EF5AADDA45554 >> 128;
-    if (x & 0x80000000 > 0)
-      result = result * 0x10000000058B90BFBF8479BD5A81B51AD >> 128;
-    if (x & 0x40000000 > 0)
-      result = result * 0x1000000002C5C85FDF84BD62AE30A74CC >> 128;
-    if (x & 0x20000000 > 0)
-      result = result * 0x100000000162E42FEFB2FED257559BDAA >> 128;
-    if (x & 0x10000000 > 0)
-      result = result * 0x1000000000B17217F7D5A7716BBA4A9AE >> 128;
-    if (x & 0x8000000 > 0)
-      result = result * 0x100000000058B90BFBE9DDBAC5E109CCE >> 128;
-    if (x & 0x4000000 > 0)
-      result = result * 0x10000000002C5C85FDF4B15DE6F17EB0D >> 128;
-    if (x & 0x2000000 > 0)
-      result = result * 0x1000000000162E42FEFA494F1478FDE05 >> 128;
-    if (x & 0x1000000 > 0)
-      result = result * 0x10000000000B17217F7D20CF927C8E94C >> 128;
-    if (x & 0x800000 > 0)
-      result = result * 0x1000000000058B90BFBE8F71CB4E4B33D >> 128;
-    if (x & 0x400000 > 0)
-      result = result * 0x100000000002C5C85FDF477B662B26945 >> 128;
-    if (x & 0x200000 > 0)
-      result = result * 0x10000000000162E42FEFA3AE53369388C >> 128;
-    if (x & 0x100000 > 0)
-      result = result * 0x100000000000B17217F7D1D351A389D40 >> 128;
-    if (x & 0x80000 > 0)
-      result = result * 0x10000000000058B90BFBE8E8B2D3D4EDE >> 128;
-    if (x & 0x40000 > 0)
-      result = result * 0x1000000000002C5C85FDF4741BEA6E77E >> 128;
-    if (x & 0x20000 > 0)
-      result = result * 0x100000000000162E42FEFA39FE95583C2 >> 128;
-    if (x & 0x10000 > 0)
-      result = result * 0x1000000000000B17217F7D1CFB72B45E1 >> 128;
-    if (x & 0x8000 > 0)
-      result = result * 0x100000000000058B90BFBE8E7CC35C3F0 >> 128;
-    if (x & 0x4000 > 0)
-      result = result * 0x10000000000002C5C85FDF473E242EA38 >> 128;
-    if (x & 0x2000 > 0)
-      result = result * 0x1000000000000162E42FEFA39F02B772C >> 128;
-    if (x & 0x1000 > 0)
-      result = result * 0x10000000000000B17217F7D1CF7D83C1A >> 128;
-    if (x & 0x800 > 0)
-      result = result * 0x1000000000000058B90BFBE8E7BDCBE2E >> 128;
-    if (x & 0x400 > 0)
-      result = result * 0x100000000000002C5C85FDF473DEA871F >> 128;
-    if (x & 0x200 > 0)
-      result = result * 0x10000000000000162E42FEFA39EF44D91 >> 128;
-    if (x & 0x100 > 0)
-      result = result * 0x100000000000000B17217F7D1CF79E949 >> 128;
-    if (x & 0x80 > 0)
-      result = result * 0x10000000000000058B90BFBE8E7BCE544 >> 128;
-    if (x & 0x40 > 0)
-      result = result * 0x1000000000000002C5C85FDF473DE6ECA >> 128;
-    if (x & 0x20 > 0)
-      result = result * 0x100000000000000162E42FEFA39EF366F >> 128;
-    if (x & 0x10 > 0)
-      result = result * 0x1000000000000000B17217F7D1CF79AFA >> 128;
-    if (x & 0x8 > 0)
-      result = result * 0x100000000000000058B90BFBE8E7BCD6D >> 128;
-    if (x & 0x4 > 0)
-      result = result * 0x10000000000000002C5C85FDF473DE6B2 >> 128;
-    if (x & 0x2 > 0)
-      result = result * 0x1000000000000000162E42FEFA39EF358 >> 128;
-    if (x & 0x1 > 0)
-      result = result * 0x10000000000000000B17217F7D1CF79AB >> 128;
-
-    result >>= 63 - (x >> 64);
-    require (result <= uint256 (MAX_64x64));
-
-    return int128 (result);
-  }
-
-  /**
-   * @dev Calculate natural exponent of x.  Revert on overflow.
-   *
-   * @param x signed 64.64-bit fixed point number
-   * @return signed 64.64-bit fixed point number
-   */
-  function exp (int128 x) internal pure returns (int128) {
-    require (x < 0x400000000000000000); // Overflow
-
-    if (x < -0x400000000000000000) return 0; // Underflow
-
-    return exp_2 (
-        int128 (int256 (x) * 0x171547652B82FE1777D0FFDA0D23A7D12 >> 128));
-  }
-
-  /**
-   * @dev Calculate x / y rounding towards zero, where x and y are unsigned 256-bit
-   * integer numbers.  Revert on overflow or when y is zero.
-   *
-   * @param x unsigned 256-bit integer number
-   * @param y unsigned 256-bit integer number
-   * @return unsigned 64.64-bit fixed point number
-   */
-  function divuu (uint256 x, uint256 y) private pure returns (uint128) {
-    require (y != 0);
-
-    uint256 result;
-
-    if (x <= 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
-      result = (x << 64) / y;
-    else {
-      uint256 msb = 192;
-      uint256 xc = x >> 192;
-      if (xc >= 0x100000000) { xc >>= 32; msb += 32; }
-      if (xc >= 0x10000) { xc >>= 16; msb += 16; }
-      if (xc >= 0x100) { xc >>= 8; msb += 8; }
-      if (xc >= 0x10) { xc >>= 4; msb += 4; }
-      if (xc >= 0x4) { xc >>= 2; msb += 2; }
-      if (xc >= 0x2) msb += 1;  // No need to shift xc anymore
-
-      result = (x << 255 - msb) / ((y - 1 >> msb - 191) + 1);
-      require (result <= 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
-
-      uint256 hi = result * (y >> 128);
-      uint256 lo = result * (y & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
-
-      uint256 xh = x >> 192;
-      uint256 xl = x << 64;
-
-      if (xl < lo) xh -= 1;
-      xl -= lo; // We rely on overflow behavior here
-      lo = hi << 128;
-      if (xl < lo) xh -= 1;
-      xl -= lo; // We rely on overflow behavior here
-
-      assert (xh == hi >> 128);
-
-      result += xl / y;
+    /**
+     * @dev Convert unsigned 256-bit integer number into signed 64.64-bit fixed point
+     * number.  Revert on overflow.
+     *
+     * @param x unsigned 256-bit integer number
+     * @return signed 64.64-bit fixed point number
+     */
+    function fromUInt(uint256 x) internal pure returns (int128) {
+        require(x <= 0x7FFFFFFFFFFFFFFF);
+        return int128(x << 64);
     }
 
-    require (result <= 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
-    return uint128 (result);
-  }
+    /**
+     * @dev Convert signed 64.64 fixed point number into unsigned 64-bit integer
+     * number rounding down.  Revert on underflow.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @return unsigned 64-bit integer number
+     */
+    function toUInt(int128 x) internal pure returns (uint64) {
+        require(x >= 0);
+        return uint64(x >> 64);
+    }
 
-  /**
-   * @dev Calculate x^y assuming 0^0 is 1, where x is unsigned 129.127 fixed point
-   * number and y is unsigned 256-bit integer number.  Revert on overflow.
-   *
-   * @param x unsigned 129.127-bit fixed point number
-   * @param y uint256 value
-   * @return unsigned 129.127-bit fixed point number
-   */
-  function powu (uint256 x, uint256 y) private pure returns (uint256) {
-    if (y == 0) return 0x80000000000000000000000000000000;
-    else if (x == 0) return 0;
-    else {
-      int256 msb = 0;
-      uint256 xc = x;
-      if (xc >= 0x100000000000000000000000000000000) { xc >>= 128; msb += 128; }
-      if (xc >= 0x10000000000000000) { xc >>= 64; msb += 64; }
-      if (xc >= 0x100000000) { xc >>= 32; msb += 32; }
-      if (xc >= 0x10000) { xc >>= 16; msb += 16; }
-      if (xc >= 0x100) { xc >>= 8; msb += 8; }
-      if (xc >= 0x10) { xc >>= 4; msb += 4; }
-      if (xc >= 0x4) { xc >>= 2; msb += 2; }
-      if (xc >= 0x2) msb += 1;  // No need to shift xc anymore
+    /**
+     * @dev Convert signed 128.128 fixed point number into signed 64.64-bit fixed point
+     * number rounding down.  Revert on overflow.
+     *
+     * @param x signed 128.128-bin fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function from128x128(int256 x) internal pure returns (int128) {
+        int256 result = x >> 64;
+        require(result >= MIN_64x64 && result <= MAX_64x64);
+        return int128(result);
+    }
 
-      int256 xe = msb - 127;
-      if (xe > 0) x >>= xe;
-      else x <<= -xe;
+    /**
+     * @dev Convert signed 64.64 fixed point number into signed 128.128 fixed point
+     * number.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @return signed 128.128 fixed point number
+     */
+    function to128x128(int128 x) internal pure returns (int256) {
+        return int256(x) << 64;
+    }
 
-      uint256 result = 0x80000000000000000000000000000000;
-      int256 re = 0;
+    /**
+     * @dev Calculate x + y.  Revert on overflow.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @param y signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function add(int128 x, int128 y) internal pure returns (int128) {
+        int256 result = int256(x) + y;
+        require(result >= MIN_64x64 && result <= MAX_64x64);
+        return int128(result);
+    }
 
-      while (y > 0) {
-        if (y & 1 > 0) {
-          result = result * x;
-          y -= 1;
-          re += xe;
-          if (result >=
-            0x8000000000000000000000000000000000000000000000000000000000000000) {
-            result >>= 128;
-            re += 1;
-          } else result >>= 127;
-          if (re < -127) return 0; // Underflow
-          require (re < 128); // Overflow
+    /**
+     * @dev Calculate x - y.  Revert on overflow.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @param y signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function sub(int128 x, int128 y) internal pure returns (int128) {
+        int256 result = int256(x) - y;
+        require(result >= MIN_64x64 && result <= MAX_64x64);
+        return int128(result);
+    }
+
+    /**
+     * @dev Calculate x * y rounding down.  Revert on overflow.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @param y signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function mul(int128 x, int128 y) internal pure returns (int128) {
+        int256 result = (int256(x) * y) >> 64;
+        require(result >= MIN_64x64 && result <= MAX_64x64);
+        return int128(result);
+    }
+
+    /**
+     * @dev Calculate x * y rounding towards zero, where x is signed 64.64 fixed point
+     * number and y is signed 256-bit integer number.  Revert on overflow.
+     *
+     * @param x signed 64.64 fixed point number
+     * @param y signed 256-bit integer number
+     * @return signed 256-bit integer number
+     */
+    function muli(int128 x, int256 y) internal pure returns (int256) {
+        if (x == MIN_64x64) {
+            require(
+                y >= -0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF &&
+                    y <= 0x1000000000000000000000000000000000000000000000000
+            );
+            return -y << 63;
         } else {
-          x = x * x;
-          y >>= 1;
-          xe <<= 1;
-          if (x >=
-            0x8000000000000000000000000000000000000000000000000000000000000000) {
-            x >>= 128;
-            xe += 1;
-          } else x >>= 127;
-          if (xe < -127) return 0; // Underflow
-          require (xe < 128); // Overflow
+            bool negativeResult = false;
+            if (x < 0) {
+                x = -x;
+                negativeResult = true;
+            }
+            if (y < 0) {
+                y = -y; // We rely on overflow behavior here
+                negativeResult = !negativeResult;
+            }
+            uint256 absoluteResult = mulu(x, uint256(y));
+            if (negativeResult) {
+                require(absoluteResult <= 0x8000000000000000000000000000000000000000000000000000000000000000);
+                return -int256(absoluteResult); // We rely on overflow behavior here
+            } else {
+                require(absoluteResult <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
+                return int256(absoluteResult);
+            }
         }
-      }
-
-      if (re > 0) result <<= re;
-      else if (re < 0) result >>= -re;
-
-      return result;
     }
-  }
 
-  /**
-   * @dev Calculate sqrt (x) rounding down, where x is unsigned 256-bit integer
-   * number.
-   *
-   * @param x unsigned 256-bit integer number
-   * @return unsigned 128-bit integer number
-   */
-  function sqrtu (uint256 x, uint256 r) private pure returns (uint128) {
-    if (x == 0) return 0;
-    else {
-      require (r > 0);
-      while (true) {
-        uint256 rr = x / r;
-        if (r == rr || r + 1 == rr) return uint128 (r);
-        else if (r == rr + 1) return uint128 (rr);
-        r = r + rr + 1 >> 1;
-      }
+    /**
+     * @dev Calculate x * y rounding down, where x is signed 64.64 fixed point number
+     * and y is unsigned 256-bit integer number.  Revert on overflow.
+     *
+     * @param x signed 64.64 fixed point number
+     * @param y unsigned 256-bit integer number
+     * @return unsigned 256-bit integer number
+     */
+    function mulu(int128 x, uint256 y) internal pure returns (uint256) {
+        if (y == 0) return 0;
+
+        require(x >= 0);
+
+        uint256 lo = (uint256(x) * (y & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)) >> 64;
+        uint256 hi = uint256(x) * (y >> 128);
+
+        require(hi <= 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
+        hi <<= 64;
+
+        require(hi <= 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF - lo);
+        return hi + lo;
     }
-  }
+
+    /**
+     * @dev Calculate x / y rounding towards zero.  Revert on overflow or when y is
+     * zero.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @param y signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function div(int128 x, int128 y) internal pure returns (int128) {
+        require(y != 0);
+        int256 result = (int256(x) << 64) / y;
+        require(result >= MIN_64x64 && result <= MAX_64x64);
+        return int128(result);
+    }
+
+    /**
+     * @dev Calculate x / y rounding towards zero, where x and y are signed 256-bit
+     * integer numbers.  Revert on overflow or when y is zero.
+     *
+     * @param x signed 256-bit integer number
+     * @param y signed 256-bit integer number
+     * @return signed 64.64-bit fixed point number
+     */
+    function divi(int256 x, int256 y) internal pure returns (int128) {
+        require(y != 0);
+
+        bool negativeResult = false;
+        if (x < 0) {
+            x = -x; // We rely on overflow behavior here
+            negativeResult = true;
+        }
+        if (y < 0) {
+            y = -y; // We rely on overflow behavior here
+            negativeResult = !negativeResult;
+        }
+        uint128 absoluteResult = divuu(uint256(x), uint256(y));
+        if (negativeResult) {
+            require(absoluteResult <= 0x80000000000000000000000000000000);
+            return -int128(absoluteResult); // We rely on overflow behavior here
+        } else {
+            require(absoluteResult <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
+            return int128(absoluteResult); // We rely on overflow behavior here
+        }
+    }
+
+    /**
+     * @dev Calculate x / y rounding towards zero, where x and y are unsigned 256-bit
+     * integer numbers.  Revert on overflow or when y is zero.
+     *
+     * @param x unsigned 256-bit integer number
+     * @param y unsigned 256-bit integer number
+     * @return signed 64.64-bit fixed point number
+     */
+    function divu(uint256 x, uint256 y) internal pure returns (int128) {
+        require(y != 0);
+        uint128 result = divuu(x, y);
+        require(result <= uint128(MAX_64x64));
+        return int128(result);
+    }
+
+    /**
+     * @dev Calculate -x.  Revert on overflow.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function neg(int128 x) internal pure returns (int128) {
+        require(x != MIN_64x64);
+        return -x;
+    }
+
+    /**
+     * @dev Calculate |x|.  Revert on overflow.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function abs(int128 x) internal pure returns (int128) {
+        require(x != MIN_64x64);
+        return x < 0 ? -x : x;
+    }
+
+    /**
+     * @dev Calculate 1 / x rounding towards zero.  Revert on overflow or when x is
+     * zero.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function inv(int128 x) internal pure returns (int128) {
+        require(x != 0);
+        int256 result = int256(0x100000000000000000000000000000000) / x;
+        require(result >= MIN_64x64 && result <= MAX_64x64);
+        return int128(result);
+    }
+
+    /**
+     * @dev Calculate arithmetics average of x and y, i.e. (x + y) / 2 rounding down.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @param y signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function avg(int128 x, int128 y) internal pure returns (int128) {
+        return int128((int256(x) + int256(y)) >> 1);
+    }
+
+    /**
+     * @dev Calculate geometric average of x and y, i.e. sqrt (x * y) rounding down.
+     * Revert on overflow or in case x * y is negative.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @param y signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function gavg(int128 x, int128 y) internal pure returns (int128) {
+        int256 m = int256(x) * int256(y);
+        require(m >= 0);
+        require(m < 0x4000000000000000000000000000000000000000000000000000000000000000);
+        return int128(sqrtu(uint256(m), (uint256(x) + uint256(y)) >> 1));
+    }
+
+    /**
+     * @dev Calculate x^y assuming 0^0 is 1, where x is signed 64.64 fixed point number
+     * and y is unsigned 256-bit integer number.  Revert on overflow.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @param y uint256 value
+     * @return signed 64.64-bit fixed point number
+     */
+    function pow(int128 x, uint256 y) internal pure returns (int128) {
+        uint256 absoluteResult;
+        bool negativeResult = false;
+        if (x >= 0) {
+            absoluteResult = powu(uint256(x) << 63, y);
+        } else {
+            // We rely on overflow behavior here
+            absoluteResult = powu(uint256(uint128(-x)) << 63, y);
+            negativeResult = y & 1 > 0;
+        }
+
+        absoluteResult >>= 63;
+
+        if (negativeResult) {
+            require(absoluteResult <= 0x80000000000000000000000000000000);
+            return -int128(absoluteResult); // We rely on overflow behavior here
+        } else {
+            require(absoluteResult <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
+            return int128(absoluteResult); // We rely on overflow behavior here
+        }
+    }
+
+    /**
+     * @dev Calculate sqrt (x) rounding down.  Revert if x < 0.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function sqrt(int128 x) internal pure returns (int128) {
+        require(x >= 0);
+        return int128(sqrtu(uint256(x) << 64, 0x10000000000000000));
+    }
+
+    /**
+     * @dev Calculate binary logarithm of x.  Revert if x <= 0.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function log_2(int128 x) internal pure returns (int128) {
+        require(x > 0);
+
+        int256 msb = 0;
+        int256 xc = x;
+        if (xc >= 0x10000000000000000) {
+            xc >>= 64;
+            msb += 64;
+        }
+        if (xc >= 0x100000000) {
+            xc >>= 32;
+            msb += 32;
+        }
+        if (xc >= 0x10000) {
+            xc >>= 16;
+            msb += 16;
+        }
+        if (xc >= 0x100) {
+            xc >>= 8;
+            msb += 8;
+        }
+        if (xc >= 0x10) {
+            xc >>= 4;
+            msb += 4;
+        }
+        if (xc >= 0x4) {
+            xc >>= 2;
+            msb += 2;
+        }
+        if (xc >= 0x2) msb += 1; // No need to shift xc anymore
+
+        int256 result = (msb - 64) << 64;
+        uint256 ux = uint256(x) << (127 - msb);
+        for (int256 bit = 0x8000000000000000; bit > 0; bit >>= 1) {
+            ux *= ux;
+            uint256 b = ux >> 255;
+            ux >>= 127 + b;
+            result += bit * int256(b);
+        }
+
+        return int128(result);
+    }
+
+    /**
+     * @dev Calculate natural logarithm of x.  Revert if x <= 0.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function ln(int128 x) internal pure returns (int128) {
+        require(x > 0);
+
+        return int128((uint256(log_2(x)) * 0xB17217F7D1CF79ABC9E3B39803F2F6AF) >> 128);
+    }
+
+    /**
+     * @dev Calculate binary exponent of x.  Revert on overflow.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function exp_2(int128 x) internal pure returns (int128) {
+        require(x < 0x400000000000000000); // Overflow
+
+        if (x < -0x400000000000000000) return 0; // Underflow
+
+        uint256 result = 0x80000000000000000000000000000000;
+
+        if (x & 0x8000000000000000 > 0) result = (result * 0x16A09E667F3BCC908B2FB1366EA957D3E) >> 128;
+        if (x & 0x4000000000000000 > 0) result = (result * 0x1306FE0A31B7152DE8D5A46305C85EDEC) >> 128;
+        if (x & 0x2000000000000000 > 0) result = (result * 0x1172B83C7D517ADCDF7C8C50EB14A791F) >> 128;
+        if (x & 0x1000000000000000 > 0) result = (result * 0x10B5586CF9890F6298B92B71842A98363) >> 128;
+        if (x & 0x800000000000000 > 0) result = (result * 0x1059B0D31585743AE7C548EB68CA417FD) >> 128;
+        if (x & 0x400000000000000 > 0) result = (result * 0x102C9A3E778060EE6F7CACA4F7A29BDE8) >> 128;
+        if (x & 0x200000000000000 > 0) result = (result * 0x10163DA9FB33356D84A66AE336DCDFA3F) >> 128;
+        if (x & 0x100000000000000 > 0) result = (result * 0x100B1AFA5ABCBED6129AB13EC11DC9543) >> 128;
+        if (x & 0x80000000000000 > 0) result = (result * 0x10058C86DA1C09EA1FF19D294CF2F679B) >> 128;
+        if (x & 0x40000000000000 > 0) result = (result * 0x1002C605E2E8CEC506D21BFC89A23A00F) >> 128;
+        if (x & 0x20000000000000 > 0) result = (result * 0x100162F3904051FA128BCA9C55C31E5DF) >> 128;
+        if (x & 0x10000000000000 > 0) result = (result * 0x1000B175EFFDC76BA38E31671CA939725) >> 128;
+        if (x & 0x8000000000000 > 0) result = (result * 0x100058BA01FB9F96D6CACD4B180917C3D) >> 128;
+        if (x & 0x4000000000000 > 0) result = (result * 0x10002C5CC37DA9491D0985C348C68E7B3) >> 128;
+        if (x & 0x2000000000000 > 0) result = (result * 0x1000162E525EE054754457D5995292026) >> 128;
+        if (x & 0x1000000000000 > 0) result = (result * 0x10000B17255775C040618BF4A4ADE83FC) >> 128;
+        if (x & 0x800000000000 > 0) result = (result * 0x1000058B91B5BC9AE2EED81E9B7D4CFAB) >> 128;
+        if (x & 0x400000000000 > 0) result = (result * 0x100002C5C89D5EC6CA4D7C8ACC017B7C9) >> 128;
+        if (x & 0x200000000000 > 0) result = (result * 0x10000162E43F4F831060E02D839A9D16D) >> 128;
+        if (x & 0x100000000000 > 0) result = (result * 0x100000B1721BCFC99D9F890EA06911763) >> 128;
+        if (x & 0x80000000000 > 0) result = (result * 0x10000058B90CF1E6D97F9CA14DBCC1628) >> 128;
+        if (x & 0x40000000000 > 0) result = (result * 0x1000002C5C863B73F016468F6BAC5CA2B) >> 128;
+        if (x & 0x20000000000 > 0) result = (result * 0x100000162E430E5A18F6119E3C02282A5) >> 128;
+        if (x & 0x10000000000 > 0) result = (result * 0x1000000B1721835514B86E6D96EFD1BFE) >> 128;
+        if (x & 0x8000000000 > 0) result = (result * 0x100000058B90C0B48C6BE5DF846C5B2EF) >> 128;
+        if (x & 0x4000000000 > 0) result = (result * 0x10000002C5C8601CC6B9E94213C72737A) >> 128;
+        if (x & 0x2000000000 > 0) result = (result * 0x1000000162E42FFF037DF38AA2B219F06) >> 128;
+        if (x & 0x1000000000 > 0) result = (result * 0x10000000B17217FBA9C739AA5819F44F9) >> 128;
+        if (x & 0x800000000 > 0) result = (result * 0x1000000058B90BFCDEE5ACD3C1CEDC823) >> 128;
+        if (x & 0x400000000 > 0) result = (result * 0x100000002C5C85FE31F35A6A30DA1BE50) >> 128;
+        if (x & 0x200000000 > 0) result = (result * 0x10000000162E42FF0999CE3541B9FFFCF) >> 128;
+        if (x & 0x100000000 > 0) result = (result * 0x100000000B17217F80F4EF5AADDA45554) >> 128;
+        if (x & 0x80000000 > 0) result = (result * 0x10000000058B90BFBF8479BD5A81B51AD) >> 128;
+        if (x & 0x40000000 > 0) result = (result * 0x1000000002C5C85FDF84BD62AE30A74CC) >> 128;
+        if (x & 0x20000000 > 0) result = (result * 0x100000000162E42FEFB2FED257559BDAA) >> 128;
+        if (x & 0x10000000 > 0) result = (result * 0x1000000000B17217F7D5A7716BBA4A9AE) >> 128;
+        if (x & 0x8000000 > 0) result = (result * 0x100000000058B90BFBE9DDBAC5E109CCE) >> 128;
+        if (x & 0x4000000 > 0) result = (result * 0x10000000002C5C85FDF4B15DE6F17EB0D) >> 128;
+        if (x & 0x2000000 > 0) result = (result * 0x1000000000162E42FEFA494F1478FDE05) >> 128;
+        if (x & 0x1000000 > 0) result = (result * 0x10000000000B17217F7D20CF927C8E94C) >> 128;
+        if (x & 0x800000 > 0) result = (result * 0x1000000000058B90BFBE8F71CB4E4B33D) >> 128;
+        if (x & 0x400000 > 0) result = (result * 0x100000000002C5C85FDF477B662B26945) >> 128;
+        if (x & 0x200000 > 0) result = (result * 0x10000000000162E42FEFA3AE53369388C) >> 128;
+        if (x & 0x100000 > 0) result = (result * 0x100000000000B17217F7D1D351A389D40) >> 128;
+        if (x & 0x80000 > 0) result = (result * 0x10000000000058B90BFBE8E8B2D3D4EDE) >> 128;
+        if (x & 0x40000 > 0) result = (result * 0x1000000000002C5C85FDF4741BEA6E77E) >> 128;
+        if (x & 0x20000 > 0) result = (result * 0x100000000000162E42FEFA39FE95583C2) >> 128;
+        if (x & 0x10000 > 0) result = (result * 0x1000000000000B17217F7D1CFB72B45E1) >> 128;
+        if (x & 0x8000 > 0) result = (result * 0x100000000000058B90BFBE8E7CC35C3F0) >> 128;
+        if (x & 0x4000 > 0) result = (result * 0x10000000000002C5C85FDF473E242EA38) >> 128;
+        if (x & 0x2000 > 0) result = (result * 0x1000000000000162E42FEFA39F02B772C) >> 128;
+        if (x & 0x1000 > 0) result = (result * 0x10000000000000B17217F7D1CF7D83C1A) >> 128;
+        if (x & 0x800 > 0) result = (result * 0x1000000000000058B90BFBE8E7BDCBE2E) >> 128;
+        if (x & 0x400 > 0) result = (result * 0x100000000000002C5C85FDF473DEA871F) >> 128;
+        if (x & 0x200 > 0) result = (result * 0x10000000000000162E42FEFA39EF44D91) >> 128;
+        if (x & 0x100 > 0) result = (result * 0x100000000000000B17217F7D1CF79E949) >> 128;
+        if (x & 0x80 > 0) result = (result * 0x10000000000000058B90BFBE8E7BCE544) >> 128;
+        if (x & 0x40 > 0) result = (result * 0x1000000000000002C5C85FDF473DE6ECA) >> 128;
+        if (x & 0x20 > 0) result = (result * 0x100000000000000162E42FEFA39EF366F) >> 128;
+        if (x & 0x10 > 0) result = (result * 0x1000000000000000B17217F7D1CF79AFA) >> 128;
+        if (x & 0x8 > 0) result = (result * 0x100000000000000058B90BFBE8E7BCD6D) >> 128;
+        if (x & 0x4 > 0) result = (result * 0x10000000000000002C5C85FDF473DE6B2) >> 128;
+        if (x & 0x2 > 0) result = (result * 0x1000000000000000162E42FEFA39EF358) >> 128;
+        if (x & 0x1 > 0) result = (result * 0x10000000000000000B17217F7D1CF79AB) >> 128;
+
+        result >>= 63 - (x >> 64);
+        require(result <= uint256(MAX_64x64));
+
+        return int128(result);
+    }
+
+    /**
+     * @dev Calculate natural exponent of x.  Revert on overflow.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function exp(int128 x) internal pure returns (int128) {
+        require(x < 0x400000000000000000); // Overflow
+
+        if (x < -0x400000000000000000) return 0; // Underflow
+
+        return exp_2(int128((int256(x) * 0x171547652B82FE1777D0FFDA0D23A7D12) >> 128));
+    }
+
+    /**
+     * @dev Calculate x / y rounding towards zero, where x and y are unsigned 256-bit
+     * integer numbers.  Revert on overflow or when y is zero.
+     *
+     * @param x unsigned 256-bit integer number
+     * @param y unsigned 256-bit integer number
+     * @return unsigned 64.64-bit fixed point number
+     */
+    function divuu(uint256 x, uint256 y) private pure returns (uint128) {
+        require(y != 0);
+
+        uint256 result;
+
+        if (x <= 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) result = (x << 64) / y;
+        else {
+            uint256 msb = 192;
+            uint256 xc = x >> 192;
+            if (xc >= 0x100000000) {
+                xc >>= 32;
+                msb += 32;
+            }
+            if (xc >= 0x10000) {
+                xc >>= 16;
+                msb += 16;
+            }
+            if (xc >= 0x100) {
+                xc >>= 8;
+                msb += 8;
+            }
+            if (xc >= 0x10) {
+                xc >>= 4;
+                msb += 4;
+            }
+            if (xc >= 0x4) {
+                xc >>= 2;
+                msb += 2;
+            }
+            if (xc >= 0x2) msb += 1; // No need to shift xc anymore
+
+            result = (x << (255 - msb)) / (((y - 1) >> (msb - 191)) + 1);
+            require(result <= 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
+
+            uint256 hi = result * (y >> 128);
+            uint256 lo = result * (y & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
+
+            uint256 xh = x >> 192;
+            uint256 xl = x << 64;
+
+            if (xl < lo) xh -= 1;
+            xl -= lo; // We rely on overflow behavior here
+            lo = hi << 128;
+            if (xl < lo) xh -= 1;
+            xl -= lo; // We rely on overflow behavior here
+
+            assert(xh == hi >> 128);
+
+            result += xl / y;
+        }
+
+        require(result <= 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
+        return uint128(result);
+    }
+
+    /**
+     * @dev Calculate x^y assuming 0^0 is 1, where x is unsigned 129.127 fixed point
+     * number and y is unsigned 256-bit integer number.  Revert on overflow.
+     *
+     * @param x unsigned 129.127-bit fixed point number
+     * @param y uint256 value
+     * @return unsigned 129.127-bit fixed point number
+     */
+    function powu(uint256 x, uint256 y) private pure returns (uint256) {
+        if (y == 0) return 0x80000000000000000000000000000000;
+        else if (x == 0) return 0;
+        else {
+            int256 msb = 0;
+            uint256 xc = x;
+            if (xc >= 0x100000000000000000000000000000000) {
+                xc >>= 128;
+                msb += 128;
+            }
+            if (xc >= 0x10000000000000000) {
+                xc >>= 64;
+                msb += 64;
+            }
+            if (xc >= 0x100000000) {
+                xc >>= 32;
+                msb += 32;
+            }
+            if (xc >= 0x10000) {
+                xc >>= 16;
+                msb += 16;
+            }
+            if (xc >= 0x100) {
+                xc >>= 8;
+                msb += 8;
+            }
+            if (xc >= 0x10) {
+                xc >>= 4;
+                msb += 4;
+            }
+            if (xc >= 0x4) {
+                xc >>= 2;
+                msb += 2;
+            }
+            if (xc >= 0x2) msb += 1; // No need to shift xc anymore
+
+            int256 xe = msb - 127;
+            if (xe > 0) x >>= xe;
+            else x <<= -xe;
+
+            uint256 result = 0x80000000000000000000000000000000;
+            int256 re = 0;
+
+            while (y > 0) {
+                if (y & 1 > 0) {
+                    result = result * x;
+                    y -= 1;
+                    re += xe;
+                    if (result >= 0x8000000000000000000000000000000000000000000000000000000000000000) {
+                        result >>= 128;
+                        re += 1;
+                    } else result >>= 127;
+                    if (re < -127) return 0; // Underflow
+                    require(re < 128); // Overflow
+                } else {
+                    x = x * x;
+                    y >>= 1;
+                    xe <<= 1;
+                    if (x >= 0x8000000000000000000000000000000000000000000000000000000000000000) {
+                        x >>= 128;
+                        xe += 1;
+                    } else x >>= 127;
+                    if (xe < -127) return 0; // Underflow
+                    require(xe < 128); // Overflow
+                }
+            }
+
+            if (re > 0) result <<= re;
+            else if (re < 0) result >>= -re;
+
+            return result;
+        }
+    }
+
+    /**
+     * @dev Calculate sqrt (x) rounding down, where x is unsigned 256-bit integer
+     * number.
+     *
+     * @param x unsigned 256-bit integer number
+     * @return unsigned 128-bit integer number
+     */
+    function sqrtu(uint256 x, uint256 r) private pure returns (uint128) {
+        if (x == 0) return 0;
+        else {
+            require(r > 0);
+            while (true) {
+                uint256 rr = x / r;
+                if (r == rr || r + 1 == rr) return uint128(r);
+                else if (r == rr + 1) return uint128(rr);
+                r = (r + rr + 1) >> 1;
+            }
+        }
+    }
 }

--- a/contracts/pool/Pool.sol
+++ b/contracts/pool/Pool.sol
@@ -1,34 +1,41 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.10;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "./YieldMath.sol";
-import "../helpers/Delegable.sol";
-import "../helpers/ERC20Permit.sol";
-import "../interfaces/IPot.sol";
-import "../interfaces/IFYDai.sol";
-import "../interfaces/IPool.sol";
-
+import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import './YieldMath.sol';
+import '../helpers/Delegable.sol';
+import '../helpers/ERC20Permit.sol';
+import '../interfaces/IPot.sol';
+import '../interfaces/IFYDai.sol';
+import '../interfaces/IPool.sol';
 
 /// @dev The Pool contract exchanges Dai for fyDai at a price defined by a specific formula.
-contract Pool is IPool, Delegable(), ERC20Permit {
-
+contract Pool is IPool, Delegable, ERC20Permit {
     event Trade(uint256 maturity, address indexed from, address indexed to, int256 daiTokens, int256 fyDaiTokens);
-    event Liquidity(uint256 maturity, address indexed from, address indexed to, int256 daiTokens, int256 fyDaiTokens, int256 poolTokens);
+    event Liquidity(
+        uint256 maturity,
+        address indexed from,
+        address indexed to,
+        int256 daiTokens,
+        int256 fyDaiTokens,
+        int256 poolTokens
+    );
 
-    int128 constant public k = int128(uint256((1 << 64)) / 126144000); // 1 / Seconds in 4 years, in 64.64
-    int128 constant public g1 = int128(uint256((950 << 64)) / 1000); // To be used when selling Dai to the pool. All constants are `ufixed`, to divide them they must be converted to uint256
-    int128 constant public g2 = int128(uint256((1000 << 64)) / 950); // To be used when selling fyDai to the pool. All constants are `ufixed`, to divide them they must be converted to uint256
-    uint128 immutable public maturity;
+    int128 public constant k = int128(uint256((1 << 64)) / 126144000); // 1 / Seconds in 4 years, in 64.64
+    int128 public constant g1 = int128(uint256((950 << 64)) / 1000); // To be used when selling Dai to the pool. All constants are `ufixed`, to divide them they must be converted to uint256
+    int128 public constant g2 = int128(uint256((1000 << 64)) / 950); // To be used when selling fyDai to the pool. All constants are `ufixed`, to divide them they must be converted to uint256
+    uint128 public immutable maturity;
 
     IERC20 public override dai;
     IFYDai public override fyDai;
 
-    constructor(address dai_, address fyDai_, string memory name_, string memory symbol_)
-        public
-        ERC20Permit(name_, symbol_)
-    {
+    constructor(
+        address dai_,
+        address fyDai_,
+        string memory name_,
+        string memory symbol_
+    ) public ERC20Permit(name_, symbol_) {
         dai = IERC20(dai_);
         fyDai = IFYDai(fyDai_);
 
@@ -37,61 +44,43 @@ contract Pool is IPool, Delegable(), ERC20Permit {
 
     /// @dev Trading can only be done before maturity
     modifier beforeMaturity() {
-        require(
-            now < maturity,
-            "Pool: Too late"
-        );
+        require(now < maturity, 'Pool: Too late');
         _;
     }
 
     /// @dev Overflow-protected addition, from OpenZeppelin
-    function add(uint128 a, uint128 b)
-        internal pure returns (uint128)
-    {
+    function add(uint128 a, uint128 b) internal pure returns (uint128) {
         uint128 c = a + b;
-        require(c >= a, "Pool: Dai reserves too high");
+        require(c >= a, 'Pool: Dai reserves too high');
 
         return c;
     }
 
     /// @dev Overflow-protected substraction, from OpenZeppelin
     function sub(uint128 a, uint128 b) internal pure returns (uint128) {
-        require(b <= a, "Pool: fyDai reserves too low");
+        require(b <= a, 'Pool: fyDai reserves too low');
         uint128 c = a - b;
 
         return c;
     }
 
     /// @dev Safe casting from uint256 to uint128
-    function toUint128(uint256 x) internal pure returns(uint128) {
-        require(
-            x <= type(uint128).max,
-            "Pool: Cast overflow"
-        );
+    function toUint128(uint256 x) internal pure returns (uint128) {
+        require(x <= type(uint128).max, 'Pool: Cast overflow');
         return uint128(x);
     }
 
     /// @dev Safe casting from uint256 to int256
-    function toInt256(uint256 x) internal pure returns(int256) {
-        require(
-            x <= uint256(type(int256).max),
-            "Pool: Cast overflow"
-        );
+    function toInt256(uint256 x) internal pure returns (int256) {
+        require(x <= uint256(type(int256).max), 'Pool: Cast overflow');
         return int256(x);
     }
 
     /// @dev Mint initial liquidity tokens.
     /// The liquidity provider needs to have called `dai.approve`
     /// @param daiIn The initial Dai liquidity to provide.
-    function init(uint256 daiIn)
-        internal
-        beforeMaturity
-        returns (uint256)
-    {
-        require(
-            totalSupply() == 0,
-            "Pool: Already initialized"
-        );
+    function init(uint256 daiIn) internal beforeMaturity returns (uint256) {
+        require(totalSupply() == 0, 'Pool: Already initialized');
         // no fyDai transferred, because initial fyDai deposit is entirely virtual
         dai.transferFrom(msg.sender, address(this), daiIn);
         _mint(msg.sender, daiIn);
@@ -106,11 +95,11 @@ contract Pool is IPool, Delegable(), ERC20Permit {
     /// @param to Wallet receiving the minted liquidity tokens.
     /// @param daiOffered Amount of `dai` being invested, an appropriate amount of `fyDai` to be invested alongside will be calculated and taken by this function from the caller.
     /// @return The amount of liquidity tokens minted.
-    function mint(address from, address to, uint256 daiOffered)
-        external override
-        onlyHolderOrDelegate(from, "Pool: Only Holder Or Delegate")
-        returns (uint256)
-    {
+    function mint(
+        address from,
+        address to,
+        uint256 daiOffered
+    ) external override onlyHolderOrDelegate(from, 'Pool: Only Holder Or Delegate') returns (uint256) {
         uint256 supply = totalSupply();
         if (supply == 0) return init(daiOffered);
 
@@ -137,17 +126,18 @@ contract Pool is IPool, Delegable(), ERC20Permit {
     /// @param to Wallet receiving the dai and fyDai.
     /// @param tokensBurned Amount of liquidity tokens being burned.
     /// @return The amount of reserve tokens returned (daiTokens, fyDaiTokens).
-    function burn(address from, address to, uint256 tokensBurned)
-        external override
-        onlyHolderOrDelegate(from, "Pool: Only Holder Or Delegate")
-        returns (uint256, uint256)
-    {
+    function burn(
+        address from,
+        address to,
+        uint256 tokensBurned
+    ) external override onlyHolderOrDelegate(from, 'Pool: Only Holder Or Delegate') returns (uint256, uint256) {
         uint256 supply = totalSupply();
         uint256 daiReserves = dai.balanceOf(address(this));
         // use the actual reserves rather than the virtual reserves
         uint256 daiReturned;
         uint256 fyDaiReturned;
-        { // avoiding stack too deep
+        {
+            // avoiding stack too deep
             uint256 fyDaiReserves = fyDai.balanceOf(address(this));
             daiReturned = tokensBurned.mul(daiReserves).div(supply);
             fyDaiReturned = tokensBurned.mul(fyDaiReserves).div(supply);
@@ -167,11 +157,11 @@ contract Pool is IPool, Delegable(), ERC20Permit {
     /// @param to Wallet receiving the fyDai being bought
     /// @param daiIn Amount of dai being sold that will be taken from the user's wallet
     /// @return Amount of fyDai that will be deposited on `to` wallet
-    function sellDai(address from, address to, uint128 daiIn)
-        external override
-        onlyHolderOrDelegate(from, "Pool: Only Holder Or Delegate")
-        returns(uint128)
-    {
+    function sellDai(
+        address from,
+        address to,
+        uint128 daiIn
+    ) external override onlyHolderOrDelegate(from, 'Pool: Only Holder Or Delegate') returns (uint128) {
         uint128 fyDaiOut = sellDaiPreview(daiIn);
 
         dai.transferFrom(from, address(this), daiIn);
@@ -184,27 +174,21 @@ contract Pool is IPool, Delegable(), ERC20Permit {
     /// @dev Returns how much fyDai would be obtained by selling `daiIn` dai
     /// @param daiIn Amount of dai hypothetically sold.
     /// @return Amount of fyDai hypothetically bought.
-    function sellDaiPreview(uint128 daiIn)
-        public view override
-        beforeMaturity
-        returns(uint128)
-    {
+    function sellDaiPreview(uint128 daiIn) public view override beforeMaturity returns (uint128) {
         uint128 daiReserves = getDaiReserves();
         uint128 fyDaiReserves = getFYDaiReserves();
 
-        uint128 fyDaiOut = YieldMath.fyDaiOutForDaiIn(
-            daiReserves,
-            fyDaiReserves,
-            daiIn,
-            toUint128(maturity - now), // This can't be called after maturity
-            k,
-            g1
-        );
+        uint128 fyDaiOut =
+            YieldMath.fyDaiOutForDaiIn(
+                daiReserves,
+                fyDaiReserves,
+                daiIn,
+                toUint128(maturity - now), // This can't be called after maturity
+                k,
+                g1
+            );
 
-        require(
-            sub(fyDaiReserves, fyDaiOut) >= add(daiReserves, daiIn),
-            "Pool: fyDai reserves too low"
-        );
+        require(sub(fyDaiReserves, fyDaiOut) >= add(daiReserves, daiIn), 'Pool: fyDai reserves too low');
 
         return fyDaiOut;
     }
@@ -215,11 +199,11 @@ contract Pool is IPool, Delegable(), ERC20Permit {
     /// @param to Wallet receiving the dai being bought
     /// @param daiOut Amount of dai being bought that will be deposited in `to` wallet
     /// @return Amount of fyDai that will be taken from `from` wallet
-    function buyDai(address from, address to, uint128 daiOut)
-        external override
-        onlyHolderOrDelegate(from, "Pool: Only Holder Or Delegate")
-        returns(uint128)
-    {
+    function buyDai(
+        address from,
+        address to,
+        uint128 daiOut
+    ) external override onlyHolderOrDelegate(from, 'Pool: Only Holder Or Delegate') returns (uint128) {
         uint128 fyDaiIn = buyDaiPreview(daiOut);
 
         fyDai.transferFrom(from, address(this), fyDaiIn);
@@ -232,19 +216,16 @@ contract Pool is IPool, Delegable(), ERC20Permit {
     /// @dev Returns how much fyDai would be required to buy `daiOut` dai.
     /// @param daiOut Amount of dai hypothetically desired.
     /// @return Amount of fyDai hypothetically required.
-    function buyDaiPreview(uint128 daiOut)
-        public view override
-        beforeMaturity
-        returns(uint128)
-    {
-        return YieldMath.fyDaiInForDaiOut(
-            getDaiReserves(),
-            getFYDaiReserves(),
-            daiOut,
-            toUint128(maturity - now), // This can't be called after maturity
-            k,
-            g2
-        );
+    function buyDaiPreview(uint128 daiOut) public view override beforeMaturity returns (uint128) {
+        return
+            YieldMath.fyDaiInForDaiOut(
+                getDaiReserves(),
+                getFYDaiReserves(),
+                daiOut,
+                toUint128(maturity - now), // This can't be called after maturity
+                k,
+                g2
+            );
     }
 
     /// @dev Sell fyDai for Dai
@@ -253,11 +234,11 @@ contract Pool is IPool, Delegable(), ERC20Permit {
     /// @param to Wallet receiving the dai being bought
     /// @param fyDaiIn Amount of fyDai being sold that will be taken from the user's wallet
     /// @return Amount of dai that will be deposited on `to` wallet
-    function sellFYDai(address from, address to, uint128 fyDaiIn)
-        external override
-        onlyHolderOrDelegate(from, "Pool: Only Holder Or Delegate")
-        returns(uint128)
-    {
+    function sellFYDai(
+        address from,
+        address to,
+        uint128 fyDaiIn
+    ) external override onlyHolderOrDelegate(from, 'Pool: Only Holder Or Delegate') returns (uint128) {
         uint128 daiOut = sellFYDaiPreview(fyDaiIn);
 
         fyDai.transferFrom(from, address(this), fyDaiIn);
@@ -270,19 +251,16 @@ contract Pool is IPool, Delegable(), ERC20Permit {
     /// @dev Returns how much dai would be obtained by selling `fyDaiIn` fyDai.
     /// @param fyDaiIn Amount of fyDai hypothetically sold.
     /// @return Amount of Dai hypothetically bought.
-    function sellFYDaiPreview(uint128 fyDaiIn)
-        public view override
-        beforeMaturity
-        returns(uint128)
-    {
-        return YieldMath.daiOutForFYDaiIn(
-            getDaiReserves(),
-            getFYDaiReserves(),
-            fyDaiIn,
-            toUint128(maturity - now), // This can't be called after maturity
-            k,
-            g2
-        );
+    function sellFYDaiPreview(uint128 fyDaiIn) public view override beforeMaturity returns (uint128) {
+        return
+            YieldMath.daiOutForFYDaiIn(
+                getDaiReserves(),
+                getFYDaiReserves(),
+                fyDaiIn,
+                toUint128(maturity - now), // This can't be called after maturity
+                k,
+                g2
+            );
     }
 
     /// @dev Buy fyDai for dai
@@ -291,11 +269,11 @@ contract Pool is IPool, Delegable(), ERC20Permit {
     /// @param to Wallet receiving the fyDai being bought
     /// @param fyDaiOut Amount of fyDai being bought that will be deposited in `to` wallet
     /// @return Amount of dai that will be taken from `from` wallet
-    function buyFYDai(address from, address to, uint128 fyDaiOut)
-        external override
-        onlyHolderOrDelegate(from, "Pool: Only Holder Or Delegate")
-        returns(uint128)
-    {
+    function buyFYDai(
+        address from,
+        address to,
+        uint128 fyDaiOut
+    ) external override onlyHolderOrDelegate(from, 'Pool: Only Holder Or Delegate') returns (uint128) {
         uint128 daiIn = buyFYDaiPreview(fyDaiOut);
 
         dai.transferFrom(from, address(this), daiIn);
@@ -305,48 +283,35 @@ contract Pool is IPool, Delegable(), ERC20Permit {
         return daiIn;
     }
 
-
     /// @dev Returns how much dai would be required to buy `fyDaiOut` fyDai.
     /// @param fyDaiOut Amount of fyDai hypothetically desired.
     /// @return Amount of Dai hypothetically required.
-    function buyFYDaiPreview(uint128 fyDaiOut)
-        public view override
-        beforeMaturity
-        returns(uint128)
-    {
+    function buyFYDaiPreview(uint128 fyDaiOut) public view override beforeMaturity returns (uint128) {
         uint128 daiReserves = getDaiReserves();
         uint128 fyDaiReserves = getFYDaiReserves();
 
-        uint128 daiIn = YieldMath.daiInForFYDaiOut(
-            daiReserves,
-            fyDaiReserves,
-            fyDaiOut,
-            toUint128(maturity - now), // This can't be called after maturity
-            k,
-            g1
-        );
+        uint128 daiIn =
+            YieldMath.daiInForFYDaiOut(
+                daiReserves,
+                fyDaiReserves,
+                fyDaiOut,
+                toUint128(maturity - now), // This can't be called after maturity
+                k,
+                g1
+            );
 
-        require(
-            sub(fyDaiReserves, fyDaiOut) >= add(daiReserves, daiIn),
-            "Pool: fyDai reserves too low"
-        );
+        require(sub(fyDaiReserves, fyDaiOut) >= add(daiReserves, daiIn), 'Pool: fyDai reserves too low');
 
         return daiIn;
     }
 
     /// @dev Returns the "virtual" fyDai reserves
-    function getFYDaiReserves()
-        public view override
-        returns(uint128)
-    {
+    function getFYDaiReserves() public view override returns (uint128) {
         return toUint128(fyDai.balanceOf(address(this)).add(totalSupply()));
     }
 
     /// @dev Returns the Dai reserves
-    function getDaiReserves()
-        public view override
-        returns(uint128)
-    {
+    function getDaiReserves() public view override returns (uint128) {
         return toUint128(dai.balanceOf(address(this)));
     }
 }

--- a/contracts/pool/YieldMath.sol
+++ b/contracts/pool/YieldMath.sol
@@ -1,277 +1,543 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.6.0;
 
-import "./Math64x64.sol";
+import './Math64x64.sol';
 
 /**
  * Ethereum smart contract library implementing Yield Math model.
  */
 library YieldMath {
-  /**
-   * Calculate the amount of fyDai a user would get for given amount of Dai.
-   *
-   * @param daiReserves Dai reserves amount
-   * @param fyDaiReserves fyDai reserves amount
-   * @param daiAmount Dai amount to be traded
-   * @param timeTillMaturity time till maturity in seconds
-   * @param k time till maturity coefficient, multiplied by 2^64
-   * @param g fee coefficient, multiplied by 2^64
-   * @return the amount of fyDai a user would get for given amount of Dai
-   */
-  function fyDaiOutForDaiIn (
-    uint128 daiReserves, uint128 fyDaiReserves, uint128 daiAmount,
-    uint128 timeTillMaturity, int128 k, int128 g)
-  internal pure returns (uint128) {
-    // t = k * timeTillMaturity
-    int128 t = Math64x64.mul (k, Math64x64.fromUInt (timeTillMaturity));
+    /**
+     * Calculate the amount of fyDai a user would get for given amount of Dai.
+     *
+     * @param daiReserves Dai reserves amount
+     * @param fyDaiReserves fyDai reserves amount
+     * @param daiAmount Dai amount to be traded
+     * @param timeTillMaturity time till maturity in seconds
+     * @param k time till maturity coefficient, multiplied by 2^64
+     * @param g fee coefficient, multiplied by 2^64
+     * @return the amount of fyDai a user would get for given amount of Dai
+     */
+    function fyDaiOutForDaiIn(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) internal pure returns (uint128) {
+        // t = k * timeTillMaturity
+        int128 t = Math64x64.mul(k, Math64x64.fromUInt(timeTillMaturity));
 
-    // a = (1 - gt)
-    int128 a = Math64x64.sub (0x10000000000000000, Math64x64.mul (g, t));
-    require (a > 0, "YieldMath: Too far from maturity");
+        // a = (1 - gt)
+        int128 a = Math64x64.sub(0x10000000000000000, Math64x64.mul(g, t));
+        require(a > 0, 'YieldMath: Too far from maturity');
 
-    // xdx = daiReserves + daiAmount
-    uint256 xdx = uint256 (daiReserves) + uint256 (daiAmount);
-    require (xdx < 0x100000000000000000000000000000000, "YieldMath: Too much Dai in");
+        // xdx = daiReserves + daiAmount
+        uint256 xdx = uint256(daiReserves) + uint256(daiAmount);
+        require(xdx < 0x100000000000000000000000000000000, 'YieldMath: Too much Dai in');
 
-    uint256 sum =
-      pow (daiReserves, uint128 (a), 0x10000000000000000) +
-      pow (fyDaiReserves, uint128 (a), 0x10000000000000000) -
-      pow (uint128(xdx), uint128 (a), 0x10000000000000000);
-    require (sum < 0x100000000000000000000000000000000, "YieldMath: Insufficient fyDai reserves");
+        uint256 sum =
+            pow(daiReserves, uint128(a), 0x10000000000000000) +
+                pow(fyDaiReserves, uint128(a), 0x10000000000000000) -
+                pow(uint128(xdx), uint128(a), 0x10000000000000000);
+        require(sum < 0x100000000000000000000000000000000, 'YieldMath: Insufficient fyDai reserves');
 
-    uint256 result = fyDaiReserves - pow (uint128 (sum), 0x10000000000000000, uint128 (a));
-    require (result < 0x100000000000000000000000000000000, "YieldMath: Rounding induced error");
-    result = result > 1e12 ? result - 1e12 : 0; // Substract error guard, flooring the result at zero
+        uint256 result = fyDaiReserves - pow(uint128(sum), 0x10000000000000000, uint128(a));
+        require(result < 0x100000000000000000000000000000000, 'YieldMath: Rounding induced error');
+        result = result > 1e12 ? result - 1e12 : 0; // Substract error guard, flooring the result at zero
 
-    return uint128 (result);
-  }
-
-  /**
-   * Calculate the amount of Dai a user would get for certain amount of fyDai.
-   *
-   * @param daiReserves Dai reserves amount
-   * @param fyDaiReserves fyDai reserves amount
-   * @param fyDaiAmount fyDai amount to be traded
-   * @param timeTillMaturity time till maturity in seconds
-   * @param k time till maturity coefficient, multiplied by 2^64
-   * @param g fee coefficient, multiplied by 2^64
-   * @return the amount of Dai a user would get for given amount of fyDai
-   */
-  function daiOutForFYDaiIn (
-    uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiAmount,
-    uint128 timeTillMaturity, int128 k, int128 g)
-  internal pure returns (uint128) {
-    // t = k * timeTillMaturity
-    int128 t = Math64x64.mul (k, Math64x64.fromUInt (timeTillMaturity));
-
-    // a = (1 - gt)
-    int128 a = Math64x64.sub (0x10000000000000000, Math64x64.mul (g, t));
-    require (a > 0, "YieldMath: Too far from maturity");
-
-    // ydy = fyDaiReserves + fyDaiAmount;
-    uint256 ydy = uint256 (fyDaiReserves) + uint256 (fyDaiAmount);
-    require (ydy < 0x100000000000000000000000000000000, "YieldMath: Too much fyDai in");
-
-    uint256 sum =
-      pow (uint128 (daiReserves), uint128 (a), 0x10000000000000000) -
-      pow (uint128 (ydy), uint128 (a), 0x10000000000000000) +
-      pow (fyDaiReserves, uint128 (a), 0x10000000000000000);
-    require (sum < 0x100000000000000000000000000000000, "YieldMath: Insufficient Dai reserves");
-
-    uint256 result =
-      daiReserves -
-      pow (uint128 (sum), 0x10000000000000000, uint128 (a));
-    require (result < 0x100000000000000000000000000000000, "YieldMath: Rounding induced error");
-    result = result > 1e12 ? result - 1e12 : 0; // Substract error guard, flooring the result at zero
-
-    return uint128 (result);
-  }
-
-  /**
-   * Calculate the amount of fyDai a user could sell for given amount of Dai.
-   *
-   * @param daiReserves Dai reserves amount
-   * @param fyDaiReserves fyDai reserves amount
-   * @param daiAmount Dai amount to be traded
-   * @param timeTillMaturity time till maturity in seconds
-   * @param k time till maturity coefficient, multiplied by 2^64
-   * @param g fee coefficient, multiplied by 2^64
-   * @return the amount of fyDai a user could sell for given amount of Dai
-   */
-  function fyDaiInForDaiOut (
-    uint128 daiReserves, uint128 fyDaiReserves, uint128 daiAmount,
-    uint128 timeTillMaturity, int128 k, int128 g)
-  internal pure returns (uint128) {
-    // t = k * timeTillMaturity
-    int128 t = Math64x64.mul (k, Math64x64.fromUInt (timeTillMaturity));
-
-    // a = (1 - gt)
-    int128 a = Math64x64.sub (0x10000000000000000, Math64x64.mul (g, t));
-    require (a > 0, "YieldMath: Too far from maturity");
-
-    // xdx = daiReserves - daiAmount
-    uint256 xdx = uint256 (daiReserves) - uint256 (daiAmount);
-    require (xdx < 0x100000000000000000000000000000000, "YieldMath: Too much Dai out");
-
-    uint256 sum =
-      pow (uint128 (daiReserves), uint128 (a), 0x10000000000000000) +
-      pow (fyDaiReserves, uint128 (a), 0x10000000000000000) -
-      pow (uint128 (xdx), uint128 (a), 0x10000000000000000);
-    require (sum < 0x100000000000000000000000000000000, "YieldMath: Resulting fyDai reserves too high");
-
-    uint256 result = pow (uint128 (sum), 0x10000000000000000, uint128 (a)) - fyDaiReserves;
-    require (result < 0x100000000000000000000000000000000, "YieldMath: Rounding induced error");
-    result = result < type(uint128).max - 1e12 ? result + 1e12 : type(uint128).max; // Add error guard, ceiling the result at max
-
-    return uint128 (result);
-  }
-
-  /**
-   * Calculate the amount of Dai a user would have to pay for certain amount of
-   * fyDai.
-   *
-   * @param daiReserves Dai reserves amount
-   * @param fyDaiReserves fyDai reserves amount
-   * @param fyDaiAmount fyDai amount to be traded
-   * @param timeTillMaturity time till maturity in seconds
-   * @param k time till maturity coefficient, multiplied by 2^64
-   * @param g fee coefficient, multiplied by 2^64
-   * @return the amount of Dai a user would have to pay for given amount of
-   *         fyDai
-   */
-  function daiInForFYDaiOut (
-    uint128 daiReserves, uint128 fyDaiReserves, uint128 fyDaiAmount,
-    uint128 timeTillMaturity, int128 k, int128 g)
-  internal pure returns (uint128) {
-    // a = (1 - g * k * timeTillMaturity)
-    int128 a = Math64x64.sub (0x10000000000000000, Math64x64.mul (g, Math64x64.mul (k, Math64x64.fromUInt (timeTillMaturity))));
-    require (a > 0, "YieldMath: Too far from maturity");
-
-    // ydy = fyDaiReserves - fyDaiAmount;
-    uint256 ydy = uint256 (fyDaiReserves) - uint256 (fyDaiAmount);
-    require (ydy < 0x100000000000000000000000000000000, "YieldMath: Too much fyDai out");
-
-    uint256 sum =
-      pow (daiReserves, uint128 (a), 0x10000000000000000) +
-      pow (fyDaiReserves, uint128 (a), 0x10000000000000000) -
-      pow (uint128 (ydy), uint128 (a), 0x10000000000000000);
-    require (sum < 0x100000000000000000000000000000000, "YieldMath: Resulting Dai reserves too high");
-
-    uint256 result =
-      pow (uint128 (sum), 0x10000000000000000, uint128 (a)) -
-      daiReserves;
-    require (result < 0x100000000000000000000000000000000, "YieldMath: Rounding induced error");
-    result = result < type(uint128).max - 1e12 ? result + 1e12 : type(uint128).max; // Add error guard, ceiling the result at max
-    
-    return uint128 (result);
-  }
-
-  /**
-   * Raise given number x into power specified as a simple fraction y/z and then
-   * multiply the result by the normalization factor 2^(128 * (1 - y/z)).
-   * Revert if z is zero, or if both x and y are zeros.
-   *
-   * @param x number to raise into given power y/z
-   * @param y numerator of the power to raise x into
-   * @param z denominator of the power to raise x into
-   * @return x raised into power y/z and then multiplied by 2^(128 * (1 - y/z))
-   */
-  function pow (uint128 x, uint128 y, uint128 z)
-  internal pure returns (uint256) {
-    require (z != 0);
-
-    if (x == 0) {
-      require (y != 0);
-      return 0;
-    } else {
-      uint256 l =
-        uint256 (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF - log_2 (x)) * y / z;
-      if (l > 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) return 0;
-      else return uint256 (pow_2 (uint128 (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF - l)));
+        return uint128(result);
     }
-  }
 
-  /**
-   * Calculate base 2 logarithm of an unsigned 128-bit integer number.  Revert
-   * in case x is zero.
-   *
-   * @param x number to calculate base 2 logarithm of
-   * @return base 2 logarithm of x, multiplied by 2^121
-   */
-  function log_2 (uint128 x)
-  internal pure returns (uint128) {
-    require (x != 0);
+    /**
+     * Calculate the amount of Dai a user would get for certain amount of fyDai.
+     *
+     * @param daiReserves Dai reserves amount
+     * @param fyDaiReserves fyDai reserves amount
+     * @param fyDaiAmount fyDai amount to be traded
+     * @param timeTillMaturity time till maturity in seconds
+     * @param k time till maturity coefficient, multiplied by 2^64
+     * @param g fee coefficient, multiplied by 2^64
+     * @return the amount of Dai a user would get for given amount of fyDai
+     */
+    function daiOutForFYDaiIn(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) internal pure returns (uint128) {
+        // t = k * timeTillMaturity
+        int128 t = Math64x64.mul(k, Math64x64.fromUInt(timeTillMaturity));
 
-    uint b = x;
+        // a = (1 - gt)
+        int128 a = Math64x64.sub(0x10000000000000000, Math64x64.mul(g, t));
+        require(a > 0, 'YieldMath: Too far from maturity');
 
-    uint l = 0xFE000000000000000000000000000000;
+        // ydy = fyDaiReserves + fyDaiAmount;
+        uint256 ydy = uint256(fyDaiReserves) + uint256(fyDaiAmount);
+        require(ydy < 0x100000000000000000000000000000000, 'YieldMath: Too much fyDai in');
 
-    if (b < 0x10000000000000000) {l -= 0x80000000000000000000000000000000; b <<= 64;}
-    if (b < 0x1000000000000000000000000) {l -= 0x40000000000000000000000000000000; b <<= 32;}
-    if (b < 0x10000000000000000000000000000) {l -= 0x20000000000000000000000000000000; b <<= 16;}
-    if (b < 0x1000000000000000000000000000000) {l -= 0x10000000000000000000000000000000; b <<= 8;}
-    if (b < 0x10000000000000000000000000000000) {l -= 0x8000000000000000000000000000000; b <<= 4;}
-    if (b < 0x40000000000000000000000000000000) {l -= 0x4000000000000000000000000000000; b <<= 2;}
-    if (b < 0x80000000000000000000000000000000) {l -= 0x2000000000000000000000000000000; b <<= 1;}
+        uint256 sum =
+            pow(uint128(daiReserves), uint128(a), 0x10000000000000000) -
+                pow(uint128(ydy), uint128(a), 0x10000000000000000) +
+                pow(fyDaiReserves, uint128(a), 0x10000000000000000);
+        require(sum < 0x100000000000000000000000000000000, 'YieldMath: Insufficient Dai reserves');
 
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x1000000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x800000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x400000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x200000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x100000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x80000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x40000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x20000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x10000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x8000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x4000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x2000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x1000000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x800000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x400000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x200000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x100000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x80000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x40000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x20000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x10000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x8000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x4000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x2000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x1000000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x800000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x400000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x200000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x100000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x80000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x40000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x20000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x10000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x8000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x4000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x2000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x1000000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x800000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x400000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x200000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x100000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x80000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x40000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x20000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x10000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x8000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x4000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x2000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x1000000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x800000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x400000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x200000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x100000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x80000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x40000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x20000000000000000;}
-    b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x10000000000000000;}
-    /* Precision reduced to 64 bits
+        uint256 result = daiReserves - pow(uint128(sum), 0x10000000000000000, uint128(a));
+        require(result < 0x100000000000000000000000000000000, 'YieldMath: Rounding induced error');
+        result = result > 1e12 ? result - 1e12 : 0; // Substract error guard, flooring the result at zero
+
+        return uint128(result);
+    }
+
+    /**
+     * Calculate the amount of fyDai a user could sell for given amount of Dai.
+     *
+     * @param daiReserves Dai reserves amount
+     * @param fyDaiReserves fyDai reserves amount
+     * @param daiAmount Dai amount to be traded
+     * @param timeTillMaturity time till maturity in seconds
+     * @param k time till maturity coefficient, multiplied by 2^64
+     * @param g fee coefficient, multiplied by 2^64
+     * @return the amount of fyDai a user could sell for given amount of Dai
+     */
+    function fyDaiInForDaiOut(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 daiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) internal pure returns (uint128) {
+        // t = k * timeTillMaturity
+        int128 t = Math64x64.mul(k, Math64x64.fromUInt(timeTillMaturity));
+
+        // a = (1 - gt)
+        int128 a = Math64x64.sub(0x10000000000000000, Math64x64.mul(g, t));
+        require(a > 0, 'YieldMath: Too far from maturity');
+
+        // xdx = daiReserves - daiAmount
+        uint256 xdx = uint256(daiReserves) - uint256(daiAmount);
+        require(xdx < 0x100000000000000000000000000000000, 'YieldMath: Too much Dai out');
+
+        uint256 sum =
+            pow(uint128(daiReserves), uint128(a), 0x10000000000000000) +
+                pow(fyDaiReserves, uint128(a), 0x10000000000000000) -
+                pow(uint128(xdx), uint128(a), 0x10000000000000000);
+        require(sum < 0x100000000000000000000000000000000, 'YieldMath: Resulting fyDai reserves too high');
+
+        uint256 result = pow(uint128(sum), 0x10000000000000000, uint128(a)) - fyDaiReserves;
+        require(result < 0x100000000000000000000000000000000, 'YieldMath: Rounding induced error');
+        result = result < type(uint128).max - 1e12 ? result + 1e12 : type(uint128).max; // Add error guard, ceiling the result at max
+
+        return uint128(result);
+    }
+
+    /**
+     * Calculate the amount of Dai a user would have to pay for certain amount of
+     * fyDai.
+     *
+     * @param daiReserves Dai reserves amount
+     * @param fyDaiReserves fyDai reserves amount
+     * @param fyDaiAmount fyDai amount to be traded
+     * @param timeTillMaturity time till maturity in seconds
+     * @param k time till maturity coefficient, multiplied by 2^64
+     * @param g fee coefficient, multiplied by 2^64
+     * @return the amount of Dai a user would have to pay for given amount of
+     *         fyDai
+     */
+    function daiInForFYDaiOut(
+        uint128 daiReserves,
+        uint128 fyDaiReserves,
+        uint128 fyDaiAmount,
+        uint128 timeTillMaturity,
+        int128 k,
+        int128 g
+    ) internal pure returns (uint128) {
+        // a = (1 - g * k * timeTillMaturity)
+        int128 a =
+            Math64x64.sub(
+                0x10000000000000000,
+                Math64x64.mul(g, Math64x64.mul(k, Math64x64.fromUInt(timeTillMaturity)))
+            );
+        require(a > 0, 'YieldMath: Too far from maturity');
+
+        // ydy = fyDaiReserves - fyDaiAmount;
+        uint256 ydy = uint256(fyDaiReserves) - uint256(fyDaiAmount);
+        require(ydy < 0x100000000000000000000000000000000, 'YieldMath: Too much fyDai out');
+
+        uint256 sum =
+            pow(daiReserves, uint128(a), 0x10000000000000000) +
+                pow(fyDaiReserves, uint128(a), 0x10000000000000000) -
+                pow(uint128(ydy), uint128(a), 0x10000000000000000);
+        require(sum < 0x100000000000000000000000000000000, 'YieldMath: Resulting Dai reserves too high');
+
+        uint256 result = pow(uint128(sum), 0x10000000000000000, uint128(a)) - daiReserves;
+        require(result < 0x100000000000000000000000000000000, 'YieldMath: Rounding induced error');
+        result = result < type(uint128).max - 1e12 ? result + 1e12 : type(uint128).max; // Add error guard, ceiling the result at max
+
+        return uint128(result);
+    }
+
+    /**
+     * Raise given number x into power specified as a simple fraction y/z and then
+     * multiply the result by the normalization factor 2^(128 * (1 - y/z)).
+     * Revert if z is zero, or if both x and y are zeros.
+     *
+     * @param x number to raise into given power y/z
+     * @param y numerator of the power to raise x into
+     * @param z denominator of the power to raise x into
+     * @return x raised into power y/z and then multiplied by 2^(128 * (1 - y/z))
+     */
+    function pow(
+        uint128 x,
+        uint128 y,
+        uint128 z
+    ) internal pure returns (uint256) {
+        require(z != 0);
+
+        if (x == 0) {
+            require(y != 0);
+            return 0;
+        } else {
+            uint256 l = (uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF - log_2(x)) * y) / z;
+            if (l > 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) return 0;
+            else return uint256(pow_2(uint128(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF - l)));
+        }
+    }
+
+    /**
+     * Calculate base 2 logarithm of an unsigned 128-bit integer number.  Revert
+     * in case x is zero.
+     *
+     * @param x number to calculate base 2 logarithm of
+     * @return base 2 logarithm of x, multiplied by 2^121
+     */
+    function log_2(uint128 x) internal pure returns (uint128) {
+        require(x != 0);
+
+        uint256 b = x;
+
+        uint256 l = 0xFE000000000000000000000000000000;
+
+        if (b < 0x10000000000000000) {
+            l -= 0x80000000000000000000000000000000;
+            b <<= 64;
+        }
+        if (b < 0x1000000000000000000000000) {
+            l -= 0x40000000000000000000000000000000;
+            b <<= 32;
+        }
+        if (b < 0x10000000000000000000000000000) {
+            l -= 0x20000000000000000000000000000000;
+            b <<= 16;
+        }
+        if (b < 0x1000000000000000000000000000000) {
+            l -= 0x10000000000000000000000000000000;
+            b <<= 8;
+        }
+        if (b < 0x10000000000000000000000000000000) {
+            l -= 0x8000000000000000000000000000000;
+            b <<= 4;
+        }
+        if (b < 0x40000000000000000000000000000000) {
+            l -= 0x4000000000000000000000000000000;
+            b <<= 2;
+        }
+        if (b < 0x80000000000000000000000000000000) {
+            l -= 0x2000000000000000000000000000000;
+            b <<= 1;
+        }
+
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x1000000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x800000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x400000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x200000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x100000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x80000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x40000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x20000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x10000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x8000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x4000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x2000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x1000000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x800000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x400000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x200000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x100000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x80000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x40000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x20000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x10000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x8000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x4000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x2000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x1000000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x800000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x400000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x200000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x100000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x80000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x40000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x20000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x10000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x8000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x4000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x2000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x1000000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x800000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x400000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x200000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x100000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x80000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x40000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x20000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x10000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x8000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x4000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x2000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x1000000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x800000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x400000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x200000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x100000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x80000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x40000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x20000000000000000;
+        }
+        b = (b * b) >> 127;
+        if (b >= 0x100000000000000000000000000000000) {
+            b >>= 1;
+            l |= 0x10000000000000000;
+        }
+        /* Precision reduced to 64 bits
     b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x8000000000000000;}
     b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x4000000000000000;}
     b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) {b >>= 1; l |= 0x2000000000000000;}
@@ -338,76 +604,75 @@ library YieldMath {
     b = b * b >> 127; if (b >= 0x100000000000000000000000000000000) l |= 0x1;
     */
 
-    return uint128 (l);
-  }
+        return uint128(l);
+    }
 
-  /**
-   * Calculate 2 raised into given power.
-   *
-   * @param x power to raise 2 into, multiplied by 2^121
-   * @return 2 raised into given power
-   */
-  function pow_2 (uint128 x)
-  internal pure returns (uint128) {
-    uint r = 0x80000000000000000000000000000000;
-    if (x & 0x1000000000000000000000000000000 > 0) r = r * 0xb504f333f9de6484597d89b3754abe9f >> 127;
-    if (x & 0x800000000000000000000000000000 > 0) r = r * 0x9837f0518db8a96f46ad23182e42f6f6 >> 127;
-    if (x & 0x400000000000000000000000000000 > 0) r = r * 0x8b95c1e3ea8bd6e6fbe4628758a53c90 >> 127;
-    if (x & 0x200000000000000000000000000000 > 0) r = r * 0x85aac367cc487b14c5c95b8c2154c1b2 >> 127;
-    if (x & 0x100000000000000000000000000000 > 0) r = r * 0x82cd8698ac2ba1d73e2a475b46520bff >> 127;
-    if (x & 0x80000000000000000000000000000 > 0) r = r * 0x8164d1f3bc0307737be56527bd14def4 >> 127;
-    if (x & 0x40000000000000000000000000000 > 0) r = r * 0x80b1ed4fd999ab6c25335719b6e6fd20 >> 127;
-    if (x & 0x20000000000000000000000000000 > 0) r = r * 0x8058d7d2d5e5f6b094d589f608ee4aa2 >> 127;
-    if (x & 0x10000000000000000000000000000 > 0) r = r * 0x802c6436d0e04f50ff8ce94a6797b3ce >> 127;
-    if (x & 0x8000000000000000000000000000 > 0) r = r * 0x8016302f174676283690dfe44d11d008 >> 127;
-    if (x & 0x4000000000000000000000000000 > 0) r = r * 0x800b179c82028fd0945e54e2ae18f2f0 >> 127;
-    if (x & 0x2000000000000000000000000000 > 0) r = r * 0x80058baf7fee3b5d1c718b38e549cb93 >> 127;
-    if (x & 0x1000000000000000000000000000 > 0) r = r * 0x8002c5d00fdcfcb6b6566a58c048be1f >> 127;
-    if (x & 0x800000000000000000000000000 > 0) r = r * 0x800162e61bed4a48e84c2e1a463473d9 >> 127;
-    if (x & 0x400000000000000000000000000 > 0) r = r * 0x8000b17292f702a3aa22beacca949013 >> 127;
-    if (x & 0x200000000000000000000000000 > 0) r = r * 0x800058b92abbae02030c5fa5256f41fe >> 127;
-    if (x & 0x100000000000000000000000000 > 0) r = r * 0x80002c5c8dade4d71776c0f4dbea67d6 >> 127;
-    if (x & 0x80000000000000000000000000 > 0) r = r * 0x8000162e44eaf636526be456600bdbe4 >> 127;
-    if (x & 0x40000000000000000000000000 > 0) r = r * 0x80000b1721fa7c188307016c1cd4e8b6 >> 127;
-    if (x & 0x20000000000000000000000000 > 0) r = r * 0x8000058b90de7e4cecfc487503488bb1 >> 127;
-    if (x & 0x10000000000000000000000000 > 0) r = r * 0x800002c5c8678f36cbfce50a6de60b14 >> 127;
-    if (x & 0x8000000000000000000000000 > 0) r = r * 0x80000162e431db9f80b2347b5d62e516 >> 127;
-    if (x & 0x4000000000000000000000000 > 0) r = r * 0x800000b1721872d0c7b08cf1e0114152 >> 127;
-    if (x & 0x2000000000000000000000000 > 0) r = r * 0x80000058b90c1aa8a5c3736cb77e8dff >> 127;
-    if (x & 0x1000000000000000000000000 > 0) r = r * 0x8000002c5c8605a4635f2efc2362d978 >> 127;
-    if (x & 0x800000000000000000000000 > 0) r = r * 0x800000162e4300e635cf4a109e3939bd >> 127;
-    if (x & 0x400000000000000000000000 > 0) r = r * 0x8000000b17217ff81bef9c551590cf83 >> 127;
-    if (x & 0x200000000000000000000000 > 0) r = r * 0x800000058b90bfdd4e39cd52c0cfa27c >> 127;
-    if (x & 0x100000000000000000000000 > 0) r = r * 0x80000002c5c85fe6f72d669e0e76e411 >> 127;
-    if (x & 0x80000000000000000000000 > 0) r = r * 0x8000000162e42ff18f9ad35186d0df28 >> 127;
-    if (x & 0x40000000000000000000000 > 0) r = r * 0x80000000b17217f84cce71aa0dcfffe7 >> 127;
-    if (x & 0x20000000000000000000000 > 0) r = r * 0x8000000058b90bfc07a77ad56ed22aaa >> 127;
-    if (x & 0x10000000000000000000000 > 0) r = r * 0x800000002c5c85fdfc23cdead40da8d6 >> 127;
-    if (x & 0x8000000000000000000000 > 0) r = r * 0x80000000162e42fefc25eb1571853a66 >> 127;
-    if (x & 0x4000000000000000000000 > 0) r = r * 0x800000000b17217f7d97f692baacded5 >> 127;
-    if (x & 0x2000000000000000000000 > 0) r = r * 0x80000000058b90bfbead3b8b5dd254d7 >> 127;
-    if (x & 0x1000000000000000000000 > 0) r = r * 0x8000000002c5c85fdf4eedd62f084e67 >> 127;
-    if (x & 0x800000000000000000000 > 0) r = r * 0x800000000162e42fefa58aef378bf586 >> 127;
-    if (x & 0x400000000000000000000 > 0) r = r * 0x8000000000b17217f7d24a78a3c7ef02 >> 127;
-    if (x & 0x200000000000000000000 > 0) r = r * 0x800000000058b90bfbe9067c93e474a6 >> 127;
-    if (x & 0x100000000000000000000 > 0) r = r * 0x80000000002c5c85fdf47b8e5a72599f >> 127;
-    if (x & 0x80000000000000000000 > 0) r = r * 0x8000000000162e42fefa3bdb315934a2 >> 127;
-    if (x & 0x40000000000000000000 > 0) r = r * 0x80000000000b17217f7d1d7299b49c46 >> 127;
-    if (x & 0x20000000000000000000 > 0) r = r * 0x8000000000058b90bfbe8e9a8d1c4ea0 >> 127;
-    if (x & 0x10000000000000000000 > 0) r = r * 0x800000000002c5c85fdf4745969ea76f >> 127;
-    if (x & 0x8000000000000000000 > 0) r = r * 0x80000000000162e42fefa3a0df5373bf >> 127;
-    if (x & 0x4000000000000000000 > 0) r = r * 0x800000000000b17217f7d1cff4aac1e1 >> 127;
-    if (x & 0x2000000000000000000 > 0) r = r * 0x80000000000058b90bfbe8e7db95a2f1 >> 127;
-    if (x & 0x1000000000000000000 > 0) r = r * 0x8000000000002c5c85fdf473e61ae1f8 >> 127;
-    if (x & 0x800000000000000000 > 0) r = r * 0x800000000000162e42fefa39f121751c >> 127;
-    if (x & 0x400000000000000000 > 0) r = r * 0x8000000000000b17217f7d1cf815bb96 >> 127;
-    if (x & 0x200000000000000000 > 0) r = r * 0x800000000000058b90bfbe8e7bec1e0d >> 127;
-    if (x & 0x100000000000000000 > 0) r = r * 0x80000000000002c5c85fdf473dee5f17 >> 127;
-    if (x & 0x80000000000000000 > 0) r = r * 0x8000000000000162e42fefa39ef5438f >> 127;
-    if (x & 0x40000000000000000 > 0) r = r * 0x80000000000000b17217f7d1cf7a26c8 >> 127;
-    if (x & 0x20000000000000000 > 0) r = r * 0x8000000000000058b90bfbe8e7bcf4a4 >> 127;
-    if (x & 0x10000000000000000 > 0) r = r * 0x800000000000002c5c85fdf473de72a2 >> 127;
-    /* Precision reduced to 64 bits
+    /**
+     * Calculate 2 raised into given power.
+     *
+     * @param x power to raise 2 into, multiplied by 2^121
+     * @return 2 raised into given power
+     */
+    function pow_2(uint128 x) internal pure returns (uint128) {
+        uint256 r = 0x80000000000000000000000000000000;
+        if (x & 0x1000000000000000000000000000000 > 0) r = (r * 0xb504f333f9de6484597d89b3754abe9f) >> 127;
+        if (x & 0x800000000000000000000000000000 > 0) r = (r * 0x9837f0518db8a96f46ad23182e42f6f6) >> 127;
+        if (x & 0x400000000000000000000000000000 > 0) r = (r * 0x8b95c1e3ea8bd6e6fbe4628758a53c90) >> 127;
+        if (x & 0x200000000000000000000000000000 > 0) r = (r * 0x85aac367cc487b14c5c95b8c2154c1b2) >> 127;
+        if (x & 0x100000000000000000000000000000 > 0) r = (r * 0x82cd8698ac2ba1d73e2a475b46520bff) >> 127;
+        if (x & 0x80000000000000000000000000000 > 0) r = (r * 0x8164d1f3bc0307737be56527bd14def4) >> 127;
+        if (x & 0x40000000000000000000000000000 > 0) r = (r * 0x80b1ed4fd999ab6c25335719b6e6fd20) >> 127;
+        if (x & 0x20000000000000000000000000000 > 0) r = (r * 0x8058d7d2d5e5f6b094d589f608ee4aa2) >> 127;
+        if (x & 0x10000000000000000000000000000 > 0) r = (r * 0x802c6436d0e04f50ff8ce94a6797b3ce) >> 127;
+        if (x & 0x8000000000000000000000000000 > 0) r = (r * 0x8016302f174676283690dfe44d11d008) >> 127;
+        if (x & 0x4000000000000000000000000000 > 0) r = (r * 0x800b179c82028fd0945e54e2ae18f2f0) >> 127;
+        if (x & 0x2000000000000000000000000000 > 0) r = (r * 0x80058baf7fee3b5d1c718b38e549cb93) >> 127;
+        if (x & 0x1000000000000000000000000000 > 0) r = (r * 0x8002c5d00fdcfcb6b6566a58c048be1f) >> 127;
+        if (x & 0x800000000000000000000000000 > 0) r = (r * 0x800162e61bed4a48e84c2e1a463473d9) >> 127;
+        if (x & 0x400000000000000000000000000 > 0) r = (r * 0x8000b17292f702a3aa22beacca949013) >> 127;
+        if (x & 0x200000000000000000000000000 > 0) r = (r * 0x800058b92abbae02030c5fa5256f41fe) >> 127;
+        if (x & 0x100000000000000000000000000 > 0) r = (r * 0x80002c5c8dade4d71776c0f4dbea67d6) >> 127;
+        if (x & 0x80000000000000000000000000 > 0) r = (r * 0x8000162e44eaf636526be456600bdbe4) >> 127;
+        if (x & 0x40000000000000000000000000 > 0) r = (r * 0x80000b1721fa7c188307016c1cd4e8b6) >> 127;
+        if (x & 0x20000000000000000000000000 > 0) r = (r * 0x8000058b90de7e4cecfc487503488bb1) >> 127;
+        if (x & 0x10000000000000000000000000 > 0) r = (r * 0x800002c5c8678f36cbfce50a6de60b14) >> 127;
+        if (x & 0x8000000000000000000000000 > 0) r = (r * 0x80000162e431db9f80b2347b5d62e516) >> 127;
+        if (x & 0x4000000000000000000000000 > 0) r = (r * 0x800000b1721872d0c7b08cf1e0114152) >> 127;
+        if (x & 0x2000000000000000000000000 > 0) r = (r * 0x80000058b90c1aa8a5c3736cb77e8dff) >> 127;
+        if (x & 0x1000000000000000000000000 > 0) r = (r * 0x8000002c5c8605a4635f2efc2362d978) >> 127;
+        if (x & 0x800000000000000000000000 > 0) r = (r * 0x800000162e4300e635cf4a109e3939bd) >> 127;
+        if (x & 0x400000000000000000000000 > 0) r = (r * 0x8000000b17217ff81bef9c551590cf83) >> 127;
+        if (x & 0x200000000000000000000000 > 0) r = (r * 0x800000058b90bfdd4e39cd52c0cfa27c) >> 127;
+        if (x & 0x100000000000000000000000 > 0) r = (r * 0x80000002c5c85fe6f72d669e0e76e411) >> 127;
+        if (x & 0x80000000000000000000000 > 0) r = (r * 0x8000000162e42ff18f9ad35186d0df28) >> 127;
+        if (x & 0x40000000000000000000000 > 0) r = (r * 0x80000000b17217f84cce71aa0dcfffe7) >> 127;
+        if (x & 0x20000000000000000000000 > 0) r = (r * 0x8000000058b90bfc07a77ad56ed22aaa) >> 127;
+        if (x & 0x10000000000000000000000 > 0) r = (r * 0x800000002c5c85fdfc23cdead40da8d6) >> 127;
+        if (x & 0x8000000000000000000000 > 0) r = (r * 0x80000000162e42fefc25eb1571853a66) >> 127;
+        if (x & 0x4000000000000000000000 > 0) r = (r * 0x800000000b17217f7d97f692baacded5) >> 127;
+        if (x & 0x2000000000000000000000 > 0) r = (r * 0x80000000058b90bfbead3b8b5dd254d7) >> 127;
+        if (x & 0x1000000000000000000000 > 0) r = (r * 0x8000000002c5c85fdf4eedd62f084e67) >> 127;
+        if (x & 0x800000000000000000000 > 0) r = (r * 0x800000000162e42fefa58aef378bf586) >> 127;
+        if (x & 0x400000000000000000000 > 0) r = (r * 0x8000000000b17217f7d24a78a3c7ef02) >> 127;
+        if (x & 0x200000000000000000000 > 0) r = (r * 0x800000000058b90bfbe9067c93e474a6) >> 127;
+        if (x & 0x100000000000000000000 > 0) r = (r * 0x80000000002c5c85fdf47b8e5a72599f) >> 127;
+        if (x & 0x80000000000000000000 > 0) r = (r * 0x8000000000162e42fefa3bdb315934a2) >> 127;
+        if (x & 0x40000000000000000000 > 0) r = (r * 0x80000000000b17217f7d1d7299b49c46) >> 127;
+        if (x & 0x20000000000000000000 > 0) r = (r * 0x8000000000058b90bfbe8e9a8d1c4ea0) >> 127;
+        if (x & 0x10000000000000000000 > 0) r = (r * 0x800000000002c5c85fdf4745969ea76f) >> 127;
+        if (x & 0x8000000000000000000 > 0) r = (r * 0x80000000000162e42fefa3a0df5373bf) >> 127;
+        if (x & 0x4000000000000000000 > 0) r = (r * 0x800000000000b17217f7d1cff4aac1e1) >> 127;
+        if (x & 0x2000000000000000000 > 0) r = (r * 0x80000000000058b90bfbe8e7db95a2f1) >> 127;
+        if (x & 0x1000000000000000000 > 0) r = (r * 0x8000000000002c5c85fdf473e61ae1f8) >> 127;
+        if (x & 0x800000000000000000 > 0) r = (r * 0x800000000000162e42fefa39f121751c) >> 127;
+        if (x & 0x400000000000000000 > 0) r = (r * 0x8000000000000b17217f7d1cf815bb96) >> 127;
+        if (x & 0x200000000000000000 > 0) r = (r * 0x800000000000058b90bfbe8e7bec1e0d) >> 127;
+        if (x & 0x100000000000000000 > 0) r = (r * 0x80000000000002c5c85fdf473dee5f17) >> 127;
+        if (x & 0x80000000000000000 > 0) r = (r * 0x8000000000000162e42fefa39ef5438f) >> 127;
+        if (x & 0x40000000000000000 > 0) r = (r * 0x80000000000000b17217f7d1cf7a26c8) >> 127;
+        if (x & 0x20000000000000000 > 0) r = (r * 0x8000000000000058b90bfbe8e7bcf4a4) >> 127;
+        if (x & 0x10000000000000000 > 0) r = (r * 0x800000000000002c5c85fdf473de72a2) >> 127;
+        /* Precision reduced to 64 bits
     if (x & 0x8000000000000000 > 0) r = r * 0x80000000000000162e42fefa39ef3765 >> 127;
     if (x & 0x4000000000000000 > 0) r = r * 0x800000000000000b17217f7d1cf79b37 >> 127;
     if (x & 0x2000000000000000 > 0) r = r * 0x80000000000000058b90bfbe8e7bcd7d >> 127;
@@ -474,8 +739,8 @@ library YieldMath {
     if (x & 0x1 > 0) r = r * 0x8000000000000000000000000000002c >> 127;
     */
 
-    r >>= 127 - (x >> 121);
+        r >>= 127 - (x >> 121);
 
-    return uint128 (r);
-  }
+        return uint128(r);
+    }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "coverage": "buidler coverage --network coverage --temp build --testfiles 'test/*.ts test/pool/*.ts test/peripheral/*.ts'",
     "lint": "prettier ./test/**/*.ts --check",
     "lint:ts": "prettier ./test/**/*.ts --write",
-    "lint:sol": "solhint -f table contracts/**/*.sol"
+    "lint:sol": "solhint -f table contracts/**/*.sol",
+    "prettier:sol": "prettier --write contracts/**/*.sol"
   },
   "devDependencies": {
     "@nomiclabs/buidler": "^1.3.8",
@@ -31,7 +32,9 @@
     "ganache-time-traveler": "^1.0.14",
     "mocha": "^7.1.0",
     "prettier": "^2.0.5",
+    "prettier-plugin-solidity": "^1.0.0-alpha.60",
     "solhint": "^3.2.0",
+    "solhint-plugin-prettier": "^0.0.5",
     "solidity-coverage": "^0.7.9",
     "truffle": "^5.1.39",
     "truffle-flattener": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -620,6 +620,13 @@
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.8.1.tgz#1b606578af86b9ad10755409804a6ba83f9ce8a4"
   integrity sha512-DF7H6T8I4lo2IZOE2NZwt3631T8j1gjpQLjmvY2xBNK50c4ltslR4XPKwT6RkeSd4+xCAK0GHC/k7sbRDBE4Yw==
 
+"@solidity-parser/parser@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.9.0.tgz#1f9aedd25bf87983a02d95458c673c017a8857af"
+  integrity sha512-u1WzZgzOBFsGAcUhyj8DN/kop1SvrsaRT2ZVvDpVYnFI86YwbLrXCTGxefJzYGnA5Vajbbhi4aRtlxxFh69dfA==
+  dependencies:
+    antlr4 "^4.8.0"
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -1044,6 +1051,11 @@ ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -1055,6 +1067,11 @@ antlr4@4.7.1:
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/antlr4/-/antlr4-4.7.1.tgz#69984014f096e9e775f53dd9744bf994d8959773"
   integrity sha512-haHyTW7Y9joE5MVs37P2lNYfU2RWBLfcRDD8OWldcdZm5TiCE91B5Xl1oWSwiDUSd4rlExpt2pu1fksYQjRBYQ==
+
+antlr4@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/antlr4/-/antlr4-4.8.0.tgz#f938ec171be7fc2855cd3a533e87647185b32b6a"
+  integrity sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg==
 
 any-promise@1.3.0, any-promise@^1.3.0:
   version "1.3.0"
@@ -2138,6 +2155,11 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+dir-to-object@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dir-to-object/-/dir-to-object-2.0.0.tgz#29723e9bd1c3e58e4f307bd04ff634c0370c8f8a"
+  integrity sha512-sXs0JKIhymON7T1UZuO2Ud6VTNAx/VTBXIl4+3mjb2RgfOpt+hectX0x04YqPOPdkeOAKoJuKqwqnXXURNPNEA==
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -2235,6 +2257,16 @@ emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^9.0.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.0.tgz#a26da8e832b16a9753309f25e35e3c0efb9a066a"
+  integrity sha512-DNc3KFPK18bPdElMJnf/Pkv5TXhxFU3YFDEuGLDRtPmV4rkmCjBkCSEp22u6rBHdSN9Vlp/GK7k98prmE1Jgug==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -2367,6 +2399,11 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
 escodegen@1.8.x:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.8.1.tgz#5a5b53af4693110bebb0867aa3430dd3b70a1018"
@@ -2449,6 +2486,13 @@ espree@^5.0.1:
     acorn "^6.0.7"
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
+
+esprima-extract-comments@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/esprima-extract-comments/-/esprima-extract-comments-1.1.0.tgz#0dacab567a5900240de6d344cf18c33617becbc9"
+  integrity sha512-sBQUnvJwpeE9QnPrxh7dpI/dp67erYG4WXEAreAMoelPRpMR7NWb4YtwRPn9b+H1uLQKl/qS8WYmyaljTpjIsw==
+  dependencies:
+    esprima "^4.0.0"
 
 esprima@2.7.x, esprima@^2.7.1:
   version "2.7.3"
@@ -3127,6 +3171,14 @@ external-editor@^3.0.3:
     chardet "^0.7.0"
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
+
+extract-comments@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/extract-comments/-/extract-comments-1.1.0.tgz#b90bca033a056bd69b8ba1c6b6b120fc2ee95c18"
+  integrity sha512-dzbZV2AdSSVW/4E7Ti5hZdHWbA+Z80RJsJhr5uiL10oyjl/gy7/o+HI1HwK4/WSZhlq4SNKU3oUzXlM13Qx02Q==
+  dependencies:
+    esprima-extract-comments "^1.1.0"
+    parse-code-context "^1.0.0"
 
 extsprintf@1.3.0:
   version "1.3.0"
@@ -4061,6 +4113,11 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-function@^1.0.1:
   version "1.0.2"
@@ -5317,6 +5374,11 @@ parse-cache-control@^1.0.1:
   resolved "https://registry.yarnpkg.com/parse-cache-control/-/parse-cache-control-1.0.1.tgz#8eeab3e54fa56920fe16ba38f77fa21aacc2d74e"
   integrity sha1-juqz5U+laSD+Fro493+iGqzC104=
 
+parse-code-context@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-code-context/-/parse-code-context-1.0.0.tgz#718c295c593d0d19a37f898473268cc75e98de1e"
+  integrity sha512-OZQaqKaQnR21iqhlnPfVisFjBWjhnMl5J9MgbP8xC+EwoVqbXrq78lp+9Zb3ahmLzrIX5Us/qbvBnaS3hkH6OA==
+
 parse-headers@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.3.tgz#5e8e7512383d140ba02f0c7aa9f49b4399c92515"
@@ -5452,6 +5514,27 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier-plugin-solidity@^1.0.0-alpha.60:
+  version "1.0.0-alpha.60"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-alpha.60.tgz#310a3af7e47d24fa1ef9e174523ff1f7b4d56c42"
+  integrity sha512-Dd6T0dVfw0kJrlEnLDFFE3mKRSP7zpT6zcIWvnSW+z4NBl+gmwJ7UJRZHD0CNDD6N48c+zb28xs3oF0ylDaYyg==
+  dependencies:
+    "@solidity-parser/parser" "^0.9.0"
+    dir-to-object "^2.0.0"
+    emoji-regex "^9.0.0"
+    escape-string-regexp "^4.0.0"
+    extract-comments "^1.1.0"
+    prettier "^2.0.5"
+    semver "^7.3.2"
+    string-width "^4.2.0"
 
 prettier@^1.14.3:
   version "1.19.1"
@@ -5996,6 +6079,11 @@ semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
 semver@~5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
@@ -6155,6 +6243,13 @@ solc@0.6.8:
     semver "^5.5.0"
     tmp "0.0.33"
 
+solhint-plugin-prettier@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/solhint-plugin-prettier/-/solhint-plugin-prettier-0.0.5.tgz#e3b22800ba435cd640a9eca805a7f8bc3e3e6a6b"
+  integrity sha512-7jmWcnVshIrO2FFinIvDQmhQpfpS2rRRn3RejiYgnjIE68xO2bvrYvjqVNfrio4xH9ghOqn83tKuTzLjEbmGIA==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 solhint@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/solhint/-/solhint-3.2.0.tgz#e3b3e568f64f71328f410a97f06e802033f0d7d2"
@@ -6302,6 +6397,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
+string-width@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
+  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
+
 string.prototype.trimend@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
@@ -6350,6 +6454,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+  dependencies:
+    ansi-regex "^5.0.0"
 
 strip-dirs@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
I was reading through the YieldSpace implementation (very nicely done, btw) and noticed a couple small formatting inconsistencies, so this PR adds and enables these formatting plugins:

* `"prettier-plugin-solidity": "^1.0.0-alpha.60",`
* `"solhint-plugin-prettier": "^0.0.5"`

This PR also adds another task to `package.json`: `prettier:sol` which will run all solidity code through prettier and write the formatted version. I would have named it `lint:sol` but that task name is already taken by `solhint`.

Finally, this PR touches a lot of solidity code and I haven't had a chance to look through very closely and make sure nothing was inadvertently changed by `prettier` (i.e if there's a bug in prettier that changes some solidity functionality by mistake). Ran the test suite and it's all passing.