### PR TITLE
Use dss-interfaces

### DIFF
--- a/contracts/Controller.sol
+++ b/contracts/Controller.sol
@@ -6,8 +6,8 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@yield-protocol/utils/contracts/access/Delegable.sol";
 import "@yield-protocol/utils/contracts/math/DecimalMath.sol";
 import "@yield-protocol/utils/contracts/access/Orchestrated.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IVat.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IPot.sol";
+import "dss-interfaces/src/dss/VatAbstract.sol";
+import "dss-interfaces/src/dss/PotAbstract.sol";
 import "./interfaces/ITreasury.sol";
 import "./interfaces/IController.sol";
 import "./interfaces/IFYDai.sol";
@@ -35,8 +35,8 @@ contract Controller is IController, Orchestrated(), Delegable(), DecimalMath {
     bytes32 public constant WETH = "ETH-A";
     uint256 public constant DUST = 50e15; // 0.05 ETH
 
-    IVat public vat;
-    IPot public pot;
+    VatAbstract public vat;
+    PotAbstract public pot;
     ITreasury public override treasury;
 
     mapping(uint256 => IFYDai) public override series;                 // FYDai series, indexed by maturity

--- a/contracts/FYDai.sol
+++ b/contracts/FYDai.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.6.10;
 
 import "@openzeppelin/contracts/math/Math.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IVat.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IPot.sol";
+import "dss-interfaces/src/dss/VatAbstract.sol";
+import "dss-interfaces/src/dss/PotAbstract.sol";
 import "./interfaces/ITreasury.sol";
 import "./interfaces/IFYDai.sol";
 import "./interfaces/IFlashMinter.sol";
@@ -31,8 +31,8 @@ contract FYDai is IFYDai, Orchestrated(), Delegable(), DecimalMath, ERC20Permit 
 
     uint256 constant internal MAX_TIME_TO_MATURITY = 126144000; // seconds in four years
 
-    IVat public vat;
-    IPot public pot;
+    VatAbstract public vat;
+    PotAbstract public pot;
     ITreasury public treasury;
 
     bool public override isMature;

--- a/contracts/Treasury.sol
+++ b/contracts/Treasury.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.6.10;
 import "@openzeppelin/contracts/math/Math.sol";
 import "@yield-protocol/utils/contracts/math/DecimalMath.sol";
 import "@yield-protocol/utils/contracts/access/Orchestrated.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IVat.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IDai.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IDaiJoin.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IGemJoin.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IPot.sol";
+import "dss-interfaces/src/dss/VatAbstract.sol";
+import "dss-interfaces/src/dss/DaiAbstract.sol";
+import "dss-interfaces/src/dss/DaiJoinAbstract.sol";
+import "dss-interfaces/src/dss/GemJoinAbstract.sol";
+import "dss-interfaces/src/dss/PotAbstract.sol";
 import "@yield-protocol/utils/contracts/interfaces/chai/IChai.sol";
 import "./interfaces/ITreasury.sol";
 
@@ -24,12 +24,12 @@ import "./interfaces/ITreasury.sol";
 contract Treasury is ITreasury, Orchestrated(), DecimalMath {
     bytes32 constant WETH = "ETH-A";
 
-    IVat public override vat;
+    VatAbstract public override vat;
     IWeth public override weth;
-    IDai public override dai;
-    IDaiJoin public override daiJoin;
-    IGemJoin public override wethJoin;
-    IPot public override pot;
+    DaiAbstract public override dai;
+    DaiJoinAbstract public override daiJoin;
+    GemJoinAbstract public override wethJoin;
+    PotAbstract public override pot;
     IChai public override chai;
     address public unwind;
 
@@ -48,13 +48,13 @@ contract Treasury is ITreasury, Orchestrated(), DecimalMath {
         address chai_
     ) public {
         // These could be hardcoded for mainnet deployment.
-        dai = IDai(dai_);
+        dai = DaiAbstract(dai_);
         chai = IChai(chai_);
-        pot = IPot(pot_);
+        pot = PotAbstract(pot_);
         weth = IWeth(weth_);
-        daiJoin = IDaiJoin(daiJoin_);
-        wethJoin = IGemJoin(wethJoin_);
-        vat = IVat(vat_);
+        daiJoin = DaiJoinAbstract(daiJoin_);
+        wethJoin = GemJoinAbstract(wethJoin_);
+        vat = VatAbstract(vat_);
         vat.hope(wethJoin_);
         vat.hope(daiJoin_);
 
@@ -231,7 +231,7 @@ contract Treasury is ITreasury, Orchestrated(), DecimalMath {
             daiJoin.exit(address(this), toBorrow); // `daiJoin` reverts on failures
         }
 
-        require(dai.transfer(to, daiAmount));                            // Give dai to user
+        dai.transfer(to, daiAmount);               // Give dai to user - Dai doesn't have a return value for `transfer`
     }
 
     /// @dev Returns chai using chai savings as much as possible, and borrowing the rest.

--- a/contracts/Unwind.sol
+++ b/contracts/Unwind.sol
@@ -7,11 +7,12 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@yield-protocol/utils/contracts/math/DecimalMath.sol";
 import "@yield-protocol/utils/contracts/interfaces/weth/IWeth.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IVat.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IGemJoin.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IDaiJoin.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IPot.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IEnd.sol";
+import "dss-interfaces/src/dss/VatAbstract.sol";
+import "dss-interfaces/src/dss/DaiAbstract.sol";
+import "dss-interfaces/src/dss/GemJoinAbstract.sol";
+import "dss-interfaces/src/dss/DaiJoinAbstract.sol";
+import "dss-interfaces/src/dss/PotAbstract.sol";
+import "dss-interfaces/src/dss/EndAbstract.sol";
 import "@yield-protocol/utils/contracts/interfaces/chai/IChai.sol";
 import "./interfaces/ITreasury.sol";
 import "./interfaces/IController.sol";
@@ -32,13 +33,13 @@ contract Unwind is Ownable(), DecimalMath {
     bytes32 public constant CHAI = "CHAI";
     bytes32 public constant WETH = "ETH-A";
 
-    IVat public vat;
-    IERC20 public dai;
-    IDaiJoin public daiJoin;
+    VatAbstract public vat;
+    DaiAbstract public dai;
+    DaiJoinAbstract public daiJoin;
     IWeth public weth;
-    IGemJoin public wethJoin;
-    IPot public pot;
-    IEnd public end;
+    GemJoinAbstract public wethJoin;
+    PotAbstract public pot;
+    EndAbstract public end;
     IChai public chai;
     ITreasury public treasury;
     IController public controller;
@@ -60,7 +61,7 @@ contract Unwind is Ownable(), DecimalMath {
         address end_,
         address liquidations_
     ) public {
-        end = IEnd(end_);
+        end = EndAbstract(end_);
         liquidations = ILiquidations(liquidations_);
         controller = liquidations.controller();
         treasury = controller.treasury();
@@ -72,7 +73,7 @@ contract Unwind is Ownable(), DecimalMath {
         pot = treasury.pot();
         chai = treasury.chai();
 
-        IERC20(treasury.dai()).approve(address(daiJoin), uint256(-1));
+        treasury.dai().approve(address(daiJoin), uint256(-1));
         vat.hope(address(treasury));
         vat.hope(address(end));
     }

--- a/contracts/interfaces/ITreasury.sol
+++ b/contracts/interfaces/ITreasury.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.6.10;
 
 import "@yield-protocol/utils/contracts/interfaces/weth/IWeth.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IVat.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IDai.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IGemJoin.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IDaiJoin.sol";
-import "@yield-protocol/utils/contracts/interfaces/maker/IPot.sol";
+import { VatAbstract } from "dss-interfaces/src/dss/VatAbstract.sol";
+import "dss-interfaces/src/dss/DaiAbstract.sol";
+import "dss-interfaces/src/dss/GemJoinAbstract.sol";
+import "dss-interfaces/src/dss/DaiJoinAbstract.sol";
+import "dss-interfaces/src/dss/PotAbstract.sol";
 import "@yield-protocol/utils/contracts/interfaces/chai/IChai.sol";
 
 interface ITreasury {
@@ -21,11 +21,11 @@ interface ITreasury {
     function shutdown() external;
     function live() external view returns(bool);
 
-    function vat() external view returns (IVat);
+    function vat() external view returns (VatAbstract);
     function weth() external view returns (IWeth);
-    function dai() external view returns (IDai);
-    function daiJoin() external view returns (IDaiJoin);
-    function wethJoin() external view returns (IGemJoin);
-    function pot() external view returns (IPot);
+    function dai() external view returns (DaiAbstract);
+    function daiJoin() external view returns (DaiJoinAbstract);
+    function wethJoin() external view returns (GemJoinAbstract);
+    function pot() external view returns (PotAbstract);
     function chai() external view returns (IChai);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/vault-v1",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Solidity contracts to implement the Yield Protocol collateralized debt engine",
   "author": "Yield Inc.",
   "files": [
@@ -8,7 +8,6 @@
     "contracts/interfaces",
     "!contracts/external",
     "contracts/external/chai/interfaces",
-    "contracts/external/maker/interfaces",
     "contracts/external/weth/interfaces",
     "!contracts/mocks"
   ],
@@ -36,7 +35,7 @@
     "lint:sol": "solhint -f table contracts/**/*.sol"
   },
   "devDependencies": {
-    "@yield-protocol/utils": "^1.0.4",
+    "@yield-protocol/utils": "^1.0.5",
     "@nomiclabs/buidler": "^1.3.8",
     "@nomiclabs/buidler-truffle5": "^1.3.4",
     "@nomiclabs/buidler-web3": "^1.3.4",
@@ -46,6 +45,7 @@
     "@types/mocha": "^8.0.0",
     "buidler-gas-reporter": "0.1.4-beta.4",
     "chai": "4.2.0",
+    "dss-interfaces": "^0.1.1",
     "ethereumjs-util": "^7.0.3",
     "ethers": "^5.0.7",
     "ganache-time-traveler": "^1.0.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -911,10 +911,10 @@
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"
 
-"@yield-protocol/utils@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@yield-protocol/utils/-/utils-1.0.4.tgz#fa550061db8472d5f15bfd1633ed4abf5fa8aaed"
-  integrity sha512-2POvpw+kEhv1ZwGcKa99rpMnMGBoW0sDEDgnYNuN8OyL8NvCjarfX7uoUES8Zx3ZOvatKGva8EsKR9RNA4Vx9w==
+"@yield-protocol/utils@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@yield-protocol/utils/-/utils-1.0.5.tgz#ef5332fa7ef78bb7bcef28a314477ccbcbdc010a"
+  integrity sha512-pPjA7pfi1PbGXL8nKJ1NxlHtI7IJO+fRRaEPSbF2yepcigvrguvLZ0Z/kgqcN8MW7hx0hty74Pr1zQocxY9f1Q==
   dependencies:
     ethereumjs-util "^7.0.8"
     ethers "^5.0.7"
@@ -2184,6 +2184,11 @@ drbg.js@^1.0.1:
     browserify-aes "^1.0.6"
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
+
+dss-interfaces@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dss-interfaces/-/dss-interfaces-0.1.1.tgz#2ed72af0f206b5a4a6968262d42ceeefe1af9a30"
+  integrity sha512-SaTUptK+0jHsgaywKLDZBZi5L6d154b62ujFlECmY7bWPLp+7JmoK502xfjh8wtkOI5T3a7vhnEYTJ4m36uNhQ==
 
 duplexer3@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
I just [did a contribution](https://www.npmjs.com/package/dss-interfaces) to MakerDAO :D

They didn't have an npm package for dss-interfaces, but more than a year ago Brian [had asked for one](https://github.com/makerdao/dss-interfaces/issues/8). I wanted it to stop serving them from our packages, so I created the npm package for them.

And now `yield-utils` is a tad cleaner, and further integration with MakerDAO, if we make them, they will be cleaner as well.